### PR TITLE
Inflict global newline policing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Declare files that will always have CRLF line endings on checkout.
+*.lua text eol=crlf


### PR DESCRIPTION
This forces all lua files in zero-k to have CRLF newlines on input, which will result in their eventual standardization across the repo.
