### PR TITLE
unit_carrier_drones.lua: implement drone nanoframe building on carrier.

### DIFF
--- a/LuaRules/Configs/drone_defs.lua
+++ b/LuaRules/Configs/drone_defs.lua
@@ -5,22 +5,23 @@ local carrierDefs = {}
 local carrierDefNames = {
 	armcarry = {
 		spawnPieces = {"support4"},
-		{drone = UnitDefNames.carrydrone.id, reloadTime = 15, maxDrones = 8, spawnSize = 2, range = 1600} },
-	--corcrw = { {drone = UnitDefNames.attackdrone.id, reloadTime = 15, maxDrones = 6, spawnSize = 2, range = 900} },
+		{drone = UnitDefNames.carrydrone.id, reloadTime = 15, maxDrones = 8, spawnSize = 2, range = 1600, buildTime=3},
+	},
+	--corcrw = { {drone = UnitDefNames.attackdrone.id, reloadTime = 15, maxDrones = 6, spawnSize = 2, range = 900, buildTime=3} },
 	funnelweb = {
 		spawnPieces = {"emitl", "emitr"},
-		{drone = UnitDefNames.attackdrone.id, reloadTime = 10, maxDrones = 6, spawnSize = 2, range = 800},
-		{drone = UnitDefNames.battledrone.id, reloadTime = 15, maxDrones = 2, spawnSize = 1, range = 800},
+		{drone = UnitDefNames.attackdrone.id, reloadTime = 10, maxDrones = 6, spawnSize = 2, range = 800, buildTime=3},
+		{drone = UnitDefNames.battledrone.id, reloadTime = 15, maxDrones = 2, spawnSize = 1, range = 800, buildTime=3},
 	},
 	nebula = {
 		spawnPieces = {"pad1", "pad2", "pad3", "pad4"},
-		{drone = UnitDefNames.fighterdrone.id, reloadTime = 15, maxDrones = 8, spawnSize = 2, range = 1000},
+		{drone = UnitDefNames.fighterdrone.id, reloadTime = 15, maxDrones = 8, spawnSize = 2, range = 1000, buildTime=3},
 	},
 }
 
 local presets = {
-	module_companion_drone = {drone = UnitDefNames.attackdrone.id, reloadTime = 10, maxDrones = 2, spawnSize = 1, range = 450},
-	module_battle_drone = {drone = UnitDefNames.battledrone.id, reloadTime = 20, maxDrones = 1, spawnSize = 1, range = 600},
+	module_companion_drone = {drone = UnitDefNames.attackdrone.id, reloadTime = 10, maxDrones = 2, spawnSize = 1, range = 450, buildTime=3},
+	module_battle_drone = {drone = UnitDefNames.battledrone.id, reloadTime = 20, maxDrones = 1, spawnSize = 1, range = 600, buildTime=3},
 }
 
 --[[

--- a/LuaRules/Gadgets/unit_carrier_drones.lua
+++ b/LuaRules/Gadgets/unit_carrier_drones.lua
@@ -12,6 +12,8 @@ function gadget:GetInfo()
 		enabled   = true
 	}
 end
+--Changelog:
+--24/6/2014 added carrier building drone on emit point. 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 local AddUnitDamage     = Spring.AddUnitDamage
@@ -36,6 +38,9 @@ local carrierDefs, thingsWhichAreDrones = include "LuaRules/Configs/drone_defs.l
 local DEFAULT_UPDATE_ORDER_FREQUENCY = 40 -- gameframes
 local DEFAULT_MAX_DRONE_RANGE = 1500
 
+local BUILD_UPDATE_INTERVAL = 15 --gameframe
+local DRONE_COLVOL_BUILD_OFFSET = 25 --elmo from carrier where drone's colvol will appear (model will still appear specified emit point. A config is a TODO)
+
 local carrierList = {}
 local droneList = {}
 local drones_to_move = {}
@@ -47,7 +52,7 @@ local GiveClampedOrderToUnit = Spring.Utilities.GiveClampedOrderToUnit
 --------------------------------------------------------------------------------
 local function InitCarrier(unitID, unitDefID, teamID)
 	local carrierData = carrierDefs[unitDefID]
-	local toReturn  = {unitDefID = unitDefID, teamID = teamID, droneSets = {}}
+	local toReturn  = {unitDefID = unitDefID, teamID = teamID, droneSets = {}, occupiedPieces={}, droneInQueue= {}}
 	local unitPieces = GetUnitPieceMap(unitID)
 	local usedPieces = carrierData.spawnPieces
 	if usedPieces then
@@ -66,12 +71,12 @@ local function InitCarrier(unitID, unitDefID, teamID)
 	return toReturn
 end
 
-local function NewDrone(unitID, unitDefID, droneName, setNum)
+local function NewDrone(unitID, unitDefID, droneName, setNum, droneBuiltExternally)
 	local carrierEntry = carrierList[unitID]
 	local _, _, _, x, y, z = GetUnitPosition(unitID, true)
 	local xS, yS, zS = x, y, z
 	local rot = 0
-	if carrierEntry.spawnPieces then
+	if carrierEntry.spawnPieces and not droneBuiltExternally then
 		local index = carrierEntry.pieceIndex
 		local px, py, pz, pdx, pdy, pdz = GetUnitPiecePosDir(unitID, carrierEntry.spawnPieces[index])
 		xS, yS, zS = px, py, pz
@@ -88,7 +93,8 @@ local function NewDrone(unitID, unitDefID, droneName, setNum)
 		zS = (z + (math.cos(angle) * 20))
 		rot = angle
 	end
-	local droneID = CreateUnit(droneName,xS,yS,zS,1,carrierList[unitID].teamID)
+	--Note: create unit argument: (unitDefID|unitDefName,x,y,z,facing,teamID,build,flattenGround,targetID,builderID)
+	local droneID = CreateUnit(droneName,xS,yS,zS,1,carrierList[unitID].teamID, droneBuiltExternally and true,false,nil,unitID)
 	if droneID then
 		local droneSet = carrierEntry.droneSets[setNum]
 		droneSet.reload = carrierDefs[unitDefID][setNum].reloadTime
@@ -111,6 +117,198 @@ local function NewDrone(unitID, unitDefID, droneName, setNum)
 
 		droneList[droneID] = {carrier = unitID, set = setNum}
 	end
+	return droneID,rot
+end
+
+function AddUnitToEmptyPad(carrierID,carrierDefID,droneName, setNum)
+	local carrierData = carrierList[carrierID]
+	carrierData.droneInQueue[ #carrierData.droneInQueue+ 1 ] = droneName
+	local clearDist = 10
+	for i=1, #carrierList[carrierID].spawnPieces do
+		local pieceNum = carrierList[carrierID].spawnPieces[i]
+		local uxx,uyy,uzz = GetUnitPiecePosDir(carrierID, pieceNum)
+		local somethingOnThePad = Spring.GetUnitsInBox(uxx-clearDist,uyy-clearDist,uzz-clearDist, uxx+clearDist,uyy+clearDist,uzz+clearDist)
+		if not carrierData.occupiedPieces[pieceNum] and ((#somethingOnThePad == 1 and somethingOnThePad[1]== carrierID) or (#somethingOnThePad == 0)) then
+			local unitIDAdded,rotation = NewDrone(carrierID, carrierDefID, droneName, setNum, true)
+			if unitIDAdded then
+				table.remove(carrierData.droneInQueue,1)
+				SitOnPad(unitIDAdded,carrierID,pieceNum,rotation)
+			
+				carrierData.occupiedPieces[pieceNum] = true
+				droneList[unitIDAdded].defaultRadius = Spring.GetUnitRadius(unitIDAdded)
+				
+				--Move collision volume away from carrier to avoid collision
+				Spring.SetUnitMidAndAimPos(unitIDAdded,0,DRONE_COLVOL_BUILD_OFFSET,0,0,DRONE_COLVOL_BUILD_OFFSET,0,true) --offset whole colvol & aim point (red dot) above the carrier (use /debugcolvol to check)
+				Spring.SetUnitRadiusAndHeight(unitIDAdded,10,nil)
+				break;
+			end
+		end
+	end
+	return unitIDAdded, unitDefIDToAdd
+end
+
+local coroutines = {}
+local coroutine = coroutine
+local Sleep	    = coroutine.yield
+local assert    = assert
+local function StartScript(fn)
+	local co = coroutine.create(fn)
+	coroutines[#coroutines + 1] = co
+end
+
+function UpdateCoroutines() 
+	local coroutineCount = #coroutines
+	local i=1
+	while (i<=coroutineCount) do 
+		local co = coroutines[i] 
+		if (coroutine.status(co) ~= "dead") then 
+			assert(coroutine.resume(coroutines[i]))
+		else
+			coroutines[i] = coroutines[coroutineCount]
+			coroutines[coroutineCount] = nil
+			coroutineCount = coroutineCount -1
+			i = i - 1
+		end
+		i = i + 1
+	end 
+end
+
+local function GetPitchYawRoll(unitID) --This allow compatibility with Spring 91
+	--NOTE:
+	--angle measurement and direction setting is based on right-hand coordinate system, but Spring might rely on left-hand coordinate system.
+	--So, input for math.sin, math.cos and math.atan2 might be swapped with respect to the usual whenever convenient.
+
+	local front, top, right = Spring.GetUnitVectors(unitID)
+	--1) Processing FRONT's vector to get Pitch and Yaw
+	local x,y,z = front[1], front[2],front[3]
+	local xz = math.sqrt(x*x + z*z) --hypothenus
+	local yaw = math.atan2 (x/xz, z/xz) --So facing south is 0-degree, and west is negative degree
+	local pitch = math.atan2 (y,xz) --So facing forward is 0-degree, and downward is negative degree
+	
+	--2) Processing TOP's vector to get Roll
+	x,y,z = top[1], top[2],top[3]
+	--rotate coordinate around Y-axis until Yaw value is 0 (a reset) 
+	local newX = x* math.cos (-yaw) + z*  math.sin (-yaw)
+	local newY = y
+	local newZ = z* math.cos (-yaw) - x* math.sin (-yaw)
+	x,y,z = newX,newY,newZ
+	--rotate coordinate around X-axis until Pitch value is 0 (a reset) 
+	newX = x 
+	newY = y* math.cos (-pitch) + z* math.sin (-pitch)
+	newZ = z* math.cos (-pitch) - y* math.sin (-pitch)
+	x,y,z = newX,newY,newZ
+	local roll =  math.atan2 (x, y) --So lifting right wing is positive degree, and lowering right wing is negative degree
+	
+	-- Spring.Echo("Pitch:" .. pitch*180/math.pi)
+	-- Spring.Echo("Yaw:" .. yaw*180/math.pi)
+	-- Spring.Echo("Roll:" .. roll*180/math.pi)
+	return pitch, yaw, roll
+end
+
+local HEADING_TO_RAD = (math.pi*2/2^16)
+local RAD_TO_HEADING = 1/HEADING_TO_RAD
+local PI = math.pi
+local cos = math.cos
+local sin = math.sin
+local acos = math.acos
+local floor = math.floor
+local sqrt = math.sqrt
+local exp = math.exp
+local min = math.min
+
+local mcSetVelocity			= Spring.MoveCtrl.SetVelocity
+local mcSetRotationVelocity	= Spring.MoveCtrl.SetRotationVelocity
+local mcSetPosition			= Spring.MoveCtrl.SetPosition
+local mcSetRotation			= Spring.MoveCtrl.SetRotation
+local mcDisable				= Spring.MoveCtrl.Disable
+local mcEnable				= Spring.MoveCtrl.Enable
+function SitOnPad(unitID,carrierID, padPieceID,rotation)
+	-- From unit_refuel_pad_handler.lua (author: GoogleFrog)
+	-- South is 0 radians and increases counter-clockwise
+	
+	Spring.SetUnitHealth(unitID,{ build = 0 })
+	
+	local px, py, pz, dx, dy, dz = Spring.GetUnitPiecePosDir(carrierID, padPieceID)
+	-- local ury = rotation*PI/180
+	
+	mcEnable(unitID)
+	Spring.SetUnitLeaveTracks(unitID, false)
+	
+	Spring.SetUnitVelocity(unitID, 0, 0, 0)
+	mcSetVelocity(unitID, 0, 0, 0)
+	mcSetPosition(unitID,px, py, pz)
+	
+	-- deactivate unit to cause the lups jets away
+	Spring.SetUnitCOBValue(unitID, COB.ACTIVATION, 0)
+	
+	local function SitLoop()
+		local previousDir,currentDir
+		local pitch,yaw,roll
+		local px, py, pz, dx, dy, dz,vx,vy,vz
+		-- local magnitude, newPadHeading
+		local landDuration = 0
+		local buildProgress,health
+		local droneInfo = carrierList[carrierID].droneSets[(droneList[unitID].set)]
+		local build_step = droneInfo.buildStep
+		local build_step_health = droneInfo.buildStepHealth
+		while true do
+			if (not carrierList[carrierID]) or (not droneList[unitID]) then
+				if Spring.ValidUnitID(unitID) then
+					Spring.DestroyUnit(unitID, true, false) -- selfd = true, reclaim = false
+				end
+				if carrierList[carrierID] then
+					carrierList[carrierID].occupiedPieces[padPieceID] = false
+				end
+				return
+			end
+			
+			vx,vy,vz = Spring.GetUnitVelocity(carrierID)
+			px, py, pz, dx, dy, dz = Spring.GetUnitPiecePosDir(carrierID, padPieceID)
+			currentDir = dx + dy*100 + dz* 10000
+			if previousDir ~= currentDir then --refresh pitch/yaw/roll calculation when unit had slight turning
+				previousDir = currentDir
+				pitch,yaw,roll = GetPitchYawRoll(carrierID)
+				-- magnitude = math.sqrt(dx^2+dy^2+dz^2)
+				-- dx = dx/magnitude --todo: some trigonometry for pitch & yaw (not compatible with Spring91). It ensure colvol appear at same relative position
+				-- dy = dy/magnitude
+				-- dz = dz/magnitude --need to normalize or the output is skewed when unit pitch & yaw
+				-- newPadHeading = acos(dz)
+				-- if dx < 0 then
+					-- newPadHeading = 2*PI-newPadHeading --for level unit only!
+				-- end
+			end
+			mcSetVelocity(unitID,vx,vy,vz)
+			mcSetPosition(unitID,px+vx, py+vy, pz+vz)
+			-- mcSetRotation(unitID,0,newPadHeading+ury,0)
+			mcSetRotation(unitID,-pitch,yaw,-roll) --Spring conveniently rotate Y-axis first, X-axis 2nd, and Z-axis 3rd which allow Yaw,Pitch & Roll control.
+			
+			landDuration = landDuration + 1
+			if landDuration % BUILD_UPDATE_INTERVAL == 0 then
+				health,_,_,_,buildProgress = Spring.GetUnitHealth(unitID)
+				buildProgress = buildProgress+build_step --progress
+				Spring.SetUnitHealth(unitID,{health=health+build_step_health, build = buildProgress }) 
+				if buildProgress >= 1 then 
+					break
+				end
+			end
+			
+			Sleep()
+		end
+		carrierList[carrierID].occupiedPieces[padPieceID] = false
+		Spring.SetUnitLeaveTracks(unitID, true)
+		Spring.SetUnitVelocity(unitID, 0, 0, 0)
+		mcDisable(unitID)
+		GG.UpdateUnitAttributes(unitID) --update pending attribute changes in unit_attributes.lua if available 
+		
+		Spring.SetUnitMidAndAimPos(unitID,0,0,0,0,0,0,true)
+		Spring.SetUnitRadiusAndHeight(unitID,droneList[unitID].defaultRadius,nil)
+		
+		
+		-- activate unit and its jets
+		Spring.SetUnitCOBValue(unitID, COB.ACTIVATION, 1)
+	end
+	
+	StartScript(SitLoop)
 end
 
 -- morph uses this
@@ -270,7 +468,8 @@ function gadget:GameFrame(n)
 							if (set.droneCount >= set.maxDrones) then
 								break
 							end
-							NewDrone(carrierID, carrier.unitDefID, carrierDef.drone, i )
+							AddUnitToEmptyPad(carrierID, carrier.unitDefID, carrierDef.drone, i )
+							-- NewDrone(carrierID, carrier.unitDefID, carrierDef.drone, i )
 						end
 					end
 				end
@@ -290,9 +489,20 @@ function gadget:GameFrame(n)
 			UpdateCarrierTarget(i)
 		end
 	end
+	UpdateCoroutines() --maintain nanoframe position relative to carrier
 end
 
-function gadget:Initialize()  
+function gadget:Initialize()
+	--pre-calculate some buildtime related variable
+	local buildUpProgress
+	for name,carrierData in pairs(carrierDefs) do
+		for i=1,#carrierData do
+			buildUpProgress = 1/(carrierData[i].buildTime)*(BUILD_UPDATE_INTERVAL/30) -- derived from: time_to_complete = (1.0/build_step_fraction)*build_interval
+			carrierDefs[name][i].buildStep = buildUpProgress
+			carrierDefs[name][i].buildStepHealth = buildUpProgress*UnitDefs[carrierData[i].drone].health
+		end
+	end
+
 	for _, unitID in ipairs(Spring.GetAllUnits()) do
 		local build  = select(5,Spring.GetUnitHealth(unitID))
 		if build == 1 then


### PR DESCRIPTION
This should make drone more vulnerable initially.

All drone is currently currently set to 3 second building in drone_defs.lua. It should be changed.

TODO: sea-carrier's drone will build inside sea-carrier's hitbox, this shielded them for attack (this is not an issue for funnelweb). A customization ability for drone-model & colvol offset will be added later for sea-carrier. (if not needed is better! :))
