### PR TITLE
gadget.lua: not crash when Explosion_GetWantedWeaponDef() not defined

### DIFF
--- a/LuaRules/gadgets.lua
+++ b/LuaRules/gadgets.lua
@@ -1765,7 +1765,7 @@ local Explosion_first = true
 function gadgetHandler:Explosion(weaponID, px, py, pz, ownerID)
 	if Explosion_first then
 		for _,g in ipairs(self.ExplosionList) do
-			local weaponDefs = g:Explosion_GetWantedWeaponDef()
+			local weaponDefs = (g:Explosion_GetWantedWeaponDef and g:Explosion_GetWantedWeaponDef()) or allWeaponDefs
 			for _,wdid in ipairs(weaponDefs) do
 				if Explosion_GadgetSingle[wdid] or Explosion_GadgetMap[wdid] then
 					if Explosion_GadgetMap[wdid] then


### PR DESCRIPTION
same as https://github.com/ZeroK-RTS/Zero-K/commit/da8056b0ed5874dc8778c1d909b74247f8edb3aa commit. 

It will crash gadget.lua when map modder/maker try to use Explosion() event in their gadget.

Example message:  [f=0000560] Error: LuaRules::RunCallIn: error = 2, Explosion, [string "LuaRules/gadgets.lua"]:1768: attempt to call method 'Explosion_GetWantedWeaponDef' (a nil value) 
from ArchShaman.
