### PR TITLE
Draw metal spot and defense range circles between the terrain and the unit layer.

### DIFF
--- a/LuaUI/Widgets/cmd_mex_placement.lua
+++ b/LuaUI/Widgets/cmd_mex_placement.lua
@@ -662,6 +662,20 @@ local function DoLine(x1, y1, z1, x2, y2, z2)
     gl.Vertex(x2, y2, z2)
 end
 
+function widget:DrawWorldPreUnit()
+
+	-- Check command is to build a mex
+	local _, cmdID = spGetActiveCommand()
+	local showecoMode = WG.showeco
+	local peruse = spGetGameFrame() < 1 or showecoMode or spGetMapDrawMode() == 'metal'
+	
+	drawMexSpots = WG.metalSpots and (-mexDefID == cmdID or CMD_AREA_MEX == cmdID or peruse)
+
+	if drawMexSpots then
+		glCallList(mainMexDrawList)
+	end
+end
+
 function widget:DrawWorld()
 	
 	-- Check command is to build a mex
@@ -674,7 +688,6 @@ function widget:DrawWorld()
 	local _, pos = spTraceScreenRay(mx, my, true)
 	
 	mexSpotToDraw = false
-	drawMexSpots = WG.metalSpots and (-mexDefID == cmdID or CMD_AREA_MEX == cmdID or peruse)
 	
 	if WG.metalSpots and pos and (-mexDefID == cmdID or peruse or CMD_AREA_MEX == cmdID) then
 	
@@ -686,7 +699,6 @@ function widget:DrawWorld()
 		if closestSpot and (-mexDefID == cmdID or not ((CMD_AREA_MEX == cmdID or peruse) and distance > 60)) and (not spotData[index]) then 
 		
 			mexSpotToDraw = closestSpot
-			gl.DepthTest(false)
 			
 			local height = spGetGroundHeight(closestSpot.x,closestSpot.z)
 			height = height > 0 and height or 0
@@ -709,10 +721,6 @@ function widget:DrawWorld()
 			gl.DepthTest(false)
 			gl.DepthMask(false)
 		end
-	end
-
-	if drawMexSpots then
-		glCallList(mainMexDrawList)
 	end
 	
 	gl.Color(1, 1, 1, 1)

--- a/LuaUI/Widgets/gui_defenseRange.lua
+++ b/LuaUI/Widgets/gui_defenseRange.lua
@@ -838,18 +838,15 @@ function CalcBallisticCircle( x, y, z, range, weaponDef )
 end
 
 local function DrawRanges()
-	glDepthTest(true)
 	if defenseRangeDrawList then
 		glCallList(defenseRangeDrawList)
 	end
-	glDepthTest(false)
 end
 
 function DrawSelectedRanges()
 	if ( options.showselectedunitrange.value == true ) then
 		-- range OpenGL stuff
 		glLineWidth(1.49)
-		glDepthTest(true)
 			-- Get selected units, sorted for efficiency
 		local selUnits = spGetSelUnitsSorted()
 		selUnits.n = nil -- So our loop works
@@ -871,7 +868,7 @@ function DrawSelectedRanges()
 	end
 end
 
-function widget:DrawWorld()
+function widget:DrawWorldPreUnit()
 	if WG.Cutscene and WG.Cutscene.IsInCutscene() then
 		return
 	end


### PR DESCRIPTION
Metal spot and defense range circles are now always drawn above the terrain and below visible units.
This fixes lines of circles sometimes being hidden inside terrain and a small issue with burrowed Fleas and other things sometimes being (partly) hidden below wide (high base metal) mex circles if people keep metal view on throughout the game.
