### PR TITLE
autoquit, endgamewindow, epicmenu: remove "quitforce" because in Spring 97+ it doesn't give chance to engine to save local replay (probably a new disk-space saving feature?!).

### DIFF
--- a/LuaUI/Widgets/autoquit.lua
+++ b/LuaUI/Widgets/autoquit.lua
@@ -52,7 +52,7 @@ function widget:Update(dt)
       -- widgetHandler:RemoveWidget()
     elseif DiffTimers(GetTimer(), endTime) > delay then
       Echo("<autoquit> Autoquit sending quit command.")
-      SendCommands("quit","quitforce")
+      SendCommands("quit")
     end
   end
 end

--- a/LuaUI/Widgets/gui_chili_endgamewindow.lua
+++ b/LuaUI/Widgets/gui_chili_endgamewindow.lua
@@ -282,7 +282,7 @@ local function SetupControls()
 		height=B_HEIGHT;
 		caption="Exit",
 		OnClick = {
-			function() Spring.SendCommands("quit","quitforce") end
+			function() Spring.SendCommands("quit") end
 		};
 		parent = window_endgame;
 	}

--- a/LuaUI/Widgets/gui_epicmenu.lua
+++ b/LuaUI/Widgets/gui_epicmenu.lua
@@ -2323,7 +2323,7 @@ local function MakeQuitButtons()
 				if (paused) and AmIPlayingAlone() then
 					spSendCommands("pause")
 				end
-				spSendCommands{"quit","quitforce"} 
+				spSendCommands{"quit"} 
 			end)
 		end,
 		key='Exit to Desktop',


### PR DESCRIPTION
I checked log, it says "quitforce" was added for a test.
commit: 042dc8fa67d42dc1bc8caffc5019e8b250c396d2
