### PR TITLE
rebrand Gauss into Phase for water-piercing fluff.

### DIFF
--- a/units/armorco.lua
+++ b/units/armorco.lua
@@ -26,10 +26,10 @@ unitDef = {
     description_fr = [[Walker Éxperimental d'Assaut Lourd]],
 	description_de = [[Ultimativer Sturmläufer]],
 	description_pl = [[Najciezszy robot szturmowy]],
-    helptext       = [[The Detriment is the single heaviest strider in the field. It can defend itself against air attacks or use its rockets to hit distant targets, but the real meat lies in the massive gauss guns designed for one purpose - to kill other heavy units quickly and efficiently. Remember - the wise commander sends his Detriment out with adequate escorts against light unit swarms and air assaults.]],
-    helptext_fr    = [[Le Detriment est le summum de la technologie. Assez solide pour résister r plusieurs missiles nucléaires, capable de repérer des unités camouflées il fait passer le Bantha pour un caniche. Son armement fait pâlir une armée enticre, et sa relative lenteur est son seul défaut. Son prix est exorbitant et éxige des sacrifices, mais une fois construit rien ne l'arrete.]],
-	helptext_de    = [[Der Detriment ist der stärkste Strider auf dem Platz. Er verteidigt sich selbst gegen Luftattacken oder nutzt seine Raketen, um entfernte Ziele zu treffen. Des Weiteren besitzt er eine Gaußkanone, die nur für einen Zweck konzipiert wurde: das schnelle und sichere Töten von starken, gegnerischen Einheiten. Beachte - der kluge Feldherr schickt seinen Detriment mit angebrachter Unterstützung aus, um Gruppen leichter Gegner, bzw. Lufteinheiten in Schach zu halten.]],
-	helptext_pl    = [[Detriment to najciezsza jednostka na polu bitwy. Posiada obrone przeciwlotnicza i rakiety dalekiego zasiegu, ale jego sila pochodzi z niesamowitego pancerza i poteznych dzial, ktore szybko likwiduja wrogie jednostki. Mimo swojej mocy, Detriment nie powinien pracowac bez odpowiedniego wsparcia ze strony lzejszych jednostek.]],
+    helptext       = [[The Detriment is the single heaviest strider in the field. It can defend itself against air attacks or use its rockets to hit distant targets, but the real meat lies in the massive phase guns designed for one purpose - to kill other heavy units quickly and efficiently. Remember - the wise commander sends his Detriment out with adequate escorts against light unit swarms and air assaults.]],
+    --helptext_fr    = [[Le Detriment est le summum de la technologie. Assez solide pour résister r plusieurs missiles nucléaires, capable de repérer des unités camouflées il fait passer le Bantha pour un caniche. Son armement fait pâlir une armée enticre, et sa relative lenteur est son seul défaut. Son prix est exorbitant et éxige des sacrifices, mais une fois construit rien ne l'arrete.]],
+	--helptext_de    = [[Der Detriment ist der stärkste Strider auf dem Platz. Er verteidigt sich selbst gegen Luftattacken oder nutzt seine Raketen, um entfernte Ziele zu treffen. Des Weiteren besitzt er eine Gaußkanone, die nur für einen Zweck konzipiert wurde: das schnelle und sichere Töten von starken, gegnerischen Einheiten. Beachte - der kluge Feldherr schickt seinen Detriment mit angebrachter Unterstützung aus, um Gruppen leichter Gegner, bzw. Lufteinheiten in Schach zu halten.]],
+	--helptext_pl    = [[Detriment to najciezsza jednostka na polu bitwy. Posiada obrone przeciwlotnicza i rakiety dalekiego zasiegu, ale jego sila pochodzi z niesamowitego pancerza i poteznych dzial, ktore szybko likwiduja wrogie jednostki. Mimo swojej mocy, Detriment nie powinien pracowac bez odpowiedniego wsparcia ze strony lzejszych jednostek.]],
 	modelradius    = [[40]],
 	extradrawrange = 925,
   },
@@ -95,7 +95,7 @@ unitDef = {
   weaponDefs             = {
 
     GAUSS         = {
-      name                    = [[Gauss Battery]],
+      name                    = [[Phase Battery]],
       alphaDecay              = 0.12,
       areaOfEffect            = 16,
       avoidfeature            = false,

--- a/units/armpb.lua
+++ b/units/armpb.lua
@@ -1,7 +1,7 @@
 unitDef = {
   unitname                      = [[armpb]],
   name                          = [[Gauss]],
-  description                   = [[Gauss Turret]],
+  description                   = [[Phase Turret]],
   buildCostEnergy               = 400,
   buildCostMetal                = 400,
   builder                       = false,
@@ -22,11 +22,11 @@ unitDef = {
   corpse                        = [[DEAD]],
 
   customParams                  = {
-    description_de = [[Versteckter Gaussturm]],
-    description_pl = [[Dzialo Gaussa]],
-    helptext       = [[The Gauss is a compact, resilent turret with a medium-range gauss cannon. When popped down, it receives a quarter of incoming damage, making it a good choice when the enemy is using artillery. It can also attack underwater targets.]],
-    helptext_de	   = [[Der Gauss ist ein kompakter Turm mit einem Gausswerfer mittleren Bereichs. Wenn er sich in seine Panzerung zurückgezogen hat, ist es viermal schwerer ihn zu zerstören, was ihn effektive gegen gegnerische Artillerie macht. Es kann auch U-Booten schiessen.]],
-    helptext_pl	   = [[Dzialo Gaussa to wszechstronna wiezyczka, ktora otrzymuje tylko cwierc obrazen, gdy sama nie prowadzi ostrzalu. Jest w stanie atakowac cele podwodne.]],
+--    description_de = [[Versteckter Gaussturm]],
+--    description_pl = [[Dzialo Gaussa]],
+    helptext       = [[The Gauss is a compact, resilent turret with a medium-range phase cannon. When popped down, it receives a quarter of incoming damage, making it a good choice when the enemy is using artillery. It can also attack underwater targets.]],
+--    helptext_de	   = [[Der Gauss ist ein kompakter Turm mit einem Gausswerfer mittleren Bereichs. Wenn er sich in seine Panzerung zurückgezogen hat, ist es viermal schwerer ihn zu zerstören, was ihn effektive gegen gegnerische Artillerie macht. Es kann auch U-Booten schiessen.]],
+ --   helptext_pl	   = [[Dzialo Gaussa to wszechstronna wiezyczka, ktora otrzymuje tylko cwierc obrazen, gdy sama nie prowadzi ostrzalu. Jest w stanie atakowac cele podwodne.]],
     modelradius    = [[15]],
 	aimposoffset   = [[0 25 0]],
   },
@@ -77,7 +77,7 @@ unitDef = {
   weaponDefs                    = {
 
     GAUSS = {
-      name                    = [[Light Gauss Cannon]],
+      name                    = [[Light Phase Cannon]],
       alphaDecay              = 0.12,
       areaOfEffect            = 16,
 	  avoidfeature            = false,

--- a/units/assaultcruiser.lua
+++ b/units/assaultcruiser.lua
@@ -24,8 +24,8 @@ unitDef = {
 
   customParams           = {
     description_pl = [[Ciezki krazownik szturmowy]],
-    helptext       = [[The Vanquisher cruiser boasts excellent armor and lethal close-in firepower. Its gauss cannons slice through surface targets like butter, while its missiles support it against enemies above and below the water surface. Its short range and lack of anti-air firepower leaves it vulnerable to standoff units and aircraft.]],
-    helptext_pl    = [[Vanquisher to krazownik bojowy z duza sila ognia i wysoka wytrzymaloscia. Jego dziala bez problemu przebijaja sie przez cele na powierzchni, a jego rakiety niszcza cele pod i nad nia. Jego glownym problemem jest niski zasieg; ponadto, rakiety nie radza sobie z jednostkami latajacymi w duzych ilosciach.]],
+    helptext       = [[The Vanquisher cruiser boasts excellent armor and lethal close-in firepower. Its phase cannons slice through surface and submerged targets, while its missiles support it against enemies above and below the water surface. Its short range and lack of anti-air firepower leaves it vulnerable to standoff units and aircraft.]],
+    --helptext_pl    = [[Vanquisher to krazownik bojowy z duza sila ognia i wysoka wytrzymaloscia. Jego dziala bez problemu przebijaja sie przez cele na powierzchni, a jego rakiety niszcza cele pod i nad nia. Jego glownym problemem jest niski zasieg; ponadto, rakiety nie radza sobie z jednostkami latajacymi w duzych ilosciach.]],
   },
 
   explodeAs              = [[BIG_UNIT]],
@@ -85,7 +85,7 @@ unitDef = {
       mainDir            = [[1 0 1]],
       maxAngleDif        = 240,
 	  badTargetCategory	 = [[FIXEDWING]],
-      onlyTargetCategory = [[FIXEDWING LAND SINK TURRET SHIP SWIM FLOAT GUNSHIP HOVER]],
+      onlyTargetCategory = [[FIXEDWING LAND SUB SINK TURRET SHIP SWIM FLOAT GUNSHIP HOVER]],
     },
 	
     {
@@ -159,7 +159,7 @@ unitDef = {
     },	
 	
     GAUSS = {
-      name                    = [[Gauss Cannon]],
+      name                    = [[Phase Cannon]],
       alphaDecay              = 0.12,
       areaOfEffect            = 16,
       bouncerebound           = 0.15,

--- a/units/commsupport1.lua
+++ b/units/commsupport1.lua
@@ -154,7 +154,7 @@ unitDef = {
     },
 	
     GAUSS = {
-      name                    = [[Gauss Rifle]],
+      name                    = [[Phase Rifle]],
       alphaDecay              = 0.12,
       areaOfEffect            = 16,
       avoidfeature            = false,

--- a/units/corsh.lua
+++ b/units/corsh.lua
@@ -26,10 +26,10 @@ unitDef = {
     description_fr = [[Hovercraft d'Attaque Éclair]],
     description_de = [[Schnellangriff Luftkissenboot]],
     description_pl = [[Lekki poduszkowiec]],
-    helptext       = [[The Dagger is the hover plant's scout. It provides a cheap, disposable method of getting intel, and can also hit economic targets of opportunity. Its light Gauss gun can also hit underwater targets.]],
-    helptext_fr    = [[Le Dagger est petit, maniable, rapide et n'a qu'une faible puissance de feu. Idéal pour les attaques surprises depuis la mer, il surprendra bien des ennemis. Son blindage est cependant trop faible pour faire face r une quelquonque résistance.]],
-    helptext_de    = [[Der Dagger ist der Aufklärer unter den Luftkissenbooten. Es bietet dir eine kostengünstige, entbehrliche Möglichkeit deinen Feind frühzeitig um seine Rohstoffquellen zu bringen. Es kann auch U-Booten schiessen.]],
-    helptext_pl    = [[Dagger to lekki poduszkowiec, ktory nadaje sie zarowno do zwiadu, jak i atakowania przeciwnika. Jest w stanie atakowac rowniez cele podwodne.]],
+    helptext       = [[The Dagger is the hover plant's scout. It provides a cheap, disposable method of getting intel, and can also hit economic targets of opportunity. Its light Phase gun can also hit underwater targets.]],
+--    helptext_fr    = [[Le Dagger est petit, maniable, rapide et n'a qu'une faible puissance de feu. Idéal pour les attaques surprises depuis la mer, il surprendra bien des ennemis. Son blindage est cependant trop faible pour faire face r une quelquonque résistance.]],
+--    helptext_de    = [[Der Dagger ist der Aufklärer unter den Luftkissenbooten. Es bietet dir eine kostengünstige, entbehrliche Möglichkeit deinen Feind frühzeitig um seine Rohstoffquellen zu bringen. Es kann auch U-Booten schiessen.]],
+--    helptext_pl    = [[Dagger to lekki poduszkowiec, ktory nadaje sie zarowno do zwiadu, jak i atakowania przeciwnika. Jest w stanie atakowac rowniez cele podwodne.]],
   },
 
   explodeAs           = [[SMALL_UNITEX]],
@@ -81,7 +81,7 @@ unitDef = {
   weaponDefs          = {
 
     GAUSS = {
-      name                    = [[Gauss Cannon]],
+      name                    = [[Phase Carbine]],
       alphaDecay              = 0.12,
       areaOfEffect            = 16,
 	  avoidfeature            = false,

--- a/units/sprinkler.lua
+++ b/units/sprinkler.lua
@@ -23,7 +23,7 @@ unitDef = {
   corpse                        = [[DEAD]],
 
   customParams                  = {
-    description_de = [[Versteckter Gaussturm]],
+    --description_de = [[Versteckter Gaussturm]],
     helptext 	   = [[The Sprinkler is an indispensable agriculture utility agreed for some sorts cleansing.]],
 	helptext_de	   = [[Der Gauss ist ein kompakter Turm mit einem Gausswerfer mittleren Bereichs. Wenn er sich in seine Panzerung zurückgezogen hat, ist es sehr schwer ihn zu zerstören, was ihn effektive gegen gegnerische Artillerie macht.]],
 	modelradius    = [[15]],


### PR DESCRIPTION
Wiki and other documentation remains to be changed separately.
Weapon names were not changed, despite luarules search for "gauss" returning none.
Translations for affected units commented out.
