### PR TITLE
Fixed partially reclaimed morphing units spawning reclaimable debris at the end of morph. (part of issue #165)

### DIFF
--- a/LuaRules/Gadgets/91_unit_nanoframe_death.lua
+++ b/LuaRules/Gadgets/91_unit_nanoframe_death.lua
@@ -104,8 +104,8 @@ end
 function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
 
 	local health, _,_,_,progress = spGetUnitHealth(unitID)
-	
-	if (progress == 1) or (health > 0 and unitFromFactory[unitID]) then
+
+	if (progress == 1) or (health > 0 and unitFromFactory[unitID]) or GG.wasMorphedTo[unitID] then
 		isAFactory[unitID] = nil
 		unitFromFactory[unitID] = nil
 		return
@@ -159,6 +159,8 @@ function gadget:Initialize()
 		local team = Spring.GetUnitTeam(unitID)
 		gadget:UnitCreated(unitID, unitDefID, team)
 	end
+	
+	GG.wasMorphedTo = GG.wasMorphedTo or {}
 end
 
 --------------------------------------------------------------------------------

--- a/LuaRules/Gadgets/unit_nanoframe_death.lua
+++ b/LuaRules/Gadgets/unit_nanoframe_death.lua
@@ -92,7 +92,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
 
 	local health, _,_,_,progress = spGetUnitHealth(unitID)
 
-	if (progress == 1) or (health > 0 and unitFromFactory[unitID]) then
+	if (progress == 1) or (health > 0 and unitFromFactory[unitID]) or GG.wasMorphedTo[unitID] then
 		isAFactory[unitID] = nil
 		unitFromFactory[unitID] = nil
 		return
@@ -130,6 +130,8 @@ function gadget:Initialize()
 		local team = Spring.GetUnitTeam(unitID)
 		gadget:UnitCreated(unitID, unitDefID, team)
 	end
+	
+	GG.wasMorphedTo = GG.wasMorphedTo or {}
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Fixed bug with partially reclaimed morphing units spawning reclaimable debris (and flying debris) at the end of morph. (part of issue #165)

This could be abused to create infinite metal at the rate of +2.25M/s per each Aegis, by morphing and partially reclaiming Aegis->Aspis->Aegis back and forth.

/Rafal
