### PR TITLE
Reduced size of Claw (Wolverine mine) icon from 1.5 to 1.4

### DIFF
--- a/LuaUI/Configs/icontypes.lua
+++ b/LuaUI/Configs/icontypes.lua
@@ -954,7 +954,7 @@ local icontypes = {
   mine = {
     bitmap='icons/mine.dds',
 	distance=0.75,
-    size=1.5,
+    size=1.4,
   },
 
   --facs


### PR DESCRIPTION
This is to reduce screen clutter in mine-heavy games. Currently Claw icons appear pretty big, especially for a 1x1 footprint unit, while having the potential to be extremely spammable and cover a large area of the battlefield.

The icon could even use a new version that better scales down for an even smaller size.
