### PR TITLE
Allow ground units to traverse fords at full speed

### DIFF
--- a/gamedata/movedefs.lua
+++ b/gamedata/movedefs.lua
@@ -9,10 +9,8 @@
 --------------------------------------------------------------------------------
 
 local common_depthmodparams = {
-	minHeight = 5,
 	quadraticCoeff = 0,
-	linearCoeff = 0.15,
-	constantCoeff = 0.25,
+	linearCoeff = 0.07,
 }
 
 local moveDefs = {


### PR DESCRIPTION
This removes the depthmod penalty from ground units moving at water depths lower than 7, non-inclusive.

E.g. at depth 6 they move at full speed, and at depth 7 they snap to 30% of their usual speed (due to default depthmod being 0.1).

It is very unlikely that this change will affect any maps that don't specifically design for this, because ZK ships can move from depths above 5, non-inclusive, and most mapping tools don't come with elmo-precise heighmap editing. 

An extra note is that ZK-default Spring water visualiation (water 4, bumpmapped) comes with waves that actually change the plane height by ~same margin. 
Areas that are actually depth 1-4 can appear dry at times, and some areas at depth 0 or height 1 can appear wet, while only some of those will impart a significant movement penalty on player's units.

For illustration, here's what depth 6 looks like: ![ultra amphibious flea!!!](https://dl.dropboxusercontent.com/u/19320633/amphflea.png)
