### PR TITLE
Metal layout for Avalanche v2.

### DIFF
--- a/LuaRules/Configs/MetalSpots/Avalanche-v2.lua
+++ b/LuaRules/Configs/MetalSpots/Avalanche-v2.lua
@@ -1,0 +1,4 @@
+return {
+        metalValueOverride = 2.0,
+}
+


### PR DESCRIPTION
This fixes a starting-area metal spot with 1.69 or so metal while the standard is supposed to be 2.
