### PR TITLE
Added PW Command Center to unit marker

### DIFF
--- a/LuaUI/Widgets/unit_marker.lua
+++ b/LuaUI/Widgets/unit_marker.lua
@@ -93,6 +93,7 @@ unitList["ZK"]["chickenflyerqueen"] =	{ markerText = "Chicken Queen Aerial" }
 unitList["ZK"]["chickenlandqueen"] =	{ markerText = "Chicken Queen Grounded" }
 unitList["ZK"]["chickenqueenlite"] =	{ markerText = "Chicken Queen Junior" }
 unitList["ZK"]["spherepole"] =	{ markerText = "Scythe", delayedRefresh = 0 }
+unitList["ZK"]["pw_hq"] =		{ markerText = "Command Center" }
 
 --END OF MARKER LIST---------------------------------------
 local markerTimePerId = 0.2 --400ms


### PR DESCRIPTION
This adds the planetwars Command Center to the list of units that are highlighted with a map marker when spotted.
