### PR TITLE
Fixed Grizzly crash (issue #244), see description

### DIFF
--- a/scripts/amphassault.lua
+++ b/scripts/amphassault.lua
@@ -296,7 +296,7 @@ function script.QueryWeapon(num)
 	if num == 1 then
 		if beamCount < 6 then
 			if beamCount == 1 then
-				Spring.SetUnitWeaponState(unitID, 1, "range", 0)
+				Spring.SetUnitWeaponState(unitID, 1, "range", 1)
 			elseif beamCount == 2 then
 				Spring.SetUnitWeaponState(unitID, 1, "range", 550)
 			end


### PR DESCRIPTION
When Grizzly tried to fire while its fire point was inside enemy unit convol, the Spring engine was crashing.
Easily reproduced if you spawned the Grizzly in water and a ball of 50 enemy Halberds above it.
Apparently 0 range is causing some div-by-zero crash in the engine. I seached and no other unit script tries to set weapon range to 0.

This fixes the crash, but I didn't look at Grizzly behaviour regarding shooting inside allied units as mentioned in issue #244.
This is because I don't understand the purpose of the original code added in commit https://github.com/ZeroK-RTS/Zero-K/commit/5f0424a7e55fc69af58b86d710d5c0e4a108830e

/Rafal
