### PR TITLE
fix context menu Archer damage

### DIFF
--- a/units/amphraider2.lua
+++ b/units/amphraider2.lua
@@ -90,6 +90,7 @@ unitDef = {
         impulsemaxdepth = [[20]],
         impulsedepthmult = [[0.5]],
         normaldamage = [[1]],
+        statsdamage = 10.4,
       },
 	  
       damage                  = {


### PR DESCRIPTION
currently it shows half of the minimum value -> changed to use the maximum value
