### PR TITLE
Added metal maps for AlienDesert and Vittra.

### DIFF
--- a/LuaRules/Configs/MetalSpots/AlienDesert.lua
+++ b/LuaRules/Configs/MetalSpots/AlienDesert.lua
@@ -1,0 +1,3 @@
+return {
+	metalValueOverride = 2.35,
+}

--- a/LuaRules/Configs/MetalSpots/Vittra_v1.lua
+++ b/LuaRules/Configs/MetalSpots/Vittra_v1.lua
@@ -1,0 +1,3 @@
+return {
+	metalValueOverride = 1.9,
+}


### PR DESCRIPTION
AlienDesert had one spot with 2.292 metal, all others had 2.355. Now all 2.35.
Vittra had slightly uneven metal values for starting boxes, average was 1.908something. Now all 1.9.
