### PR TITLE
COFC tuning and mouse rotation tweak

### DIFF
--- a/LuaUI/Widgets/camera_cofc.lua
+++ b/LuaUI/Widgets/camera_cofc.lua
@@ -1119,6 +1119,10 @@ local function ZoomTiltCorrection(cs, zoomin, mouseX,mouseY)
 	-- Spring.Echo("Ref {"..gx..", "..gy..", "..gz.."}, Test {"..testgx..", "..testgy..", "..testgz.."}")
 	local centerwardVDriftFactor = ((mouseY - vsy/2)/(vsy/2) - 0.35) * 0.18 -- Slight intentional overcorrection, helps the rotating camera keep the target in view
 	local centerwardHDriftFactor = (mouseX - vsx/2)/(vsx/2) * 0.18 * (vsx/vsy)
+
+	-- TODO: Correct dx & dz values to ensure the same y-axis distance from camera. 
+	--			 This will be a bigger issue if this function is re-written to use WorldToScreenCoordinates and any hypothetical inverse, 
+	--			 	as OverrideTraceScreenRay ensures this 95% of the time
 	local dx, dz = (gx - testgx), (gz - testgz)
 	cs.px = cs.px + dx - math.abs(math.sin(cs.ry)) * centerwardVDriftFactor * dx + math.abs(math.cos(cs.ry)) * centerwardHDriftFactor * dz
 	cs.pz = cs.pz + dz - math.abs(math.cos(cs.ry)) * centerwardVDriftFactor * dz - math.abs(math.sin(cs.ry)) * centerwardHDriftFactor * dx


### PR DESCRIPTION
Some tuning to the zoom behaviours of COFC (particularly in tiltzoom), and rotation with mouse now rotates around a point in the world rather than the camera rotating FPS-style. I'll be modifying the options later to allow a choice between mouse behaviours in a radio-button format of "Rotate Camera, Orbit Camera/Rotate World, and Pan Camera", which will be both for vertical and horizontal separately
