### PR TITLE
Reef: remove E drain and radar

### DIFF
--- a/units/armcarry.lua
+++ b/units/armcarry.lua
@@ -37,7 +37,7 @@ unitDef = {
     modelradius    = [[30]],
   },
 
-  energyUse              = 1.5,
+  energyUse              = 0,
   explodeAs              = [[ATOMIC_BLASTSML]],
   floater                = true,
   footprintX             = 6,
@@ -51,7 +51,6 @@ unitDef = {
   movementClass          = [[BOAT6]],
   objectName             = [[ARMCARRIER]],
   script                 = [[armcarry.lua]],
-  radarDistance          = 1200,
   seismicSignature       = 4,
   selfDestructAs         = [[ATOMIC_BLASTSML]],
   showNanoSpray          = false,


### PR DESCRIPTION
Removes Reef's 1200 radar, which was originally put there to show antinuke coverage in some old Spring version, this is no longer needed. It has 1105 sight (the second highest in the game after Vulture, actually) so the radar didn't actually do much.

Also removes Reef's 1.5 E/s drain.
