### PR TITLE
fix emp->disarm adding

### DIFF
--- a/LuaRules/Gadgets/unit_boolean_disable.lua
+++ b/LuaRules/Gadgets/unit_boolean_disable.lua
@@ -105,7 +105,7 @@ local function moveUnitID(unitID, byFrame, byUnitID, frame, extraParamFrames)
 end
 
 local function addParalysisDamageToUnit(unitID, damage, pTime)
-	local health,_,paralyzeDamage = Spring.GetUnitHealth(unitID)
+	local health,maxHealth,paralyzeDamage = Spring.GetUnitHealth(unitID)
 	local extraTime = math.floor(damage/health*DECAY_FRAMES) -- time that the damage would add
 	if partialUnitID[unitID] then -- if the unit is partially paralysed
 		local newPara = partialUnitID[unitID].frameID+extraTime
@@ -131,8 +131,7 @@ local function addParalysisDamageToUnit(unitID, damage, pTime)
 		end
 	else -- unit is not paralysed at all
 		if paralyzeDamage > 0 then
-			damage = damage + paralyzeDamage
-			extraTime = math.floor(damage/health*DECAY_FRAMES)
+			extraTime = math.floor((damage/health + paralyzeDamage/maxHealth)*DECAY_FRAMES)
 		end
 		if extraTime > DECAY_FRAMES then -- if the new paralysis puts it over 100%
 			local newPara = extraTime + f


### PR DESCRIPTION
erroneous case: unit is damaged and has accumulated EMP damage, and then gets disarm damage.
the resulting disarm % should be (disarm % + current emp %)
currently this is (disarm % + (emp % \* maxHP / hp))

example case:
unit is at 20% health and has 10% EMP damage, gets 1% disarm
result should be 11% disarm
currently it's 51% disarm (1% plus (10/20))
