### PR TITLE
Fix visual artifacts in Blurry Halo Selection

### DIFF
--- a/LuaUI/Widgets/unit_selectionblurryhalo.lua
+++ b/LuaUI/Widgets/unit_selectionblurryhalo.lua
@@ -130,7 +130,6 @@ local gAlpha = 0.8
 
 local offscreentex
 local outlinemasktex
-local depthtex
 local blurtex
 local fbo
 
@@ -345,9 +344,8 @@ function widget:DrawWorldPreUnit()
     glUniformInt(uniformScreenY,  vsy )
   end
 
-  glDepthTest(GL.GEQUAL)
-  glActiveFBO(fbo,MyDrawVisibleUnits)
   glDepthTest(false)
+  glActiveFBO(fbo,MyDrawVisibleUnits)
 
   glTexture(offscreentex)
   glRenderToTexture(outlinemasktex, maskGen)
@@ -549,17 +547,9 @@ function widget:ViewResize(viewSizeX, viewSizeY)
 
   fbo.color0 = nil
 
-  gl.DeleteTexture(depthtex or 0)
   gl.DeleteTextureFBO(offscreentex or 0)
   gl.DeleteTextureFBO(blurtex or 0)
   gl.DeleteTextureFBO(outlinemasktex or 0)
-
-  depthtex = gl.CreateTexture(vsx,vsy, {
-    border = false,
-    format = GL_DEPTH_COMPONENT24,
-    min_filter = GL.NEAREST,
-    mag_filter = GL.NEAREST,
-  })
 
   offscreentex = gl.CreateTexture(vsx,vsy, {
     border = false,
@@ -588,7 +578,6 @@ function widget:ViewResize(viewSizeX, viewSizeY)
     fbo = true,
   })
 
-  fbo.depth  = depthtex
   fbo.color0 = offscreentex
   fbo.drawbuffers = GL_COLOR_ATTACHMENT0_EXT
 
@@ -597,7 +586,6 @@ end
 
 
 function widget:Shutdown()
-  gl.DeleteTexture(depthtex)
   if (gl.DeleteTextureFBO) then
     gl.DeleteTextureFBO(offscreentex)
     gl.DeleteTextureFBO(blurtex)


### PR DESCRIPTION
18953da958bc292c0a2 introduced a depth buffer to the FBO with the apparent intention to show outlines for units behind a <i>unit that already has outline</i> (?). The code never called `gl.DepthMask(true)` so nothing was ever written to the depth buffer and it ended up containing garbage.

I disabled depth testing and removed the depth buffer. This doesn't change the way selection is rendered and fixes the bug.
## Screenshots illustrating the bug

![screen00321](https://cloud.githubusercontent.com/assets/2241548/4692987/aefadf28-5784-11e4-8808-a6c0e056dc2e.jpg)
![screen00322](https://cloud.githubusercontent.com/assets/2241548/4692988/aefb05a2-5784-11e4-95d6-18a65ba6f2aa.jpg)
![screen00323](https://cloud.githubusercontent.com/assets/2241548/4692986/aef98484-5784-11e4-812e-91a606790fc5.jpg)
