### PR TITLE
COFC zoom polish

### DIFF
--- a/LuaUI/Widgets/camera_cofc.lua
+++ b/LuaUI/Widgets/camera_cofc.lua
@@ -1377,11 +1377,12 @@ local function Zoom(zoomin, shift, forceCenter)
 		end
 		ls_dist = ls_dist_new
 
-		if options.tiltedzoom.value then
-			cs = ZoomTiltCorrection(cs, zoomin, nil)
-		end
-
 		local cstemp = UpdateCam(cs)
+
+		if options.tiltedzoom.value then
+			cstemp = ZoomTiltCorrection(cstemp, zoomin, nil)
+			cstemp = UpdateCam(cstemp)
+		end
 		
 		if cstemp then cs = cstemp; end
 	end


### PR DESCRIPTION
- Zoomtilt uses camera Y alone, rather than distance from ground at zoom target. Panning, MMB, and clicking on minimap now adjust zoomtilt angle to maintain consistency.
- Zoom out to center bounds loosened slightly. Map now takes up 2/3 of the screen at full zoomout, rather than 3/4.
- maxDistY better respected as the actual camera Y limit when freemode is off. Panning and zooming out from screen center didn't previously respect this properly.
- Centering to cursor target from full zoomout with zoomtilt on improved for targets above map minimum height. Also now works off trig computations rather than hardcoded hacks.
