### PR TITLE
Fixes jumpUI crash

### DIFF
--- a/LuaUI/Widgets/gui_jumpjets.lua
+++ b/LuaUI/Widgets/gui_jumpjets.lua
@@ -206,7 +206,7 @@ end
 
 local function  DrawMouseArc(unitID, shift, groundPos, quality)
 	local unitDefID = spGetUnitDefID(unitID)
-	if (not groundPos or not UnitDefs[unitDefID].customParams.canjump == "1") then
+	if not(groundPos and UnitDefs[unitDefID].customParams.canjump == "1") then
 		return
 	end
 


### PR DESCRIPTION
fixes #420
the second "not" was bugged and not applied to UnitDefs[unitDefID].customParams.canjump == "1" because brackets were missing

if (not groundPos or not(UnitDefs[unitDefID].customParams.canjump == "1")) then
and
if (not groundPos or UnitDefs[unitDefID].customParams.canjump ~= "1") then
would have both worked

Used [De Morgan's laws](http://en.wikipedia.org/wiki/De_Morgan%27s_laws) to make it look clearer:
"not (A and B)" is the same as "(not A) or (not B)"
"not (A or B)" is the same as "(not A) and (not B)"
