### PR TITLE
gui_epicmenu.lua: hide hotkey for directory button

### DIFF
--- a/LuaUI/Widgets/gui_epicmenu.lua
+++ b/LuaUI/Widgets/gui_epicmenu.lua
@@ -1,7 +1,7 @@
 function widget:GetInfo()
   return {
     name      = "EPIC Menu",
-    desc      = "v1.436 Extremely Powerful Ingame Chili Menu.",
+    desc      = "v1.437 Extremely Powerful Ingame Chili Menu.",
     author    = "CarRepairer",
     date      = "2009-06-02", --2014-05-3
     license   = "GNU GPL, v2 or later",
@@ -969,6 +969,7 @@ local function AddOption(path, option, wname ) --Note: this is used when loading
 				MakeSubWindow(path2, false)  --this made this button open another menu
 			end,
 			desc=path2,
+			isDirectoryButton = true,
 		}
 		
 		if path == '' and path2 == '' then --prevent adding '...' button on '' (Main Menu)
@@ -1089,7 +1090,7 @@ local function AddOption(path, option, wname ) --Note: this is used when loading
 				option.value = item.value
 				settings.config[fullkey] = option.value
 				
-				if (path == curPath) or filterUserInsertedTerm~='' then --search window will always need to show options in wrong path and we have to refresh the window to show changes
+				if (path == curPath) or filterUserInsertedTerm~='' then --we need to refresh the window to show changes, and current path is irrelevant if we are doing search
 					MakeSubWindow(curPath, false) --remake window to update the buttons' visuals when pressed
 				end
 			end
@@ -1108,7 +1109,7 @@ local function AddOption(path, option, wname ) --Note: this is used when loading
 	end
 	
 	--Keybindings
-	if option.type == 'button' or option.type == 'bool' then
+	if (option.type == 'button' and not option.isDirectoryButton) or option.type == 'bool' then
 		local actionName = GetActionName(path, option)
 		
 		--migrate from old logic, make sure this is done before setting orig_key
@@ -1402,43 +1403,59 @@ local function GetHotkeyData(path, option)
 end
 
 --Make a stack with control and its hotkey button
-local function MakeHotkeyedControl(control, path, option, icon)
+local function MakeHotkeyedControl(control, path, option, icon, noHotkey)
 
-	local hotkeystring = GetHotkeyData(path, option)
-	local kbfunc = function() 
-			if not get_key then
-				MakeKeybindWindow( path, option ) 
-			end
-		end
-
-	local hklength = math.max( hotkeystring:len() * 10, 20)
-	local control2 = control
-	control.x = 0
-	if icon then
-		control.x = 20
-	end
-	control.right = hklength+2 --room for hotkey button on right side?
-	control:DetectRelativeBounds()
-	
-	local hkbutton = Button:New{
-		name = option.wname .. ' hotKeyButton';
-		minHeight = 30,
-		right=0,
-		width = hklength,
-		caption = hotkeystring, 
-		OnClick = { kbfunc },
-		backgroundColor = color.sub_button_bg,
-		textColor = color.sub_button_fg, 
-		tooltip = 'Hotkey: ' .. hotkeystring,
-	}
-	
 	local children = {}
-	if icon then
-		local iconImage = Image:New{ file= icon, width = 16,height = 16, }
-		children = { iconImage, }
+	if noHotkey then
+		control.x = 0
+		if icon then
+			control.x = 20
+		end
+		control.right = 2
+		control:DetectRelativeBounds()
+			
+		if icon then
+			local iconImage = Image:New{ file= icon, width = 16,height = 16, }
+			children = { iconImage, }
+		end
+		children[#children+1] = control	
+	else
+		local hotkeystring = GetHotkeyData(path, option)
+		local kbfunc = function() 
+				if not get_key then
+					MakeKeybindWindow( path, option ) 
+				end
+			end
+
+		local hklength = math.max( hotkeystring:len() * 10, 20)
+		local control2 = control
+		control.x = 0
+		if icon then
+			control.x = 20
+		end
+		control.right = hklength+2 --room for hotkey button on right side
+		control:DetectRelativeBounds()
+		
+		local hkbutton = Button:New{
+			name = option.wname .. ' hotKeyButton';
+			minHeight = 30,
+			right=0,
+			width = hklength,
+			caption = hotkeystring, 
+			OnClick = { kbfunc },
+			backgroundColor = color.sub_button_bg,
+			textColor = color.sub_button_fg, 
+			tooltip = 'Hotkey: ' .. hotkeystring,
+		}
+		
+		--local children = {}
+		if icon then
+			local iconImage = Image:New{ file= icon, width = 16,height = 16, }
+			children = { iconImage, }
+		end
+		children[#children+1] = control
+		children[#children+1] = hkbutton
 	end
-	children[#children+1] = control
-	children[#children+1] = hkbutton
 	
 	return Panel:New{
 		width = "100%",
@@ -1493,7 +1510,7 @@ end
 local function SearchElement(termToSearch,path)
 	local filtered_pathOptions = {}
 	local tree_children = {} --used for displaying buttons
-	local maximumResult = 18 --maximum result to display. Any more it will just say "too many"
+	local maximumResult = 23 --maximum result to display. Any more it will just say "too many"
 	
 	local DiggDeeper = function() end --must declare itself first before callin self within self
 	DiggDeeper = function(currentPath)
@@ -1627,21 +1644,20 @@ MakeSubWindow = function(path, pause)
 	local root = path == ''
 	
 	local searchedElement
-	if filterUserInsertedTerm ~= "" then --this check whether window is remake during Searching or not.
-		-- MakeSubWindowSearch(path) --if Search term is being used then remake the Search window instead of normal window
-		-- return 
-		parent_path = path --we go back to HERE if we go back after searching
+	if filterUserInsertedTerm ~= "" then --this check whether window is a remake for Searching or not.
+		--if Search term is being used then remake the Search window instead of normal window
+		parent_path = path --User go "back" (back button) to HERE if we go "back" after searching
 		searchedElement,tree_children = SearchElement(filterUserInsertedTerm,path)
 	end
 	
-	local listOfElements = searchedElement or pathoptions[path] --show search result or all
+	local listOfElements = searchedElement or pathoptions[path] --show search result or show all
 	local pathLabeling = searchedElement and ""
 	for _,elem in ipairs(listOfElements) do
 		local option = elem[2]
 		local currentPath
 		if pathLabeling then
-			currentPath = elem[1] --since search has mixed path, the first entry in "listOfElements[index]" table will store path (in contrast: first entry in "pathoptions[path]" table only store indexes)
-			if pathLabeling ~= currentPath then --add label saying where this option is found
+			currentPath = elem[1] --note: during search mode the first entry in "listOfElements[index]" table will contain search result's path, in normal mode the first entry in "pathoptions[path]" table will contain indexes.
+			if pathLabeling ~= currentPath then --add label which shows where this option is found
 				local sub_path = currentPath:gsub(path,"") --remove root
 				-- tree_children[#tree_children+1] = Label:New{ caption = "- Location: " .. sub_path,  textColor = color.tooltip_bg, }
 				tree_children[#tree_children+1] = Button:New{
@@ -1666,7 +1682,7 @@ MakeSubWindow = function(path, pause)
 		
 		local optionkey = option.key
 		
-		--fixme: shouldn't be needed
+		--fixme: shouldn't be needed (?)
 		if not option.OnChange then
 			option.OnChange = function(self) end
 		end
@@ -1689,8 +1705,8 @@ MakeSubWindow = function(path, pause)
 				end
 			end
 			
-			if not hide then
-				local escapeSearch = searchedElement and option.desc and option.desc:find(currentPath) and option.name:find("...")--this type of button is a shortcut to somewhere else (defined in "AddOption(path,option,wname)")
+			if not hide then 
+				local escapeSearch = searchedElement and option.desc and option.desc:find(currentPath) and option.isDirectoryButton --this type of button will open sub-level when pressed (defined in "AddOption(path, option, wname )")
 				local disabled = option.DisableFunc and option.DisableFunc()
 				local icon = option.icon
 				local button = Button:New{
@@ -1710,7 +1726,7 @@ MakeSubWindow = function(path, pause)
 					local width = root and 24 or 16
 					Image:New{ file= icon, width = width, height = width, parent = button, x=4,y=4,  }
 				end
-				tree_children[#tree_children+1] = MakeHotkeyedControl(button, path, option)
+				tree_children[#tree_children+1] = MakeHotkeyedControl(button, path, option,nil,option.isDirectoryButton )
 			end
 			
 		elseif option.type == 'label' then	


### PR DESCRIPTION
1) hide hotkey button for subdirectory button. 
Pro: In term of utility, hotkey is not needed for navigating menu & hiding hotkey make subdirectory button looked a bit different than regular button, 
Con: in term of aesthetic, the symmetry might be lesser because hotkey button does not appear on all button

2) Increase search result limit to 23. 
Pro: higher number will get result for vague search term
Con: higher number will mean more mix of button, checkbox & slider from all directory, will look messy.
