### PR TITLE
Standarize status effect damage to shields

### DIFF
--- a/units/armstiletto_laser.lua
+++ b/units/armstiletto_laser.lua
@@ -89,13 +89,13 @@ unitDef = {
       craterMult              = 0,
 
       customParams        = {
-        disarmDamageMult = 3,
+        disarmDamageMult = 1,
         disarmDamageOnly = 1,
         disarmTimer      = 16, -- seconds
       },
  
       damage                  = {
-        default        = 225,
+        default        = 675,
       },
 
       edgeEffectiveness       = 0.4,

--- a/units/shieldarty.lua
+++ b/units/shieldarty.lua
@@ -79,14 +79,14 @@ unitDef = {
       craterMult              = 0,
 
 	  customParams        = {
-	    disarmDamageMult = 3,
+	    disarmDamageMult = 1,
 		disarmDamageOnly = 1,
 		disarmTimer      = 8, -- seconds
 	  
 	  },
 	  
       damage                  = {
-        default        = 500,
+        default        = 1500,
       },
 
       edgeEffectiveness       = 0.4,


### PR DESCRIPTION
Slow and Disarm (both normal and mixed) will now behave the same way EMP does, ie. the status effect part will do 1/3 damage to shields in addition to any real damage.

Affects disruptors and mixed disarm (ie. Skeeter) - these used to skip the real damage part unlike EMP.