### PR TITLE
Feature fx

### DIFF
--- a/LuaRules/Gadgets/feature_fx.lua
+++ b/LuaRules/Gadgets/feature_fx.lua
@@ -1,0 +1,39 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function gadget:GetInfo()
+  return {
+    name      = "Feature Effects",
+    desc      = "Spawns and plays various effects related to feature life and death",
+    author    = "Anarchid",
+    date      = "January 2015",
+    license   = "GNU GPL, v2 or later",
+    layer     = 0,
+    enabled   = true  --  loaded by default?
+  }
+end
+
+local spSpawnCEG = Spring.SpawnCEG;
+local spGetFeaturePosition     = Spring.GetFeaturePosition;
+local spGetFeatureResources    = Spring.GetFeatureResources;
+local spGetFeatureRadius       = Spring.GetFeatureRadius;
+
+local CEG_SPAWN = [[feature_poof]];
+
+function gadget:FeatureDestroyed(id, allyTeam)
+	local x,y,z = spGetFeaturePosition(id);
+	local r = spGetFeatureRadius(id);
+	
+	spSpawnCEG( CEG_SPAWN,
+		x,y,z,
+		0,0,0,
+		1+r, 1+r
+	);
+
+	--SendToUnsynced("feature_destroyed", x, y, z);
+end

--- a/LuaRules/Gadgets/feature_fx.lua
+++ b/LuaRules/Gadgets/feature_fx.lua
@@ -9,7 +9,7 @@ end
 function gadget:GetInfo()
   return {
     name      = "Feature Effects",
-    desc      = "Spawns and plays various effects related to feature life and death",
+    desc      = "Does effects related to feature life and death",
     author    = "Anarchid",
     date      = "January 2015",
     license   = "GNU GPL, v2 or later",
@@ -23,7 +23,7 @@ local spGetFeaturePosition     = Spring.GetFeaturePosition;
 local spGetFeatureResources    = Spring.GetFeatureResources;
 local spGetFeatureRadius       = Spring.GetFeatureRadius;
 
-local CEG_SPAWN = [[feature_poof]];
+local CEG_SPAWN = [[feature_poof_spawner]];
 
 function gadget:FeatureDestroyed(id, allyTeam)
 	local x,y,z = spGetFeaturePosition(id);
@@ -35,5 +35,6 @@ function gadget:FeatureDestroyed(id, allyTeam)
 		1+r, 1+r
 	);
 
+	--This could be used to later play sounds without betraying events or positions of destroyed features
 	--SendToUnsynced("feature_destroyed", x, y, z);
 end

--- a/effects/feature_poof.lua
+++ b/effects/feature_poof.lua
@@ -1,0 +1,34 @@
+-- feature_poof
+
+return {
+  ["feature_poof"] = {
+    poof01 = {
+      air                = true,
+      class              = [[CSimpleParticleSystem]],
+      count              = [[10]],
+      ground             = true,
+      properties = {
+        airdrag            = 0.98,
+        alwaysvisible      = false,
+        colormap           = [[0.8 0.65 0.55 1.0	0 0 0 0.0]],
+        directional        = true,
+        emitrot            = 180,
+        emitrotspread      = 180,
+        emitvector         = [[0, 1, 0]],
+        gravity            = [[r-0.05 r0.05, -0.2 r0.05, r-0.05 r0.05]],
+        numparticles       = [[1 d0.05]],
+        particlelife       = 30,
+        particlelifespread = 10,
+        particlesize       = [[1 d0.25]],
+        particlesizespread = [[d0.4]],
+        particlespeed      = [[d0.05 r1]],
+        particlespeedspread = 1,
+        pos                = [[r-5 r5 xd2, r-25 r1 xd2, r-5 r5 xd2]],
+        sizegrowth         = 1.2,
+        sizemod            = 0.995,
+        texture            = [[dirt]],
+      },
+    },
+  },
+}
+

--- a/effects/feature_poof.lua
+++ b/effects/feature_poof.lua
@@ -1,14 +1,27 @@
 -- feature_poof
 
 return {
+  ["feature_poof_spawner"] = {
+    poof01 = {
+      air                = true,
+      class              = [[CExpGenSpawner]],
+      count              = [[10]],
+      ground             = true,
+      properties = {
+        delay              = [[i1 x0.1d]],
+        damage             = [[d1]],
+        explosionGenerator = [[custom:feature_poof]],
+      },
+    },
+  },
   ["feature_poof"] = {
     poof01 = {
       air                = true,
       class              = [[CSimpleParticleSystem]],
-      count              = [[10]],
+      count              = [[1]],
       ground             = true,
       properties = {
-        airdrag            = 0.98,
+        airdrag            = 0.975,
         alwaysvisible      = false,
         colormap           = [[0.8 0.65 0.55 1.0	0 0 0 0.0]],
         directional        = true,


### PR DESCRIPTION
I got too fed up with potentially huge features doing nothing when crushed, destroyed, blown up or reclaimed. This tries to make me less annoyed at this by hiding the disappearance between a cloud of dust.

The cloud scales with destroyed feature's radius and is always 10 particles.

There is no sound included because googlefrog hates sounds. 