### PR TITLE
Small screen handling for Commander selection menu...

### DIFF
--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -526,7 +526,7 @@ function CreateWindow()
 	--// Some (only some) Configuration for shared values
 	local subWindowWidth = '50%'
 	local screenHorizCentre = screenWidth / 2
-	local economyPanelWidth = 660
+	local economyPanelWidth = math.min(660,screenWidth-10)
 
 	--// WINDOW
 	window = Chili.Window:New{

--- a/LuaUI/Widgets/gui_epicmenu.lua
+++ b/LuaUI/Widgets/gui_epicmenu.lua
@@ -1,7 +1,7 @@
 function widget:GetInfo()
   return {
     name      = "EPIC Menu",
-    desc      = "v1.437 Extremely Powerful Ingame Chili Menu.",
+    desc      = "v1.438 Extremely Powerful Ingame Chili Menu.",
     author    = "CarRepairer",
     date      = "2009-06-02", --2014-05-3
     license   = "GNU GPL, v2 or later",
@@ -110,7 +110,7 @@ local explodeSearchTerm = {text="", terms={}} -- store exploded "filterUserInser
 --------------------------------------------------------------------------------
 -- Misc
 local B_HEIGHT = 26
-local B_WIDTH_TOMAINMENU = 80 --100 --160
+local B_WIDTH_TOMAINMENU = 80
 local C_HEIGHT = 16
 
 local scrH, scrW = 0,0
@@ -1850,7 +1850,7 @@ MakeSubWindow = function(path, pause)
 		end
 	end
 	
-	local window_height = 400
+	local window_height = min(400, scrH - B_HEIGHT*6)
 	if settings_height < window_height then
 		window_height = settings_height+10
 	end

--- a/LuaUI/Widgets/init_startup_info_selector.lua
+++ b/LuaUI/Widgets/init_startup_info_selector.lua
@@ -1,4 +1,4 @@
-local versionNumber = "1.21"
+local versionNumber = "1.22"
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 function widget:GetInfo()
@@ -36,7 +36,7 @@ local screen0
 local Image
 local Button
 
-local vsx, vsy
+local vsx, vsy = widgetHandler:GetViewSizes()
 local modoptions = Spring.GetModOptions() --used in LuaUI\Configs\startup_info_selector.lua for planetwars
 local selectorShown = false
 local mainWindow
@@ -56,6 +56,14 @@ local WINDOW_WIDTH = 720
 local WINDOW_HEIGHT = 480
 local BUTTON_WIDTH = 128
 local BUTTON_HEIGHT = 128
+
+if (vsx < 1024 or vsy < 768) then 
+	--shrinker
+	WINDOW_WIDTH = vsx* (WINDOW_WIDTH/1024)
+	WINDOW_HEIGHT = vsy* (WINDOW_HEIGHT/768)
+	BUTTON_WIDTH = vsx* (BUTTON_WIDTH/1024)
+	BUTTON_HEIGHT = vsy* (BUTTON_HEIGHT/768)
+end
 
 --local wantLabelUpdate = false
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Commander selection menu is quite big, and designed for 1024x786 resolution according to KingRaptor. 

I added some code to scale down the menu for screen size less than 1024x768. 

It benefit low resolution screen and also user with big screen but running the game in Windowed mode. 

Side commit:
I also tweaked Epicmenu and Eco Panel 2 (default widget) to support at least 640x480. 