### PR TITLE
fix issue #504 (fontsize 9 or 10 in any Chili Chat console cause Spring crash during Loading)

### DIFF
--- a/LuaUI/Widgets/gui_chili_chat2_1.lua
+++ b/LuaUI/Widgets/gui_chili_chat2_1.lua
@@ -612,7 +612,7 @@ local function displayMessage(msg, remake)
 		local textbox = WG.Chili.TextBox:New{
 			width = '100%',
 			align = "left",
-			fontsize = (msg.highlight and options.highlighted_text_height.value or options.text_height.value),
+			fontsize = (msg.highlight and options.highlighted_text_height.value or options.text_height.value) + 0.1,   --note: use floating point, to avoid memory leak when set to magic number 9 & 10 
 			valign = "ascender",
 			lineSpacing = 0,
 			padding = { 0, 0, 0, 0 },

--- a/LuaUI/Widgets/gui_chili_chatbubbles.lua
+++ b/LuaUI/Widgets/gui_chili_chatbubbles.lua
@@ -381,7 +381,7 @@ function widget:AddChatMessage(msg)
 		valign  = "ascender";
 		align   = "left";
 		font    = {
-			size   = options.text_height.value;
+			size   = options.text_height.value + 0.1;  --note: floating point, just in case magic number 9 & 10 trigger memory leak
 			shadow = true;
 		}
 	}
@@ -479,7 +479,7 @@ function widget:AddMapPoint(player, caption, px, py, pz)
 		valign   = "ascender";
 		align    = "left";
 		font    = {
-			size   = options.text_height.value;
+			size   = options.text_height.value + 0.1;
 			shadow = true;
 		}
 	}
@@ -534,7 +534,7 @@ function widget:AddWarning(text)
 		align   = "left";
 		font    = {
 			color = {1, 0.5, 0, 1},
-			size   = options.text_height.value;
+			size   = options.text_height.value + 0.1;
 			shadow = true;
 		}
 	}

--- a/LuaUI/Widgets/gui_chili_crudeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_crudeplayerlist.lua
@@ -390,7 +390,7 @@ end
 --------------------------------------------------------------------------------
 
 local function AddCfCheckbox(allyTeam)
-	local fontsize = options.text_height.value
+	local fontsize = options.text_height.value + 0.1
 	if cf and allyTeam ~= -1 and allyTeam ~= localAlliance then
 		local cfCheck = Checkbox:New{
 			x=x_cf,y=(fontsize+1) * row + 3,width=20,
@@ -409,7 +409,7 @@ end
 
 
 local function	WriteAllyTeamNumbers(allyTeam)
-	local fontsize = options.text_height.value
+	local fontsize = options.text_height.value + 0.1
 	local aCol = {1,0,0,1}
 	if allyTeam == -1 then
 		aCol = {1,1,1,1}
@@ -437,7 +437,7 @@ end
 
 -- adds all the entity information
 local function AddEntity(entity, teamID, allyTeamID)
-	local fontsize = options.text_height.value
+	local fontsize = options.text_height.value + 0.1
 
 	local deadTeam = false
 	if entity == nil then
@@ -688,7 +688,7 @@ SetupPlayerNames = function()
 	
 	local specTeam = {roster = {}}
 
-	local fontsize = options.text_height.value
+	local fontsize = options.text_height.value + 0.1
 	scroll_cpl:ClearChildren()
 	
 	scroll_cpl:AddChild( Label:New{ x=x_team, 		caption = 'T', 		fontShadow = true, 	fontsize = fontsize, } )

--- a/LuaUI/Widgets/gui_chili_ctf.lua
+++ b/LuaUI/Widgets/gui_chili_ctf.lua
@@ -330,7 +330,7 @@ function widget:Update(s)
 					caption = GetTimeFormatted(spawn_time);
 					height = 10,
 					width = "100%";
-					fontsize = 10;
+					fontsize = 10.1; --floating point value, just in case integer 9&10 could trigger memory leak
 					textColor = green;
 				}
 				mid_stack:AddChild(respawn_timer)

--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -859,7 +859,7 @@ local function AddTableHeaders()
 end
 
 local function AddCfCheckbox(allyTeam)
-	local fontsize = options.text_height.value
+	local fontsize = options.text_height.value + 0.1
 	if cf and allyTeam ~= -1 and allyTeam ~= localAlliance then
 		local cfCheck = Checkbox:New{
 			x=x_cf,y=(fontsize+1) * row + 3,width=20,
@@ -1088,7 +1088,7 @@ SetupPlayerNames = function()
 	specTeam = {roster = {}}
 	playerTeamStatsCache = {}
 
-	fontsize = options.text_height.value
+	fontsize = options.text_height.value + 0.1
 	scroll_cpl:ClearChildren()
 	
 	local playerlist = Spring.GetPlayerList()

--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -641,7 +641,7 @@ function CreateWindow()
 		align  = "left",
 		caption = "0",
 		autosize = false,
-		font   = {size = options.fontSize.value, outline = true, color = {.8,.8,.8,.9}, outlineWidth = 2, outlineWeight = 2},
+		font   = {size = options.fontSize.value + 0.1, outline = true, color = {.8,.8,.8,.9}, outlineWidth = 2, outlineWeight = 2},
 		tooltip = "Your metal storage.",
 	}
 	
@@ -655,7 +655,7 @@ function CreateWindow()
 		valign = "bottom",
  		align  = "left",
 		autosize = false,
-		font   = {size = options.fontSize.value, outline = true, outlineWidth = 2, outlineWeight = 2},
+		font   = {size = options.fontSize.value + 0.1, outline = true, outlineWidth = 2, outlineWeight = 2},
 		tooltip = "Your metal Income.\nGained from metal extractors, overdrive and reclaim",
 	}
 	
@@ -669,7 +669,7 @@ function CreateWindow()
 		valign = "bottom",
 		align  = "left",
 		autosize = false,
-		font   = {size = options.fontSize.value, outline = true, outlineWidth = 2, outlineWeight = 2},
+		font   = {size = options.fontSize.value + 0.1, outline = true, outlineWidth = 2, outlineWeight = 2},
 		tooltip = "Your metal demand. Construction and morph demand metal.",
 	}
 	
@@ -772,7 +772,7 @@ function CreateWindow()
 		align  = "left",
 		caption = "0",
 		autosize = false,
-		font   = {size = options.fontSize.value, outline = true, color = {.8,.8,.8,.9}, outlineWidth = 2, outlineWeight = 2},
+		font   = {size = options.fontSize.value + 0.1, outline = true, color = {.8,.8,.8,.9}, outlineWidth = 2, outlineWeight = 2},
 		tooltip = "Your energy storage.",
 	}
 	
@@ -786,7 +786,7 @@ function CreateWindow()
 		valign = "bottom",
  		align  = "left",
 		autosize = false,
-		font   = {size = options.fontSize.value, outline = true, outlineWidth = 2, outlineWeight = 2},
+		font   = {size = options.fontSize.value + 0.1, outline = true, outlineWidth = 2, outlineWeight = 2},
 		tooltip = "Your energy income.\nGained from powerplants.",
 	}
 	
@@ -800,7 +800,7 @@ function CreateWindow()
 		valign = "bottom",
 		align  = "left",
 		autosize = false,
-		font   = {size = options.fontSize.value, outline = true, outlineWidth = 2, outlineWeight = 2},
+		font   = {size = options.fontSize.value + 0.1, outline = true, outlineWidth = 2, outlineWeight = 2},
 		tooltip = "This is this total energy demand of your economy and abilities which require energy upkeep",
 	}
 	

--- a/LuaUI/Widgets/gui_chili_proconsole2.lua
+++ b/LuaUI/Widgets/gui_chili_proconsole2.lua
@@ -814,17 +814,17 @@ local function AddMessage(msg, target, remake)
 	local size
 	if target == 'chat' then
 		stack = stack_chat
-		size = options.text_height_chat.value
+		size = options.text_height_chat.value + 0.1  --note: use floating point, to avoid memory leak when set to magic number 9 & 10 
 		if not remake then
 			fade = true
 		end
 		lastMsg = lastMsgChat
 	elseif target == 'console' then
 		stack = stack_console
-		size = options.text_height_console.value
+		size = options.text_height_console.value + 0.1
 		lastMsg = lastMsgConsole
 	elseif target == 'backchat' then
-		size = options.text_height_chat.value
+		size = options.text_height_chat.value + 0.1
 		stack = stack_backchat
 		lastMsg = lastMsgBackChat
 	end	

--- a/LuaUI/Widgets/gui_chili_proconsole_test.lua
+++ b/LuaUI/Widgets/gui_chili_proconsole_test.lua
@@ -788,17 +788,17 @@ local function AddMessage(msg, target, remake)
 	local size
 	if target == 'chat' then
 		stack = stack_chat
-		size = options.text_height_chat.value
+		size = options.text_height_chat.value + 0.1  --note: use floating point, to avoid memory leak when set to magic number 9 & 10 
 		if not remake then
 			fade = true
 		end
 		lastMsg = lastMsgChat
 	elseif target == 'console' then
 		stack = stack_console
-		size = options.text_height_console.value
+		size = options.text_height_console.value + 0.1 
 		lastMsg = lastMsgConsole
 	elseif target == 'backchat' then
-		size = options.text_height_chat.value
+		size = options.text_height_chat.value + 0.1
 		stack = stack_backchat
 		lastMsg = lastMsgBackChat
 	end	

--- a/LuaUI/Widgets/nubtron.lua
+++ b/LuaUI/Widgets/nubtron.lua
@@ -475,7 +475,7 @@ local function SetupNubtronWindow()
 		align="left";
 		valign="top";
 		caption = 'Tip';
-		fontSize = 10;
+		fontSize = 10.1; --floating point, just in case integer 10 & 9 could trigger memory leak
 		fontShadow = true;
 		parent = button;
 	}


### PR DESCRIPTION
What happen when someone have this bug:
Spring will lock-up after "Finalizing" and a window will appear saying: "Spring: Failed to Allocate Memory".
This bug won't appear ingame or with /reload. It will only happen at next game.

Magically adding + 0.1 to fontsize fixed it. 

issue #504 

Is confirmed to effect "Chili Chat 2" & "Chili Chat Proconsole", but I also apply fix to other widget just in case... (also 0.1 is too tiny to effect design IMO)