### PR TITLE
Block "/take" of inactive-team or AI

### DIFF
--- a/LuaRules/Gadgets/game_disable_take.lua
+++ b/LuaRules/Gadgets/game_disable_take.lua
@@ -1,0 +1,40 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function gadget:GetInfo()
+  return {
+    name      = "Disable /take",
+    desc      = "Disable /take of AI's unit or inactive team's unit unless /cheat is enabled", 
+    author    = "xponen",
+    date      = "21 January 2015",
+    license   = "ZK's default license",
+    layer     = 0,
+    enabled   = true  --  loaded by default?
+  }
+end
+
+local spIsCheatingEnabled = Spring.IsCheatingEnabled
+local spGetPlayerInfo     = Spring.GetPlayerInfo
+local spGetTeamInfo       = Spring.GetTeamInfo
+
+GG.allowTransfer = false
+function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
+	--NOTE: this gadget don't block unit transfer to enemy (which is an Engine setting).
+	if capture or GG.allowTransfer or spIsCheatingEnabled() then --ALLOW transfer when capturing unit, or when superuser asked it, or when gadget requested it
+		return true 
+	end
+	local _,leaderID,isDead,isAI = spGetTeamInfo(oldTeam)
+	if isAI or isDead then --DISALLOW /take of AI or dead player
+		return false
+	end
+	local _, active, spectator = spGetPlayerInfo(leaderID)
+	if (spectator or not active) then --DISALLOW /take of resigned or afk player
+		return false
+	end
+	return true --ALLOW transfer for all other case (eg: player to player)
+end

--- a/LuaRules/Gadgets/game_over.lua
+++ b/LuaRules/Gadgets/game_over.lua
@@ -214,7 +214,9 @@ local function DestroyAlliance(allianceID)
 					local u = teamUnits[j]
 					local pwUnits = (GG.PlanetWars or {}).unitsByID
 					if pwUnits and pwUnits[u] then
+						GG.allowTransfer = true
 						spTransferUnit(u, gaiaTeamID, true)		-- don't blow up PW buildings
+						GG.allowTransfer = false
 					else
 						toDestroy[u] = true
 					end

--- a/LuaRules/Gadgets/unit_marketplace.lua
+++ b/LuaRules/Gadgets/unit_marketplace.lua
@@ -90,7 +90,9 @@ local function CheckOffers()
 			market[unitID] = nil
 			GG.AddDebt(customer, teamID, saleprice)
 			GG.shareunits[unitID] = true
+			GG.allowTransfer = true
 			Spring.TransferUnit(unitID, customer, true)
+			GG.allowTransfer = false
 			Spring.SetUnitRulesParam( unitID, 'buy'..teamID, 0, {allied=true} )
 			Spring.SetUnitRulesParam( unitID, 'sell'..teamID, 0, {allied=true} )
 		end

--- a/LuaRules/Gadgets/unit_planetwars.lua
+++ b/LuaRules/Gadgets/unit_planetwars.lua
@@ -439,7 +439,9 @@ end
 function gadget:AllowCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
 	if unitsByID[unitID] and cmdID == CMD_ABANDON_PW then
 		local gaiaTeam = Spring.GetGaiaTeamID()
+		GG.allowTransfer = true
 		Spring.TransferUnit(unitID, gaiaTeam, true)
+		GG.allowTransfer = false
 		Spring.SetUnitNeutral(unitID, true)
 		return false
 	elseif cmdID == CMD.ATTACK and #cmdParams == 1 then


### PR DESCRIPTION
Why blocking "/take" is a good idea:
  -#457 reported that "/take" prevent lagmonitor from returning unit to its owner. (fix #457 )
  -also, "/take" prevent some game mode like "player as chicken" from working properly (since the original design didn't want player to have all chicken)

Changes:
  -added "game_disable_take.lua"
  -tweaked some other gadget to make sure they use "GG.allowTransfer" to differentiate user's "/take" from gadget's unit transfer.