### PR TITLE
fix #528

### DIFF
--- a/LuaUI/Widgets/unit_healthbars.lua
+++ b/LuaUI/Widgets/unit_healthbars.lua
@@ -830,7 +830,7 @@ do
 	  --// SLOW
       local slowState = GetUnitRulesParam(unitID,"slowState")
       if (slowState and (slowState>0)) then
-        AddBar("slow",slowState,"slow",(fullText and floor(slowState*100)..'%') or '')
+        AddBar("slow",slowState*2,"slow",(fullText and floor(slowState*100)..'%') or '')
       end
 	  
 	  --// GOO


### PR DESCRIPTION
Makes slowdamage healthbar filled on max slow