### PR TITLE
Increased reload time on airpads in attempt to nerf Raven

### DIFF
--- a/LuaRules/Gadgets/unit_refuel_pad_handler.lua
+++ b/LuaRules/Gadgets/unit_refuel_pad_handler.lua
@@ -169,7 +169,7 @@ local function SitOnPad(unitID)
 			
 			landDuration = landDuration + 1
 			
-			if landDuration%15 == 0 then
+			if landDuration%20 == 0 then
 				local stunned_or_inbuild = spGetUnitIsStunned(landData.padID) or (spGetUnitRulesParam(landData.padID,"disarmed") == 1)
 				if stunned_or_inbuild then
 					if drainingEnergy then


### PR DESCRIPTION
Increased reload time on airpads from 15 cycles to 20 (that is 2.5 second) in attempt to lessen dps output of raven. This is a very minor change but I am afraid to hurt other bombers too much by it as well :\
While it wont hurt Wyvern and Thunderbird as much because these planes usually wait for their window of opportunity anyway and they hover around doing nothing after they spend a shot. Phoenix will suffer considerably and might require small buff?