### PR TITLE
Disable game_disable_take.lua gadget for workaround random orphaned Com blinking problem

### DIFF
--- a/LuaRules/Gadgets/game_disable_take.lua
+++ b/LuaRules/Gadgets/game_disable_take.lua
@@ -14,7 +14,7 @@ function gadget:GetInfo()
     date      = "21 January 2015",
     license   = "ZK's default license",
     layer     = 0,
-    enabled   = true  --  loaded by default?
+    enabled   = false  --  loaded by default?
   }
 end
 


### PR DESCRIPTION
orphaned com issue is reallly long issue, exist since ancient time, not sure can fix while people might experience random case of flashes of light.

People will usually /take this units. In mean time I investigate lagmonitor.

If its not really important issue then don't Pull this yet.
ref: https://github.com/ZeroK-RTS/Zero-K/issues/570