### PR TITLE
Chat Console widgets: Fontsize safety 2.0

### DIFF
--- a/LuaUI/Widgets/gui_chili_chatbubbles.lua
+++ b/LuaUI/Widgets/gui_chili_chatbubbles.lua
@@ -371,7 +371,10 @@ function widget:AddChatMessage(msg)
 		}
 	}
 	]]--
-
+	local fontsize = options.text_height.value;
+	if (fontsize==9 or fontsize==10) then --note: magic number 9 & 10 trigger memory leak
+		fontsize = fontsize + 0.1
+	end
 	Chili.TextBox:New{
 		parent  = w;
 		text    = textColor .. playerName .. ":\008 " .. color2incolor(bubbleColor) .. text .. "\008";
@@ -381,7 +384,7 @@ function widget:AddChatMessage(msg)
 		valign  = "ascender";
 		align   = "left";
 		font    = {
-			size   = options.text_height.value;
+			size   = fontsize;
 			shadow = true;
 		}
 	}
@@ -470,6 +473,10 @@ function widget:AddMapPoint(player, caption, px, py, pz)
 	}
 	local text = color2incolor(teamcolor) .. playerName .. "\008 added point" .. (caption and (": " .. caption) or '')
 	
+	local fontsize = options.text_height.value;
+	if (fontsize==9 or fontsize==10) then
+		fontsize = fontsize + 0.1
+	end
 	local l = Chili.TextBox:New{
 		parent   = w;
 		text  = text;
@@ -479,7 +486,7 @@ function widget:AddMapPoint(player, caption, px, py, pz)
 		valign   = "ascender";
 		align    = "left";
 		font    = {
-			size   = options.text_height.value;
+			size   = fontsize;
 			shadow = true;
 		}
 	}

--- a/LuaUI/Widgets/gui_chili_proconsole2.lua
+++ b/LuaUI/Widgets/gui_chili_proconsole2.lua
@@ -252,7 +252,7 @@ options = {
 		OnChange = onOptionsChanged,
 	},
 	clickable_points = {
-		name = "Clickable points and labels",
+		name = "Clickable name and points",
 		type = 'bool',
 		value = true,
 		OnChange = onOptionsChanged,
@@ -828,6 +828,9 @@ local function AddMessage(msg, target, remake)
 		stack = stack_backchat
 		lastMsg = lastMsgBackChat
 	end	
+	if (size==9 or size==10) then --note: magic number 9 & 10 trigger memory leak
+		size = size + 0.1
+	end
 	
 	-- TODO betterify this / make configurable
 	--[[
@@ -925,6 +928,23 @@ local function AddMessage(msg, target, remake)
 		}
 	}
 	
+	if options.clickable_points.value and WG.alliedCursorsPos and msg.player and msg.player.id then --make hidden button (on player name) for regular say
+		local cur = WG.alliedCursorsPos[msg.player.id]
+		if cur then
+			sourceTextBox.OnMouseDown = {function(self, x, y, mouse)
+					local alt,ctrl, meta,shift = Spring.GetModKeyState()
+					if ( shift or ctrl or meta or alt ) then return false end --skip all modifier key
+					local click_on_name = x <= sourceTextBox.font:GetTextWidth(msg.playername)+10;
+					if (mouse == 1 and click_on_name) then
+						Spring.SetCameraTarget(cur[1], 0,cur[2], 1) --go to where player is pointing at. NOTE: "cur" is table referenced to "WG.alliedCursorsPos" so its always updated with latest value
+					end
+			end}
+			function sourceTextBox:HitTest(x, y)  -- copied this hack from chili bubbles
+				return self
+			end
+		end
+	end
+	
 	local tbheight = 20
 	
 	local controlChildren = {sourceTextBox, messageTextBoxCont}
@@ -989,26 +1009,6 @@ local function AddMessage(msg, target, remake)
 			AddControlToFadeTracker(flagButton, 'button')
 		end
 	end
-	
-	--[[
-	
-		elseif WG.alliedCursorsPos and msg.player and msg.player.id then --message is regular chat, make hidden button
-			local cur = WG.alliedCursorsPos[msg.player.id]
-			if cur then
-				textbox.OnMouseDown = {function(self, x, y, mouse)
-						local alt,ctrl, meta,shift = Spring.GetModKeyState()
-						if ( shift or ctrl or meta or alt ) then return false end --skip all modifier key
-						local click_on_text = x <= textbox.font:GetTextWidth(self.text); -- use self.text instead of text to include dedupe message prefix
-						if (mouse == 1 and click_on_text) then
-							Spring.SetCameraTarget(cur[1], 0,cur[2], 1) --go to where player is pointing at. NOTE: "cur" is table referenced to "WG.alliedCursorsPos" so its always updated with latest value
-						end
-				end}
-				function textbox:HitTest(x, y)  -- copied this hack from chili bubbles
-					return self
-				end
-			end
-		end
-	--]]
 	
 	if target == 'chat' then
 		lastMsgChat = messageTextBox

--- a/LuaUI/Widgets/gui_chili_proconsole_test.lua
+++ b/LuaUI/Widgets/gui_chili_proconsole_test.lua
@@ -249,7 +249,7 @@ options = {
 		OnChange = onOptionsChanged,
 	},
 	clickable_points = {
-		name = "Clickable points and labels",
+		name = "Clickable name and points",
 		type = 'bool',
 		value = true,
 		OnChange = onOptionsChanged,
@@ -802,6 +802,9 @@ local function AddMessage(msg, target, remake)
 		stack = stack_backchat
 		lastMsg = lastMsgBackChat
 	end	
+	if (size==9 or size==10) then --note: magic number 9 & 10 trigger memory leak
+		size = size + 0.1
+	end
 	
 	--if msg.highlight and options.highlighted_text_height.value
 	
@@ -845,10 +848,26 @@ local function AddMessage(msg, target, remake)
 			--color         = {0,0,0,0},
 		}
 	}
+	if WG.alliedCursorsPos and msg.player and msg.player.id then --make hidden button (on player name) for regular say
+		local cur = WG.alliedCursorsPos[msg.player.id]
+		if cur then
+			textbox.OnMouseDown = {function(self, x, y, mouse)
+					local alt,ctrl, meta,shift = Spring.GetModKeyState()
+					if ( shift or ctrl or meta or alt ) then return false end --skip all modifier key
+					local click_on_name = x <= textbox.font:GetTextWidth(msg.playername)+10;
+					if (mouse == 1 and click_on_name) then
+						Spring.SetCameraTarget(cur[1], 0,cur[2], 1) --go to where player is pointing at. NOTE: "cur" is table referenced to "WG.alliedCursorsPos" so its always updated with latest value
+					end
+			end}
+			function textbox:HitTest(x, y)  -- copied this hack from chili bubbles
+				return self
+			end
+		end
+	end
 	
 	if options.clickable_points.value then
 		local control = textbox
-		if msg.point then --message is a marker, make obvious looking button
+		if msg.point then --message is a marker
 			local padding
 			if target == 'chat' then
 				padding = { 3,3,1,1 }
@@ -868,7 +887,7 @@ local function AddMessage(msg, target, remake)
 				backgroundColor = {0,0,0,0},
 				caption = '',
 				children = {
-					WG.Chili.Button:New{
+					WG.Chili.Button:New{  --make obvious looking button for marker
 						caption='',
 						x=0;y=0;
 						width = 30,
@@ -895,7 +914,7 @@ local function AddMessage(msg, target, remake)
 				},
 				
 			}
-		elseif target == 'chat' then
+		elseif target == 'chat' then --message is regular chat
 			-- Make a panel for each chat line because this removes the message jitter upon fade.
 			textbox:SetPos( 3, 3, stack.width - 3 )
 			textbox:Update()
@@ -911,21 +930,6 @@ local function AddMessage(msg, target, remake)
 					textbox,
 				},
 			}
-		elseif WG.alliedCursorsPos and msg.player and msg.player.id then --message is regular chat, make hidden button
-			local cur = WG.alliedCursorsPos[msg.player.id]
-			if cur then
-				textbox.OnMouseDown = {function(self, x, y, mouse)
-						local alt,ctrl, meta,shift = Spring.GetModKeyState()
-						if ( shift or ctrl or meta or alt ) then return false end --skip all modifier key
-						local click_on_text = x <= textbox.font:GetTextWidth(self.text); -- use self.text instead of text to include dedupe message prefix
-						if (mouse == 1 and click_on_text) then
-							Spring.SetCameraTarget(cur[1], 0,cur[2], 1) --go to where player is pointing at. NOTE: "cur" is table referenced to "WG.alliedCursorsPos" so its always updated with latest value
-						end
-				end}
-				function textbox:HitTest(x, y)  -- copied this hack from chili bubbles
-					return self
-				end
-			end
 		end
 		stack:AddChild(control, false)
 		if fade then


### PR DESCRIPTION
This is an improved version of https://github.com/ZeroK-RTS/Zero-K/pull/515 fix.

In this version, I only target fontsize 9 & 10 and not any other cases. This should avoid side-effect (such as lag) caused by https://github.com/ZeroK-RTS/Zero-K/pull/515

In addition, 
I fixed a feature which moves the camera to a player's cursor by clicking on their player-name.