### PR TITLE
Capture scaling (3-2x) -> (1/x)

### DIFF
--- a/LuaRules/Gadgets/91_unit_capture.lua
+++ b/LuaRules/Gadgets/91_unit_capture.lua
@@ -20,8 +20,6 @@ local RETAKING_DEGRADE_TIMER = 15
 local GENERAL_DEGRADE_TIMER = 5
 local DEGRADE_FACTOR = 0.04
 
-local DAMAGE_MULT = 3	-- n times faster when target is at 0% health
-
 include("LuaRules/Configs/customcmds.h.lua")
 local CMD_STOP = CMD.STOP
 local CMD_SELFD = CMD.SELFD
@@ -245,7 +243,7 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 	if health <= 0 then 
 		health = 0.01 
 	end
-	newCaptureDamage = newCaptureDamage * (DAMAGE_MULT - (DAMAGE_MULT - 1)*(health/maxHealth))
+	newCaptureDamage = newCaptureDamage * (maxHealth / health)
 	
 	local allyTeamData = allyTeams[attackerAllyTeam]
 	

--- a/LuaRules/Gadgets/unit_capture.lua
+++ b/LuaRules/Gadgets/unit_capture.lua
@@ -20,8 +20,6 @@ local RETAKING_DEGRADE_TIMER = 15
 local GENERAL_DEGRADE_TIMER = 5
 local DEGRADE_FACTOR = 0.04
 
-local DAMAGE_MULT = 3	-- n times faster when target is at 0% health
-
 include("LuaRules/Configs/customcmds.h.lua")
 local CMD_STOP = CMD.STOP
 local CMD_SELFD = CMD.SELFD
@@ -238,7 +236,7 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 	if health <= 0 then 
 		health = 0.01 
 	end
-	newCaptureDamage = newCaptureDamage * (DAMAGE_MULT - (DAMAGE_MULT - 1)*(health/maxHealth))
+	newCaptureDamage = newCaptureDamage * (maxHealth / health)
 	
 	local allyTeamData = allyTeams[attackerAllyTeam]
 	


### PR DESCRIPTION
That is the same scaling as other status effects, ie. at eg. 25% hp the unit will be capped 4x as fast.
Currently it goes up to 3x at 0%, which:
* is not consistent with the other status effects
* relies on the 3 constant which is not really documented anywhere
* doesn't keep the time-spent-capping-to-received-value ratio constant; currently you get best efficiency for 75% hp units due to the equation
* previous also causes targeting issues (low health targets are preferred but actually have much worse cap efficiency)

Balance is kept intact for full health units; units at (0.5, 1) health would be captured slightly slower than currently and units at (0, 0.5) health would be capped faster.