### PR TITLE
Revert "Crabe: don't curl when stunned/disarmed/reclaimed"

### DIFF
--- a/scripts/armcrabe.lua
+++ b/scripts/armcrabe.lua
@@ -107,10 +107,6 @@ local function Curl()
 	if nocurl then return end
 	--Spring.Echo("Initiating curl")
 	
-	while (Spring.GetUnitIsStunned(unitID) or (Spring.GetUnitRulesParam(unitID, "disarmed") == 1)) do
-		Sleep (100)
-	end
-	
 	Signal(SIG_MOVE)
 	SetSignalMask(SIG_MOVE)
 	


### PR DESCRIPTION
ops! disarm shouldn't stop curl because its not stun,

and, there's problem with the animation: the crabe don't stop walking when emped, same is when being disarmed, 

also (minor) it doesn't actually stop the animation of curling if being emped/disarmed after it begun curling.