### PR TITLE
ModOptions: hide unneeded ROI option.

### DIFF
--- a/LuaRules/Gadgets/unit_mex_overdrive.lua
+++ b/LuaRules/Gadgets/unit_mex_overdrive.lua
@@ -29,8 +29,8 @@ local mexDefs = {}
 local pylonDefs = {}
 local odSharingModOptions = (Spring.GetModOptions()).overdrivesharingscheme
 
-local RoIoverdrive = ((odSharingModOptions == "investmentreturn") or (odSharingModOptions == "investmentreturn_od"))
-local RoIbase = ((odSharingModOptions == "investmentreturn") or (odSharingModOptions == "investmentreturn_base"))
+local enableEnergyPayback = ((odSharingModOptions == "investmentreturn") or (odSharingModOptions == "investmentreturn_energy_od"))
+local enableMexPayback = ((odSharingModOptions == "investmentreturn") or (odSharingModOptions == "investmentreturn_mex_base"))
 
 -- this is "fun" mod
 local OreMexModOption = tonumber((Spring.GetModOptions()).oremex) or 0 -- Red Annihilation mexes, no harvesters though, use cons/coms to reclaim ore.
@@ -1183,7 +1183,7 @@ function gadget:GameFrame(n)
 				
 				local summedOverdriveMetalAfterPayback = summedOverdrive
 				local teamPacybackOD = {}
-				if RoIoverdrive then
+				if enableEnergyPayback then
 					for i = 1, allyTeamData.teams do 
 						local teamID = allyTeamData.team[i]
 						if activeTeams[teamID] then
@@ -1289,7 +1289,7 @@ local function AddMex(unitID, teamID, metalMake)
 	if (allyTeamID) then
 		mexByID[unitID] = {gridID = 0, allyTeamID = allyTeamID}
 		
-		if teamID and RoIbase then
+		if teamID and enableMexPayback then
 			local refundTime = 400/metalMake
 			mexByID[unitID].refundTeamID = teamID
 			mexByID[unitID].refundTime = refundTime
@@ -1421,11 +1421,14 @@ function gadget:Initialize()
 	-- "oremex" modoption, instead of modyfing overdrive code integrity and decreasing readability, this will do
 	-- check unit_oremex.lua for oremex code.
 	if (OreMexModOption == 1) then
-		spAddTeamResource = function(a,b,c) if b~="m" then Spring.AddTeamResource(a,b,c) end end
-		setOreIncome = function(unitID, oreAmount)
-			 GG.oreIncome[unitID] = oreAmount -- this is set to nil, if unitID is destroyed in unit_oremex.lua anyway
+		spAddTeamResource = function(a,b,c) 
+			if b~="m" then Spring.AddTeamResource(a,b,c) end  --disable metal distribution issued by *this* gadget.
 		end
-		RoIoverdrive = false -- because OD communism is handled within oremex. -- or does oremex communism need seperate modoption?
+		setOreIncome = function(unitID, oreAmount)
+			 GG.oreIncome[unitID] = oreAmount -- this spawn the rocks. It don't need to reset to empty value, because this is set to NIL when unitID is destroyed in unit_oremex.lua anyway
+		end
+		enableEnergyPayback = false -- because metal/rocks is reclaimable by anyone, so payback can't work. Also resource distribution is handled within oremex (currently communism). -- or does oremex need a communism modoption?
+		enableMexPayback = false
 	end
 	
 	gadgetHandler:AddChatAction("odb",OverdriveDebugToggle,"Toggles debug mode for overdrive.")
@@ -1449,7 +1452,7 @@ function gadget:UnitFinished(unitID, unitDefID, unitTeam)
 	if (pylonDefs[unitDefID] and notDestroyed[unitID]) then
 		AddPylon(unitID, unitDefID, pylonDefs[unitDefID].extractor, pylonDefs[unitDefID].range)
 	end
-	if paybackDefs[unitDefID] and RoIoverdrive then
+	if paybackDefs[unitDefID] and enableEnergyPayback then
 		AddEnergyToPayback(unitID, unitDefID, unitTeam)
 	end
 end
@@ -1495,7 +1498,7 @@ function gadget:UnitTaken(unitID, unitDefID, oldTeamID, teamID)
 			RemovePylon(unitID)
 		end
 		
-		if paybackDefs[unitDefID] and RoIoverdrive then
+		if paybackDefs[unitDefID] and enableEnergyPayback then
 			RemoveEnergyToPayback(unitID, unitDefID)
 		end
 		--if (energyDefs[unitDefID]) then
@@ -1513,7 +1516,7 @@ function gadget:UnitDestroyed(unitID, unitDefID, unitTeam)
 		notDestroyed[unitID] = nil
 		RemovePylon(unitID)
 	end
-	if paybackDefs[unitDefID] and RoIoverdrive then
+	if paybackDefs[unitDefID] and enableEnergyPayback then
 		RemoveEnergyToPayback(unitID, unitDefID)
 	end
 	--if (energyDefs[unitDefID]) then

--- a/LuaRules/Gadgets/unit_oremex.lua
+++ b/LuaRules/Gadgets/unit_oremex.lua
@@ -100,7 +100,7 @@ local mapHeight
 local teamIDs
 local UnderAttack = {} -- holds frameID per mex so it goes neutral, if someone attacks it, for 5 seconds, it will not return to owner if no grid connected.
 local Ore = {} -- hold features should they emit harm they will ongameframe
-local OreIncome = GG.oreIncome
+local OreIncome = GG.oreIncome --is set by unit_mex_overdrive.lua every 32th frame
 local gameframe = Spring.GetGameFrame()
 
 local TiberiumProofDefs = {
@@ -218,7 +218,7 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam)
 	end
 end
 
-local TransferLoop = function()
+local TransferLoop = function() --transfer mex to nearest team that deliver energy
 	for unitID, data in pairs(OreMex) do
 		local x = data.x
 		local z = data.z
@@ -302,12 +302,12 @@ function gadget:AllowFeatureBuildStep(builderID, builderTeam, featureID, feature
 	if not(OreDefs[featureDefID]) or not(MinedOre[builderTeam]) or (builderTeam == GaiaTeamID) then
 		return true
 	end
- 	MinedOre[builderTeam] = MinedOre[builderTeam] + (-part/FeatureDefs[featureDefID].metal)
+ 	MinedOre[builderTeam] = MinedOre[builderTeam] + (-part/FeatureDefs[featureDefID].metal) --reclaiming ore
 	return true
 end
 
 function gadget:AllowUnitBuildStep(builderID, builderTeam, step) -- was not documented in spring wiki
-	if (OwnsOreToTeam[builderTeam]) and (MinedOre[builderTeam] >= 10) then -- you own your team some metal, until you repay the amount you can't build, i'm so sorry
+	if (OwnsOreToTeam[builderTeam]) and (MinedOre[builderTeam] >= 10) then -- (halt construction until reclaimed ore is shared with teams,) You owe your team some metal, until you repay the amount you can't build, i'm so sorry
 		return false
 	end
 	return true
@@ -338,7 +338,7 @@ local function AlliesNeedM(teamIDs)
 	return needs
 end
 
-local ShareMinedOre = function()
+local ShareMinedOre = function() --perform communism/resource-sharing and allocation
 	for teamID, allies in pairs(TeamData) do
 		if (MinedOre[teamID] > 1) then
 			MinedOre[teamID] = floor(MinedOre[teamID]) -- keep the change!
@@ -379,10 +379,10 @@ end
 function gadget:GameFrame(f)
 	gameframe = f
 	if ((f%32)==1) then
-		ShareMinedOre()
-		MineMoreOreLoop()
-		InflictOreDamage()
-		TransferLoop()
+		ShareMinedOre() --distribute metal from reclaimed ores to ally
+		MineMoreOreLoop() --spawn a reclaimable ore around mex
+		InflictOreDamage() --damage units walking on the ore, like tiberium
+		TransferLoop() --transfer mex to team which connect energy to it
 	end
 end
 

--- a/ModOptions.lua
+++ b/ModOptions.lua
@@ -415,22 +415,22 @@ local options = {
       {
         key  = "investmentreturn",
         name = "Investment Return",
-        desc = "Extra income is given to active players who built economy structure until the cost of the structure is paid.",
+        desc = "Extra metal income is given to active players who built economy structure until the cost of the structure is paid.",
       },
-      {
-        key  = "investmentreturn_od",
-        name = "Overdrive Return",
-        desc = "Extra overdrive is given to active players who built energy structure until the cost of the structure is paid.",
-      },
-      {
-        key  = "investmentreturn_base",
-        name = "Extractor Return",
-        desc = "Extra income is given to active players who built metal extractor until the cost of the structure is paid.",
-      },
+      -- {
+        -- key  = "investmentreturn_energy_od",
+        -- name = "Investment Return (Energy only)",
+        -- desc = "Extra overdrive is given to active players who built energy structure until the cost of the structure is paid.",
+      -- },
+      -- {
+        -- key  = "investmentreturn_mex_base",
+        -- name = "Investment Return (Mex only)",
+        -- desc = "Extra metal income is given to active players who built metal extractors until the cost of the extractor is paid.",
+      -- },
       {
         key  = "communism",
         name = "Equal Sharing",
-        desc = "All overdrive is shared equally among active players at all time.",
+        desc = "All metal income is shared equally among active players at all time.",
       },
     },
   },  


### PR DESCRIPTION
 I think not needed to create question among users why there's option to only payback Energy structure and another option to only payback mex.

Other:
unit_oremex.lua: some in-code comment
unit_mex_overdrive.lua: rename some ROI variable to something better. Disabled payback for Oremex because it shouldn't work when Oremex active.