### PR TITLE
LUS notification gadget

### DIFF
--- a/LuaRules/Gadgets/unit_boolean_disable.lua
+++ b/LuaRules/Gadgets/unit_boolean_disable.lua
@@ -70,6 +70,7 @@ local f = 0 -- frame, set in game frame
 local function applyEffect(unitID)
 	Spring.SetUnitRulesParam(unitID, "disarmed", 1, LOS_ACCESS)
 	GG.UpdateUnitAttributes(unitID)
+	GG.ScriptNotifyDisarmed(unitID)
 end
 
 local function removeEffect(unitID)

--- a/LuaRules/Gadgets/unit_script_notification.lua
+++ b/LuaRules/Gadgets/unit_script_notification.lua
@@ -1,0 +1,38 @@
+function gadget:GetInfo() return {
+	name    = "Script notification",
+	desc    = "Notifies scripts about various events.",
+	author  = "Sprung",
+	date    = "2015-03-12",
+	license = "PD",
+	layer   = -1,
+	enabled = true,
+} end
+
+if (not gadgetHandler:IsSyncedCode()) then return end
+
+local spGetScriptEnv = Spring.UnitScript.GetScriptEnv
+local spCallAsUnit   = Spring.UnitScript.CallAsUnit
+
+local function callScript (unitID, funcName, args)
+	local func = spGetScriptEnv(unitID)
+	if func then
+		func = func[funcName]
+		if func then
+			return spCallAsUnit(unitID, func, args)
+		end
+	end
+	return false
+end
+
+local function ScriptNotifyEMPed (unitID)
+	callScript (unitID, "Stunned", 1)
+end
+
+local function ScriptNotifyDisarmed (unitID)
+	callScript (unitID, "Stunned", 0)
+end
+
+function gadget:Initialize ()
+	GG.ScriptNotifyEMPed    = ScriptNotifyEMPed
+	GG.ScriptNotifyDisarmed = ScriptNotifyDisarmed
+end


### PR DESCRIPTION
This is #331 done the suggested way. Adds a gadget that other gadgets can use to communicate with LUS. Currently used by EMP and Disarm gadgets to tell LUS a unit got stunned by their respective status effect.