### PR TITLE
forceresign made sane

### DIFF
--- a/LuaRules/Gadgets/game_resign.lua
+++ b/LuaRules/Gadgets/game_resign.lua
@@ -1,52 +1,52 @@
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
+function gadget:GetInfo() return {
+	name    = "Resign Gadget",
+	desc    = "Resign stuff",
+	author  = "KingRaptor",
+	date    = "2012.5.1",
+	license = "Public domain",
+	layer   = 0,
+	enabled = true,
+} end
 
-function gadget:GetInfo()
-	return {
-		name      = "Resign Gadget",
-		desc      = "Resign stuff",
-		author    = "KingRaptor",
-		date      = "2012.5.1",
-		license   = "Public domain",
-		layer     = 0,
-		enabled   = true  --  loaded by default?
-	}
-end
+if (not gadgetHandler:IsSyncedCode()) then return end
 
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
-  
-if (gadgetHandler:IsSyncedCode()) then
---------------------------------------------------------------------------------
--- synced
---------------------------------------------------------------------------------
+local spGetPlayerInfo = Spring.GetPlayerInfo
+local spKillTeam = Spring.KillTeam
+local spSetTeamRulesParam = Spring.SetTeamRulesParam
+local spGetPlayerList = Spring.GetPlayerList
 
-function gadget:RecvLuaMsg(msg, playerID)
+function gadget:RecvLuaMsg (msg, senderID)
 	if msg == "forceresign" then
-		local team = select(4, Spring.GetPlayerInfo(playerID))
-		Spring.KillTeam(team)
-		Spring.SetTeamRulesParam(team, "WasKilled", 1)
+		local team = select(4, spGetPlayerInfo(senderID))
+		spKillTeam(team)
+		spSetTeamRulesParam(team, "WasKilled", 1)
 	end
 end
 
-else
---------------------------------------------------------------------------------
--- unsynced
---------------------------------------------------------------------------------
+function gadget:GotChatMsg (msg, senderID)
+	if (string.find(msg, "resignteam") == 1) then
 
-local function Resign(_, name)
-	local playerID = Spring.GetMyPlayerID()
-	local myName = Spring.GetPlayerInfo(playerID)
-	if name == myName then
-		--Spring.SendCommands('spectator')
-		Spring.SendLuaRulesMsg("forceresign")
+		local allowed = false
+		if (senderID == 255) then -- Springie
+			allowed = true
+		else
+			local playerkeys = select (10, spGetPlayerInfo(senderID))
+			if (playerkeys and playerkeys.admin and (playerkeys.admin == "1")) then
+				allowed = true
+			end
+		end
+		if not allowed then return end
+
+		local target = string.sub(msg, 12)
+		local people = spGetPlayerList()
+		for i = 1, #people do
+			local personID = people[i]
+			local nick, _, _, teamID = spGetPlayerInfo(personID)
+			if (target == nick) then
+				spKillTeam (teamID)
+				spSetTeamRulesParam (teamID, "WasKilled", 1)
+				return
+			end
+		end
 	end
 end
-
-function gadget:Initialize()
-	gadgetHandler:AddChatAction('resignteam', Resign, " resigns the player with the specified name")
-end
-
-end
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------

--- a/LuaRules/gadgets.lua
+++ b/LuaRules/gadgets.lua
@@ -2101,27 +2101,7 @@ function gadgetHandler:RecvFromSynced(...)
 end
 --]]
 
-local limited_commands = {
-	"resignteam",
-}
-
 function gadgetHandler:GotChatMsg(msg, player)
-
-	local elevated = false
-	if player == 255 then
-		elevated = true
-	else
-		local playerkeys = select(10, Spring.GetPlayerInfo(player))
-		if (playerkeys and playerkeys.admin and (playerkeys.admin == "1")) then
-			elevated = true
-		end
-	end
-
-	for i=1, #limited_commands do
-		if (string.find(msg, limited_commands[i]) == 1) and not elevated then
-			return true
-		end
-	end
 
   if (((player == 0) or (player == 255)) and Spring.IsCheatingEnabled()) then	-- ours
   --if ((player == 0) and Spring.IsCheatingEnabled()) then		-- base


### PR DESCRIPTION
* is now handled directly on reception instead of being redirected through unsynced action handler back to synced.
* not being wrapped through AH means sender info is not discarded so the rights check happens on the spot (reverts the GH change)
* not going through unsynced also means voteresign gets enforced immediately (ie. laggers aren't delayed).