### PR TITLE
fix Epicmenu search crash, and some more!

### DIFF
--- a/LuaRules/Gadgets/unit_oremex.lua
+++ b/LuaRules/Gadgets/unit_oremex.lua
@@ -100,7 +100,7 @@ local mapHeight
 local teamIDs
 local UnderAttack = {} -- holds frameID per mex so it goes neutral, if someone attacks it, for 5 seconds, it will not return to owner if no grid connected.
 local Ore = {} -- hold features should they emit harm they will ongameframe
-local OreIncome = GG.oreIncome
+local OreIncome = GG.oreIncome --is set by unit_mex_overdrive.lua every 32th frame
 local gameframe = Spring.GetGameFrame()
 
 local TiberiumProofDefs = {
@@ -218,7 +218,7 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam)
 	end
 end
 
-local TransferLoop = function()
+local TransferLoop = function() --transfer mex to nearest team that deliver energy
 	for unitID, data in pairs(OreMex) do
 		local x = data.x
 		local z = data.z
@@ -302,12 +302,12 @@ function gadget:AllowFeatureBuildStep(builderID, builderTeam, featureID, feature
 	if not(OreDefs[featureDefID]) or not(MinedOre[builderTeam]) or (builderTeam == GaiaTeamID) then
 		return true
 	end
- 	MinedOre[builderTeam] = MinedOre[builderTeam] + (-part/FeatureDefs[featureDefID].metal)
+ 	MinedOre[builderTeam] = MinedOre[builderTeam] + (-part/FeatureDefs[featureDefID].metal) --reclaiming ore
 	return true
 end
 
 function gadget:AllowUnitBuildStep(builderID, builderTeam, step) -- was not documented in spring wiki
-	if (OwnsOreToTeam[builderTeam]) and (MinedOre[builderTeam] >= 10) then -- you own your team some metal, until you repay the amount you can't build, i'm so sorry
+	if (OwnsOreToTeam[builderTeam]) and (MinedOre[builderTeam] >= 10) then -- (halt construction until reclaimed ore is shared with teams,) You owe your team some metal, until you repay the amount you can't build, i'm so sorry
 		return false
 	end
 	return true
@@ -338,7 +338,7 @@ local function AlliesNeedM(teamIDs)
 	return needs
 end
 
-local ShareMinedOre = function()
+local ShareMinedOre = function() --perform communism/resource-sharing and allocation
 	for teamID, allies in pairs(TeamData) do
 		if (MinedOre[teamID] > 1) then
 			MinedOre[teamID] = floor(MinedOre[teamID]) -- keep the change!
@@ -379,10 +379,10 @@ end
 function gadget:GameFrame(f)
 	gameframe = f
 	if ((f%32)==1) then
-		ShareMinedOre()
-		MineMoreOreLoop()
-		InflictOreDamage()
-		TransferLoop()
+		ShareMinedOre() --distribute metal from reclaimed ores to ally
+		MineMoreOreLoop() --spawn a reclaimable ore around mex
+		InflictOreDamage() --damage units walking on the ore, like tiberium
+		TransferLoop() --transfer mex to team which connect energy to it
 	end
 end
 

--- a/LuaUI/Widgets/gui_epicmenu.lua
+++ b/LuaUI/Widgets/gui_epicmenu.lua
@@ -1579,6 +1579,7 @@ local function SearchElement(termToSearch,path)
 						local found = SearchInText(lowercase_name,termToSearch) or SearchInText(lowercase_desc,termToSearch)
 						if found then
 							filtered_pathOptions[#filtered_pathOptions+1] = {currentPath,option}
+							break;
 						end
 					end
 				end

--- a/LuaUI/Widgets/gui_lasso_terraform.lua
+++ b/LuaUI/Widgets/gui_lasso_terraform.lua
@@ -1613,7 +1613,7 @@ function widget:GameFrame(f)
 	
 end
 
-function WG.Terraform_SetPlacingRectangle(unitDefID)
+function Terraform_SetPlacingRectangle(unitDefID)
 	
 	-- Do no terraform with pregame placement.
 	if Spring.GetGameFrame() < 1 then
@@ -1656,6 +1656,10 @@ function WG.Terraform_SetPlacingRectangle(unitDefID)
 	SetFixedRectanglePoints(pos)
 	
 	return true
+end
+
+function widget:Initialize()
+	WG.Terraform_SetPlacingRectangle = Terraform_SetPlacingRectangle --set WG content at initialize rather than during file read to avoid conflict with local copy (for dev/experimentation)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Fix for Epicmenu crash If we search the term "color"... which throw: "multiple control with same name" error. This commit fix the duplicate  https://github.com/ZeroK-RTS/Zero-K/commit/0f233c32324c1a604442897570aaae59529a4ec3 .

Also renamed variable & comment in Overdrive & Oremex gadget to help clarify how mexPayback + oremex option combine to work https://github.com/ZeroK-RTS/Zero-K/commit/375ede365c274da7be45373980073483c8196f1e (for devving)

Finally fix Integral Menu crash if we use local widge for  "gui_lasso_terraform.lua" ( https://github.com/ZeroK-RTS/Zero-K/commit/4b2b54f60bea51c104f55a7bf9f102c83ffb1288 ). Shouldn't add WG item before Initialize()

