### PR TITLE
Revert "fix areashield module"

### DIFF
--- a/gamedata/modularcomms/moduledefs.lua
+++ b/gamedata/modularcomms/moduledefs.lua
@@ -566,7 +566,6 @@ upgrades = {
 	},
 	module_personal_shield = {
 		name = "Personal Shield",
-		order = 1,
 		description = "Generates a small bubble shield",
 		func = function(unitDef)
 				ApplyWeapon(unitDef, "commweapon_personal_shield", 4)
@@ -583,7 +582,6 @@ upgrades = {
 	
 	module_areashield = {
 		name = "Area Shield",
-		order = 2, -- conversion
 		description = "A bubble shield that protects surrounding units within 350 m",
 		func = function(unitDef)
 				--ApplyWeapon(unitDef, "commweapon_areashield", 2)
@@ -727,6 +725,25 @@ upgrades = {
 				ReplaceWeapon(unitDef, "commweapon_beamlaser", "commweapon_hparticlebeam")
 			end,	
 	}
+}
+
+upgrades_dota = {
+	module_personal_cloak = {
+		name = "Stealth System",
+		description = "Makes the commander invisible to radar",
+		func = function(unitDef)
+				unitDef.stealth = true
+			end,
+	},
+	module_cloak_field = upgrades.module_jammer,
+	
+	module_resurrect = {
+		name = "Lazarus Nanolathe",
+		description = "Adds +7.5 metal/s build speed",
+		func = function(unitDef)
+				if unitDef.workertime then unitDef.workertime = unitDef.workertime + 7.5 end
+			end,
+	},
 }
 
 decorations = {
@@ -882,7 +899,15 @@ for name,data in pairs(upgrades) do
 		data.order = order
 	end
 end
-
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+if Spring and Spring.GetModOptions and Spring.GetModOptions().zkmode == "dota" then
+	for name,data in pairs(upgrades_dota) do
+		upgrades[name] = data
+	end
+end
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 local weaponsList = VFS.DirList("gamedata/modularcomms/weapons", "*.lua") or {}
 for i=1,#weaponsList do
 	local name, array = VFS.Include(weaponsList[i])


### PR DESCRIPTION
Reverts ZeroK-RTS/Zero-K#687

got error: 
```
[f=0000000] Loading GameData Definitions
[f=0000000] [gamedata/modularcomms/unitdefgen.lua] Warning: Modular Comms warning: Comm data entry in modoption is empty or in invalid format
[f=0000000] [defs.lua] Error: Failed to load unitDefs
[f=0000000] Error: 2, gamedata/defs.lua, [string "gamedata/defs.lua"]:38: [string "gamedata/defs.lua"]:26: error = 2, gamedata/unitDefs.lua, error = 2, gamedata/unitdefs_post.lua, error = 2, gamedata/modularcomms/unitdefgen.lua, [string "gamedata/modularcomms/moduledefs.lua"]:500: attempt to perform arithmetic on field 'reloadtime' (a nil value)



[f=0000000] Game::LoadDefs (GameData): 241 ms
[f=0000000] Error: [ErrorMessageBox][1] msg="Defs-Parser: [string "gamedata/defs.lua"]:38: [string "gamedata/defs.lua"]:26: error = 2, gamedata/unitDefs.lua, error = 2, gamedata/unitdefs_post.lua, error = 2, gamedata/modularcomms/unitdefgen.lua, [string "gamedata/modularcomms/moduledefs.lua"]:500: attempt to perform arithmetic on field 'reloadtime' (a nil value)
```
have checked with previous version. No such error, only
```
[f=0000000] Loading GameData Definitions
[f=0000000] [gamedata/modularcomms/unitdefgen.lua] Warning: Modular Comms warning: Comm data entry in modoption is empty or in invalid format
```