### PR TITLE
Smart ai for Slasher.

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -213,7 +213,7 @@ local slasherSkirmieeArray = {
 	["corsumo"] = true,
 	["dante"] = true,
 	["armwar"] = true,
-	["hoverassault"] = true,
+
 	["cormak"] = true,
 	["corthud"] = true,
 	["spiderriot"] = true,
@@ -796,11 +796,11 @@ local behaviourConfig = {
 		skirms = slasherSkirmieeArray, 
 		swarms = {}, 
 		flees = {},
-		skirmLeeway = -400, 
-		skirmOrderDis = 700,
+		skirmLeeway = 0, 
+		skirmOrderDis = 300,
 		skirmKeepOrder = true,
-		velocityPrediction = 10,
-		skirmOnlyNearEnemyRange = 80
+		velocityPrediction = 30,
+		skirmOnlyNearEnemyRange = 20
 	},
 	
 	-- arty range skirms


### PR DESCRIPTION
Removed Halberd from list of skirmed units since it's faster than Slasher.
Trying to make Slasher Smart AI less cowardly so you could actually send Slashers on fight command and expect them to advance.