### PR TITLE
Jump improvements

### DIFF
--- a/LuaRules/Gadgets/unit_morph.lua
+++ b/LuaRules/Gadgets/unit_morph.lua
@@ -609,6 +609,9 @@ local function FinishMorph(unitID, morphData)
   local newXp = Spring.GetUnitExperience(unitID)*XpScale 
   --//copy unit speed
   local velX,velY,velZ = Spring.GetUnitVelocity(unitID) --remember speed
+ 
+
+  Spring.SetUnitRulesParam(newUnit, "jumpReload", Spring.GetUnitRulesParam(unitID, "jumpReload") or 1)
   
   --// FIXME: - re-attach to current transport?
   --// update selection
@@ -719,11 +722,13 @@ end
 local function UpdateMorph(unitID, morphData)
   if Spring.GetUnitTransporter(unitID) then return true end
   
-  local allow = GG.CheckMiscPriorityBuildStep(unitID, morphData.teamID, morphData.def.resTable.m) --use unit_priority.lua gadget to handle morph priority.
-  if allow and (Spring.UseUnitResource(unitID, morphData.def.resTable)) then
-    morphData.progress = morphData.progress + morphData.increment
+  if (morphData.progress < 1.0) then
+	  local allow = GG.CheckMiscPriorityBuildStep(unitID, morphData.teamID, morphData.def.resTable.m) --use unit_priority.lua gadget to handle morph priority.
+	  if allow and (Spring.UseUnitResource(unitID, morphData.def.resTable)) then
+		morphData.progress = morphData.progress + morphData.increment
+	  end
   end
-  if (morphData.progress >= 1.0) then
+  if (morphData.progress >= 1.0 and Spring.GetUnitRulesParam(unitID, "is_jumping") ~= 1) then
     FinishMorph(unitID, morphData)
     return false -- remove from the list, all done
   end


### PR DESCRIPTION
- jump cooldown now obeys status effects (previously healthbar did but actual cooldown did not).
- jump cooldown is remembered through morph.
- morph orders are no longer blocked from being queued mid-jump.
- morph will no longer finalize on a mid-jump unit (will instead wait at 100% for it to land). This increases maintainability of the gadget by simplifying logic (removes a lot of workarounds for mid-air replacement) and might increase safety against bugs that stem from weird interaction between morph and jump (as it's usually Recons undergoing morph who are involved).