### PR TITLE
replay_controls.lua: add easy to use fast-forward function to help debug stuff

### DIFF
--- a/LuaUI/Widgets/gui_replay_controls.lua
+++ b/LuaUI/Widgets/gui_replay_controls.lua
@@ -123,6 +123,10 @@ function CreateTheUI(showProgress)
 					if x>progress_speed.x and y>progress_speed.y
 					and x<progress_speed.x2 and  y<progress_speed.y2
 					then
+						progress_speed.color = {0.9,0.15,0.2,0.75}
+						progress_speed:SetValue(progress_speed.max)
+						progress_speed.flash = true
+						
 						label_hoverTime:SetCaption("twice to activate")
 						if spDiffTimers(spGetTimer(),self.lastClick) <0.40 then
 							CreateTheUI(true)
@@ -142,6 +146,10 @@ function CreateTheUI(showProgress)
 						setReplaySpeed (speeds[#speeds], #speeds)
 						fastForwardTo = modf(target*progress_speed.max)
 						label_hoverTime:SetCaption("> >")
+					else
+						snapButton(2)
+						progress_target:SetValue(0)
+						setReplaySpeed (speeds[2],2)
 					end
 				end
 				return 
@@ -153,7 +161,14 @@ function CreateTheUI(showProgress)
 				end
 				
 				if not showProgress then
-					label_hoverTime:SetCaption(" ")
+					if progress_speed.flash then
+						progress_speed.color = {1,1,1,0.0} 
+						progress_speed:SetValue(0)
+						progress_speed.flash = false
+					end
+					if label_hoverTime.caption ~= " " then
+						label_hoverTime:SetCaption(" ")
+					end
 					return
 				end
 
@@ -166,7 +181,9 @@ function CreateTheUI(showProgress)
 					second = 60*second --multiply remainder with 60sec-per-minute to get second back.
 					label_hoverTime:SetCaption(format ("%d:%02d" , minute, second))
 				else
-					label_hoverTime:SetCaption(" ")
+					if label_hoverTime.caption ~= " " then
+						label_hoverTime:SetCaption(" ")
+					end
 				end
 				return 
 			end},
@@ -188,6 +205,9 @@ function CreateTheUI(showProgress)
 			snapButton(i)
 			progress_target:SetValue(0)
 			setReplaySpeed (speeds[i], i)
+			if isPaused then
+				unpause()
+			end
 		end}
 	}
 	end
@@ -248,7 +268,7 @@ function CreateTheUI(showProgress)
 			width   = 280,
 			height	= 20, 
 			max     = 1;
-			color   = {0.75,0.75,0.75,0.25} ;
+			color   = {0.75,0.75,0.75,0.5} ;
 			backgroundColor = {0,0,0,0} ,
 			value = 0,
 		}
@@ -261,9 +281,11 @@ function CreateTheUI(showProgress)
 			width   = 280,
 			height	= 20, 
 			max     = replayLen;
-			caption = window.showProgress and (frame/replayLen .. "%") or " ",
+			caption = window.showProgress and (frame/replayLen*100 .. "%") or " ",
 			color   = window.showProgress and {0.9,0.15,0.2,0.75} or  {1,1,1,0.0} ; --red, --{0.2,0.9,0.3,1}; --green
+			backgroundColor = {0,0,0,0.8} ,
 			value = frame,
+			flash = false,
 		}
 	progress_speed.x2 =  progress_speed.x + progress_speed.width
 	progress_speed.y2 =  progress_speed.y + progress_speed.height

--- a/LuaUI/Widgets/gui_replay_controls.lua
+++ b/LuaUI/Widgets/gui_replay_controls.lua
@@ -4,14 +4,16 @@ function widget:GetInfo()
     desc      = "Graphical buttons for controlling replay speed, " .. 
     "pausing and skipping pregame chatter",
     author    = "knorke",
-    date      = "August 2012",
+    date      = "August 2012", --updated on 5 May 2015
     license   = "stackable",
     layer     = 1, 
     enabled   = true  --  loaded by my horse?
   }
 end
-
+--Speedup
 local widgetName = widget:GetInfo().name
+local modf = math.modf
+local format = string.format
 
 local Chili
 local Button
@@ -29,13 +31,17 @@ local window
 local button_setspeed = {}
 local button_skipPreGame
 local button_startStop
+local progress_speed
+local progress_target
+local label_hoverTime
 
 local speeds = {0.5, 1, 2, 3, 4, 5,10}
 
 local isPaused = false
-local wantedSpeed = nil
+-- local wantedSpeed = nil
 local skipped = false
-local lastSkippedTime = 0
+local fastForwardTo = -1
+local demoStarted = false
 
 function widget:Initialize()
 	if (not Spring.IsReplay()) then
@@ -80,46 +86,94 @@ function widget:Initialize()
 		padding = {0, 0, 0, 0},
 		--itemMargin  = {0, 0, 0, 0},
 		--caption = "replay control"
+		OnMouseDown = {function(self, x, y, mouse) 
+				--clickable bar, reference: "Chili Economy Panel Default"'s Reserve bar
+				if x>progress_target.x
+				and y>progress_target.y
+				and x<progress_target.x + progress_target.width
+				and  y<progress_target.y+ progress_target.height
+				then
+					local target = (x-progress_target.x) / (progress_target.width)
+					progress_target:SetValue(target)
+					snapButton(#speeds)
+					setReplaySpeed (speeds[#speeds], #speeds)
+					fastForwardTo = modf(target*progress_speed.max)
+				end
+				return 
+			end},
+		OnMouseMove = {function(self, x, y, mouse) 
+				--clickable bar, reference: "Chili Economy Panel Default"'s Reserve bar
+				if x>progress_target.x
+				and y>progress_target.y
+				and x<progress_target.x + progress_target.width
+				and  y<progress_target.y+ progress_target.height
+				then
+					local target = (x-progress_target.x) / (progress_target.width)
+					local hoverOver = modf(target*progress_speed.max/30)
+					local minute, second = modf(hoverOver/60)--second divide by 60sec-per-minute, then saperate result from its remainder
+					second = 60*second --multiply remainder with 60sec-per-minute to get second back.
+					label_hoverTime:SetCaption(format ("%d:%02d" , minute, second))
+				else
+					label_hoverTime:SetCaption(" ")
+				end
+				return 
+			end},
 	}
 	
 	for i = 1, #speeds do
 		button_setspeed[i] = Button:New {
 		width = 40,
 		height = 20,
-		y = 30,
+		y = 36,
 		x = 10+(i-1)*40,
 		parent=window;
 		padding = {0, 0, 0,0},
 		margin = {0, 0, 0, 0},
-		backgroundColor = {1, 1, 0, 1},		
+		backgroundColor = (i==2 and {0, 0, 1, 1}) or {1, 1, 0, 1}, -- 1x selected by default
 		caption=speeds[i] .."x",
 		tooltip = "play at " .. speeds[i] .. "x speed";
 		OnClick = {function()
+			snapButton(i)
+			progress_target:SetValue(0)
 			setReplaySpeed (speeds[i], i)
-			button_setspeed.backgroundColor = {0, 0, 1, 1}
-			end}
+		end}
 	}
 	end
 	
-	button_skipPreGame = Button:New {
-		width = 180,
-		height = 20,
-		y = 55,
-		x = 100,
+	if (Spring.GetGameFrame() == 0) then 
+		button_skipPreGame = Button:New {
+			width = 180,
+			height = 20,
+			y = 58,
+			x = 100,
+			parent=window;
+			padding = {0, 0, 0,0},
+			margin = {0, 0, 0, 0},
+			caption="skip pregame chatter",
+			tooltip = "Skip the pregame chat and startposition chosing, directly to the action!";
+			OnClick = {function()
+				skipPreGameChatter ()
+				end}
+		}
+	else 
+		--in case reloading luaui mid demo
+		widgetHandler:RemoveCallIn("AddConsoleMessage")
+		widgetHandler:RemoveCallIn("Update")
+	end
+	
+	label_hoverTime = Label:New {
+		width = 20,
+		height = 15,
+		y = 58,
+		x = 133,
 		parent=window;
-		padding = {0, 0, 0,0},
-		margin = {0, 0, 0, 0},
-		caption="skip pregame chatter",
-		tooltip = "Skip the pregame chat and startposition chosing, directly to the action!";
-		OnClick = {function()
-			skipPreGameChatter ()
-			end}
+		caption=" ",
 	}
 	
 	button_startStop = Button:New {
 		width = 80,
 		height = 20,
-		y = 55,
+		y = 58,
 		x = 10,
 		parent=window;
 		padding = {0, 0, 0,0},
@@ -135,20 +189,41 @@ function widget:Initialize()
 			end}
 	}
 	
-	progress_speed = Progressbar:New{
+	progress_target = Progressbar:New{
 			parent = window,
-			y = 8,
+			y =  8,
 			x		= 10,
 			width   = 280,
-			height	= 20,
-			max     = #speeds;
-			caption = "replay speed";
-			color   = (i == 1 and {0.2,0.9,0.3,1}) or {0.9,0.15,0.2,1};
-			value = 1 +1,
+			height	= 20, 
+			max     = 1;
+			color   = {0.75,0.75,0.75,0.75};
+			value = 0,
+		}
+
+	local replayLen = (Spring.GetReplayLength and Spring.GetReplayLength() or 1)* 30 -- in frame
+	progress_speed = Progressbar:New{
+			parent = window,
+			y =  8,
+			x		= 10,
+			width   = 280,
+			height	= 20, 
+			max     = replayLen;
+			caption = "0%",
+			color   = {0.9,0.15,0.2,0.75}; --red, --{0.2,0.9,0.3,1}; --green
+			value = replayLen,
+			isWorking = (replayLen>30),
+			currSpeed = 2,
 		}
 	
 	screen0:AddChild(window)
 
+end
+
+function snapButton(pushButton)
+	button_setspeed[progress_speed.currSpeed].backgroundColor = {1, 1, 0, 1}
+	button_setspeed[progress_speed.currSpeed]:Invalidate()
+	button_setspeed[pushButton].backgroundColor = {0, 0, 1, 1}
+	button_setspeed[pushButton]:Invalidate()
 end
 
 function pause ()
@@ -157,7 +232,7 @@ function pause ()
 	isPaused = true
 	button_startStop:SetCaption ("play")
 	--window:SetColor ({1,0,0, 1})
-	--window:SetCaption ("trololo")--button stays pressed down and game lags	ANY INVALID CODE MAKES IT LAG, REASON WHY COM MORPH LAGS?	
+	--window:SetCaption ("trololo")--button stays pressed down and game lags	ANY INVALID CODE MAKES IT LAG, REASON WHY COM MORPH LAGS?
 end
 
 function unpause ()
@@ -199,9 +274,10 @@ function setReplaySpeed (speed, i)
 		-- end	
 	end	
 	--Spring.SendCommands ("setmaxpeed " .. speed)
-	progress_speed:SetValue(i)
+	progress_speed.currSpeed = i
 end
 
+local lastSkippedTime = 0
 function widget:Update(dt)
 	-- if (wantedSpeed) then
 	-- 	if (Spring.GetGameSpeed() > wantedSpeed) then
@@ -210,7 +286,7 @@ function widget:Update(dt)
 	-- 		wantedSpeed = nil
 	-- 	end
 	-- end
-	if skipped == true then
+	if skipped and demoStarted then --do not do "skip 1" at or before demoStart because,it Hung Spring/broke the command respectively. 
 		if lastSkippedTime > 1.5 then
 			Spring.SendCommands("skip 1")
 			lastSkippedTime = 0
@@ -221,16 +297,40 @@ function widget:Update(dt)
 end
 
 function widget:GameFrame (f)
+	if (fastForwardTo>0) then
+		if f==fastForwardTo then
+			pause ()
+			progress_target:SetValue(0)
+			fastForwardTo = -1
+		elseif f>fastForwardTo then
+			progress_target:SetValue(0)
+			fastForwardTo = -1
+		end
+	end
 	if (f==1) then
 		window:RemoveChild(button_skipPreGame)
 		skipped = nil
 		lastSkippedTime = nil
+		widgetHandler:RemoveCallIn("AddConsoleMessage")
+		widgetHandler:RemoveCallIn("Update")
+	elseif progress_speed.isWorking and (f%2 ==0)  then
+		progress_speed:SetValue(f)
+		progress_speed:SetCaption(math.modf(f/progress_speed.max*100) .. "%")
+	end
+end
+
+function widget:AddConsoleMessage(msg)
+	if msg.text == "Beginning demo playback" then
+		demoStarted = true
+		widgetHandler:RemoveCallIn("AddConsoleMessage")
 	end
 end
 
 function skipPreGameChatter ()
 	Spring.Echo("Skipping pregame chatter")
-	Spring.SendCommands("skip 1")
+	if (demoStarted) then 
+		Spring.SendCommands("skip 1")
+	end
 	skipped = true
-	window:RemoveChild(button_skipPreGame)
+	-- window:RemoveChild(button_skipPreGame)
 end


### PR DESCRIPTION
Really simple but neat feature, just click at any time to fast forward to, the game will be paused when you got back to it. 
![replay bar update](https://cloud.githubusercontent.com/assets/2525365/7464777/94afa29c-f2f8-11e4-81d0-d808143a275d.jpg)
