### PR TITLE
fixed jump not working on 91.0

### DIFF
--- a/LuaRules/Gadgets/unit_jumpjets.lua
+++ b/LuaRules/Gadgets/unit_jumpjets.lua
@@ -69,6 +69,8 @@ local jumps = {}
 local jumping = {}
 local goalSet = {}
 
+local quiteNew = not Spring.Utilities.IsCurrentVersionNewerThan(95, 0)
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
@@ -85,6 +87,15 @@ local jumpCmdDesc = {
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+
+local function spTestMoveOrderX(unitDefID, x, y, z)
+	if quiteNew then
+		return spTestMoveOrder(unitDefID, x, y, z, 0, 0, 0, true, true, true)
+	else
+		return spTestMoveOrder(unitDefID, x, y, z)
+	end
+end
+
 
 local function GetDist3(a, b)
 	local x, y, z = (a[1] - b[1]), (a[2] - b[2]), (a[3] - b[3])
@@ -352,7 +363,7 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 	end
 	
 	if cmdID == CMD_JUMP and 
-			not spTestMoveOrder(unitDefID, cmdParams[1], cmdParams[2], cmdParams[3], 0, 0, 0, true, true, true) then
+			not spTestMoveOrderX(unitDefID, cmdParams[1], cmdParams[2], cmdParams[3]) then
 		return false
 	end
 	if goalSet[unitID] then

--- a/LuaUI/Widgets/gui_jumpjets.lua
+++ b/LuaUI/Widgets/gui_jumpjets.lua
@@ -21,6 +21,7 @@ function widget:GetInfo()
 end
 
 local reverseCompatibility = (Game.version:find('91.0') == 1) or (Game.version:find('94') and not Game.version:find('94.1.1'))
+local quiteNew = not Spring.Utilities.IsCurrentVersionNewerThan(95, 0)
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -63,6 +64,14 @@ local pink     = {  1, 0.5, 0.5,   1}
 local red      = {  1,   0,   0,   1}
 
 local jumpDefs  = VFS.Include"LuaRules/Configs/jump_defs.lua"
+
+local function spTestMoveOrderX(unitDefID, x, y, z)
+	if quiteNew then
+		return spTestMoveOrder(unitDefID, x, y, z, 0, 0, 0, true, true, true)
+	else
+		return spTestMoveOrder(unitDefID, x, y, z)
+	end
+end
 
 local function ListToSet(t)
   local new = {}
@@ -223,7 +232,7 @@ local function DrawMouseArc(unitID, shift, groundPos, quality)
 	end
 
 	--local canJumpThere = (spTestBuildOrder(unitDefID, groundPos[1], groundPos[2], groundPos[3], 1) ~= 0)
-	local canJumpThere = spTestMoveOrder(unitDefID, groundPos[1], groundPos[2], groundPos[3], 0, 0, 0, true, true, true)
+	local canJumpThere = spTestMoveOrderX(unitDefID, groundPos[1], groundPos[2], groundPos[3])
 	
 	local range = jumpDefs[unitDefID].range
 	if passIf then

--- a/LuaUI/Widgets/gui_jumpjets.lua
+++ b/LuaUI/Widgets/gui_jumpjets.lua
@@ -21,7 +21,6 @@ function widget:GetInfo()
 end
 
 local reverseCompatibility = (Game.version:find('91.0') == 1) or (Game.version:find('94') and not Game.version:find('94.1.1'))
-local quiteNew = not Spring.Utilities.IsCurrentVersionNewerThan(95, 0)
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -66,10 +65,10 @@ local red      = {  1,   0,   0,   1}
 local jumpDefs  = VFS.Include"LuaRules/Configs/jump_defs.lua"
 
 local function spTestMoveOrderX(unitDefID, x, y, z)
-	if quiteNew then
-		return spTestMoveOrder(unitDefID, x, y, z, 0, 0, 0, true, true, true)
-	else
+	if reverseCompatibility then
 		return spTestMoveOrder(unitDefID, x, y, z)
+	else
+		return spTestMoveOrder(unitDefID, x, y, z, 0, 0, 0, true, true, true)		
 	end
 end
 
@@ -232,7 +231,8 @@ local function DrawMouseArc(unitID, shift, groundPos, quality)
 	end
 
 	--local canJumpThere = (spTestBuildOrder(unitDefID, groundPos[1], groundPos[2], groundPos[3], 1) ~= 0)
-	local canJumpThere = spTestMoveOrderX(unitDefID, groundPos[1], groundPos[2], groundPos[3])
+	--local canJumpThere = spTestMoveOrderX(unitDefID, groundPos[1], groundPos[2], groundPos[3])
+	local canJumpThere = spTestMoveOrder(unitDefID, groundPos[1], groundPos[2], groundPos[3], 0, 0, 0, true, true, true)
 	
 	local range = jumpDefs[unitDefID].range
 	if passIf then


### PR DESCRIPTION
Reverted to less number of arguments for spTestMoveOrder for spring version older than 95.0