### PR TITLE
Remaining fire damage for burning units is now readable by widgets

### DIFF
--- a/LuaRules/Gadgets/91_unit_attributes.lua
+++ b/LuaRules/Gadgets/91_unit_attributes.lua
@@ -357,7 +357,7 @@ local function UpdateUnitAttributes(unitID, frame)
 		end
 	end
 	
-	local cloakBlocked = (spGetUnitRulesParam(unitID,"on_fire") == 1) or (disarmed == 1)
+	local cloakBlocked = (spGetUnitRulesParam(unitID,"on_fire") > 0) or (disarmed == 1)
 	if cloakBlocked then
 		changedAtt = true
 		if not unitCannotCloak[unitID] then

--- a/LuaRules/Gadgets/unit_attributes.lua
+++ b/LuaRules/Gadgets/unit_attributes.lua
@@ -405,7 +405,7 @@ function UpdateUnitAttributes(unitID, frame)
 		end
 	end
 
-	local cloakBlocked = (spGetUnitRulesParam(unitID,"on_fire") == 1) or (disarmed == 1)
+	local cloakBlocked = (spGetUnitRulesParam(unitID,"on_fire") > 0) or (disarmed == 1)
 	if cloakBlocked then
 		GG.PokeDecloakUnit(unitID, 1)
 	end

--- a/LuaRules/Gadgets/unit_decloak_damaged.lua
+++ b/LuaRules/Gadgets/unit_decloak_damaged.lua
@@ -103,7 +103,7 @@ function gadget:GameFrame(n)
 	if n%UPDATE_FREQUENCY == 2 then
 		for unitID, frames in pairs(recloakUnit) do
 			if frames <= UPDATE_FREQUENCY then
-				if not ((spGetUnitRulesParam(unitID,"on_fire") == 1) or (spGetUnitRulesParam(unitID,"disarmed") == 1)) then
+				if not ((spGetUnitRulesParam(unitID,"on_fire") > 0) or (spGetUnitRulesParam(unitID,"disarmed") == 1)) then
 					local wantCloakState = spGetUnitRulesParam(unitID, "wantcloak")
 					local areaCloaked = spGetUnitRulesParam(unitID, "areacloaked")
 					spSetUnitRulesParam(unitID, "cannotcloak", 0, alliedTrueTable)

--- a/LuaUI/Widgets/gfx_lups_units_on_fire.lua
+++ b/LuaUI/Widgets/gfx_lups_units_on_fire.lua
@@ -127,7 +127,7 @@ function widget:GameFrame(n)
 		local unitID
 		for i = 1, #units do
 			unitID = units[i]
-			if spGetUnitRulesParam(unitID, "on_fire") == 1 then
+			if spGetUnitRulesParam(unitID, "on_fire") > 0 then
 				burningUnits.count = burningUnits.count + 1
 				burningUnits[burningUnits.count] = unitID
 			end

--- a/LuaUI/Widgets/unit_healthbars.lua
+++ b/LuaUI/Widgets/unit_healthbars.lua
@@ -594,7 +594,7 @@ do
     hp  = (health or 0)/maxHealth
     morph = UnitMorphs[unitID]
   
-    if (drawUnitsOnFire)and(GetUnitRulesParam(unitID,"on_fire")==1) then
+    if (drawUnitsOnFire)and(GetUnitRulesParam(unitID,"on_fire") > 0) then
       onFireUnits[#onFireUnits+1]=unitID
     end
   
@@ -663,7 +663,7 @@ do
     
     morph = UnitMorphs[unitID]
 
-    if (drawUnitsOnFire)and(GetUnitRulesParam(unitID,"on_fire")==1) then
+    if (drawUnitsOnFire)and(GetUnitRulesParam(unitID,"on_fire") > 0) then
       onFireUnits[#onFireUnits+1]=unitID
     end
 


### PR DESCRIPTION
through the 'on_fire' unit rules param (previously this param was boolean whether the unit is burning).

Fire burning DPS is now readable through the 'unitsOnFire' game rules param (previously this param was boolean whether units can catch fire).