### PR TITLE
Further JJ behaviour fix across 91 and 98+

### DIFF
--- a/LuaRules/Gadgets/unit_jumpjets.lua
+++ b/LuaRules/Gadgets/unit_jumpjets.lua
@@ -42,6 +42,7 @@ local spSetUnitBlocking    = Spring.SetUnitBlocking
 local spSetUnitMoveGoal    = Spring.SetUnitMoveGoal
 local spGetGroundHeight    = Spring.GetGroundHeight
 local spTestMoveOrder      = Spring.TestMoveOrder
+local spTestBuildOrder     = Spring.TestBuildOrder
 local spGetGameSeconds     = Spring.GetGameSeconds
 local spGetUnitHeading     = Spring.GetUnitHeading
 local spSetUnitNoDraw      = Spring.SetUnitNoDraw
@@ -69,7 +70,7 @@ local jumps = {}
 local jumping = {}
 local goalSet = {}
 
-local quiteNew = not Spring.Utilities.IsCurrentVersionNewerThan(95, 0)
+local quiteNew = Spring.Utilities.IsCurrentVersionNewerThan(95, 0)
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -92,7 +93,7 @@ local function spTestMoveOrderX(unitDefID, x, y, z)
 	if quiteNew then
 		return spTestMoveOrder(unitDefID, x, y, z, 0, 0, 0, true, true, true)
 	else
-		return spTestMoveOrder(unitDefID, x, y, z)
+		return spTestBuildOrder(unitDefID, x, y, z, 1)
 	end
 end
 

--- a/LuaUI/Widgets/gui_jumpjets.lua
+++ b/LuaUI/Widgets/gui_jumpjets.lua
@@ -47,6 +47,7 @@ local spGetUnitDefID           = Spring.GetUnitDefID
 local spGetUnitPosition        = Spring.GetUnitPosition
 local spTraceScreenRay         = Spring.TraceScreenRay
 local spTestMoveOrder          = Spring.TestMoveOrder
+local spTestBuildOrder         = Spring.TestBuildOrder
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -66,7 +67,7 @@ local jumpDefs  = VFS.Include"LuaRules/Configs/jump_defs.lua"
 
 local function spTestMoveOrderX(unitDefID, x, y, z)
 	if reverseCompatibility then
-		return spTestMoveOrder(unitDefID, x, y, z)
+		return spTestBuildOrder(unitDefID, x, y, z, 1)
 	else
 		return spTestMoveOrder(unitDefID, x, y, z, 0, 0, 0, true, true, true)		
 	end
@@ -232,7 +233,7 @@ local function DrawMouseArc(unitID, shift, groundPos, quality)
 
 	--local canJumpThere = (spTestBuildOrder(unitDefID, groundPos[1], groundPos[2], groundPos[3], 1) ~= 0)
 	--local canJumpThere = spTestMoveOrderX(unitDefID, groundPos[1], groundPos[2], groundPos[3])
-	local canJumpThere = spTestMoveOrder(unitDefID, groundPos[1], groundPos[2], groundPos[3], 0, 0, 0, true, true, true)
+	local canJumpThere = spTestMoveOrderX(unitDefID, groundPos[1], groundPos[2], groundPos[3], 0, 0, 0, true, true, true)
 	
 	local range = jumpDefs[unitDefID].range
 	if passIf then


### PR DESCRIPTION
Fixed few typos, reverted back to original implementation (spTestBuildOrder) to determine if location is "jumpable" on 91.0. 98.x implementation is left as is.