### PR TITLE
Resigns during pause can trigger game-over

### DIFF
--- a/LuaRules/Gadgets/game_over.lua
+++ b/LuaRules/Gadgets/game_over.lua
@@ -194,7 +194,7 @@ local function RevealAllianceUnits(allianceID)
 	end
 end
 
--- purge the alliance!
+-- purge the alliance! for the horde!
 local function DestroyAlliance(allianceID)
 	if not destroyedAlliances[allianceID] then
 		destroyedAlliances[allianceID] = true
@@ -372,6 +372,10 @@ end
 --------------------------------------------------------------------------------
 -- callins
 --------------------------------------------------------------------------------
+
+function gadget:TeamDied (teamID)
+	ProcessLastAlly()
+end
 
 function gadget:UnitFinished(u, ud, team)
 	if (team ~= gaiaTeamID)


### PR DESCRIPTION
Fixes a case where everybody resigns during a pause and there is noone left to unpause for the periodic game-over check to kick in
Related to https://github.com/ZeroK-RTS/Zero-K-Infrastructure/issues/605 (so far there is no way to unpause from LuaRules so this is only a partial fix).