### PR TITLE
Prevent Claymore barrel pong

### DIFF
--- a/scripts/hoverdepthcharge.lua
+++ b/scripts/hoverdepthcharge.lua
@@ -100,7 +100,7 @@ function script.AimFromWeapon(num)
 end
 
 function script.AimWeapon(num)
-	return true
+	return num ~= 3
 end
 
 local function ShotThread()
@@ -123,7 +123,7 @@ local depthchargeWeaponDef = WeaponDefNames["hoverdepthcharge_depthcharge"]
 local RELOAD = math.ceil( depthchargeWeaponDef.reload * Game.gameSpeed )
 
 function ShootDepthcharge()
-	EmitSfx(pads, FIRE_W1)
+	EmitSfx(pads, FIRE_W3)
 	StartThread(ShotThread)
 end
 
@@ -138,7 +138,7 @@ local function FakeWeaponShoot()
 			local reloadFrame = gameFrame + RELOAD / reloadMult
 			spSetUnitWeaponState(unitID, 1, {reloadFrame = reloadFrame} )
 			
-			EmitSfx(pads, FIRE_W1)
+			EmitSfx(pads, FIRE_W3)
 			StartThread(ShotThread)
 			Move(gun, y_axis, -2)
 			Move(gun, y_axis, 2, 2)

--- a/units/hoverdepthcharge.lua
+++ b/units/hoverdepthcharge.lua
@@ -77,6 +77,12 @@ unitDef = {
       onlyTargetCategory = [[LAND SINK TURRET SHIP SWIM FLOAT HOVER]],
     },
 
+    {
+      def                = [[FAKE_DEPTHCHARGE]],
+      badTargetCategory  = [[FIXEDWING]],
+      onlyTargetCategory = [[SWIM FIXEDWING LAND SUB SINK TURRET FLOAT SHIP GUNSHIP HOVER]],
+    },
+
   },
 
   weaponDefs             = {
@@ -125,6 +131,50 @@ unitDef = {
       weaponAcceleration      = 15,
       weaponType              = [[TorpedoLauncher]],
       weaponVelocity          = 280,
+    },
+	
+	FAKE_DEPTHCHARGE = {
+      name                    = [[Fake Depth Charge]],
+      areaOfEffect            = 290,
+      avoidFriendly           = false,
+	  bounceSlip              = 0.4,
+	  bounceRebound           = 0.4,
+      canAttackGround		  = false,	-- it cannot really, this will stop people from being confused.
+      collideFriendly         = false,
+      craterBoost             = 1,
+      craterMult              = 2,
+
+      damage                  = {
+        default = 900.5,
+      },
+
+      edgeEffectiveness       = 0.4,
+      explosionGenerator      = [[custom:TORPEDOHITHUGE]],
+      fixedLauncher           = true,
+      flightTime              = 2,
+	  groundBounce            = true,
+	  heightMod               = 0,
+	  impulseBoost            = 0.4,
+      impulseFactor           = 1,
+      interceptedByShieldType = 1,
+      model                   = [[depthcharge_big.s3o]],
+	  myGravity               = 0.2,
+      noSelfDamage            = false,
+      numbounce               = 4,
+      predictBoost            = 0,
+      range                   = 270,
+      reloadtime              = 8,
+      soundHitDry             = [[explosion/mini_nuke]],
+      soundHitWet             = [[explosion/wet/ex_underwater]],
+      soundStart              = [[weapon/torp_land]],
+      soundStartVolume        = 8,
+      tolerance               = 1000000,
+      tracks                  = false,
+      turnRate                = 0,
+      turret                  = true,
+      waterWeapon             = true,
+      weaponType              = [[Cannon]],
+      weaponVelocity          = 5,
     },
 	
 	FAKEGUN = {


### PR DESCRIPTION
Fixes Claymore barrels manually dropped into water homing back to the original launch point for extended periods of time
Fixes #284