### PR TITLE
Reimplement aircraft regen for ground consistency

### DIFF
--- a/LuaRules/Gadgets/unit_regeneration.lua
+++ b/LuaRules/Gadgets/unit_regeneration.lua
@@ -1,0 +1,57 @@
+if not gadgetHandler:IsSyncedCode() then return end
+
+function gadget:GetInfo() return {
+	name    = "Regeneration",
+	desc    = "Handles idle regeneration for air units",
+	author  = "Sprung",
+	date    = "2015-05-22",
+	license = "PD",
+	layer   = 0,
+	enabled = true,
+} end
+
+local spGetUnitIsStunned  = Spring.GetUnitIsStunned
+local spGetUnitHealth     = Spring.GetUnitHealth
+local spSetUnitHealth     = Spring.SetUnitHealth
+
+local units = {}
+local regenDefs = {}
+
+for id, def in pairs(UnitDefs) do
+	if def.customParams.idle_regen then
+		regenDefs[id] = { def.idleTime, def.customParams.idle_regen / 2 }
+	end
+end
+
+local currentFrame
+function gadget:Initialize ()
+	currentFrame = Spring.GetGameFrame()
+end
+
+function gadget:GameFrame (frame)
+	currentFrame = frame
+	if ((frame % 15) == 7) then
+		for unitID, data in pairs(units) do
+			if (data[1] < frame) and (not spGetUnitIsStunned(unitID)) then
+				local health = spGetUnitHealth(unitID) + data[2]
+				spSetUnitHealth(unitID, health)
+			end
+		end
+	end
+end
+
+function gadget:UnitCreated(unitID, unitDefID)
+	if regenDefs[unitDefID] then
+		units[unitID] = {0, regenDefs[unitDefID][2]}
+	end
+end
+
+function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage)
+	if regenDefs[unitDefID] then
+		units[unitID][1] = currentFrame + regenDefs[unitDefID][1]
+	end
+end
+
+function gadget:UnitDestroyed(unitID)
+	units[unitID] = nil
+end

--- a/LuaUI/Widgets/gui_contextmenu.lua
+++ b/LuaUI/Widgets/gui_contextmenu.lua
@@ -906,14 +906,15 @@ local function printAbilities(ud)
 		cells[#cells+1] = ''
 	end
 
-	if (ud.idleTime < 1800) or (ud.idleAutoHeal > 5) or (ud.autoHeal > 0) or (cp.amph_regen) or (cp.armored_regen) then
+	local idle_autoheal = ud.customParams.idle_regen and tonumber(ud.customParams.idle_regen) or (ud.idleAutoHeal * 2)
+	if (ud.idleTime < 1800) or (idle_autoheal > 5) or (ud.autoHeal > 0) or (cp.amph_regen) or (cp.armored_regen) then
 		cells[#cells+1] = 'Improved regeneration'
 		cells[#cells+1] = ''
-		if ud.idleTime < 1800 or ud.idleAutoHeal > 5 then
+		if ud.idleTime < 1800 or (idle_autoheal > 5) then
 			cells[#cells+1] = ' - Idle regen: '
-			cells[#cells+1] = numformat(ud.idleAutoHeal * 2) .. ' HP/s'
+			cells[#cells+1] = numformat(idle_autoheal) .. ' HP/s'
 			cells[#cells+1] = ' - Time to enable: '
-			cells[#cells+1] = numformat(ud.idleTime / 30) .. 's' -- .. ((ud.wantedHeight > 0) and ' landed' or '')
+			cells[#cells+1] = numformat(ud.idleTime / 30) .. 's'
 		end
 		if ud.autoHeal > 0 then
 			cells[#cells+1] = ' - Combat regen: '

--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -809,6 +809,14 @@ for name, ud in pairs(UnitDefs) do
 	end
 end
 
+-- Fix inconsistent idle regeneration for air units
+for name, ud in pairs(UnitDefs) do
+	if ud.canfly then
+		ud.customparams.idle_regen = ud.idleautoheal
+		ud.idleautoheal = 0
+	end
+end
+
 -- Set defaults for area cloak
 local area_cloak_defaults = VFS.Include("gamedata/unitdef_defaults/area_cloak_defs.lua")
 for name, ud in pairs(UnitDefs) do


### PR DESCRIPTION
Aircraft now follow the same rules as ground units for idle regen (they used to reset their timer on movement previously).
Most important for Banshee who has Glaive-like regen and no longer needs to sit still to use it.