### PR TITLE
Widgets call UnitDestroyed for enemies that die in LoS

### DIFF
--- a/LuaRules/Gadgets/api_widget_events.lua
+++ b/LuaRules/Gadgets/api_widget_events.lua
@@ -1,0 +1,26 @@
+if gadgetHandler:IsSyncedCode() then return end
+
+function gadget:GetInfo() return {
+	name      = "Widget Events",
+	desc      = "Tells widgets about events they can know about",
+	author    = "Sprung",
+	date      = "2015-05-27",
+	license   = "PD",
+	layer     = 0,
+	enabled   = true,
+} end
+
+local spAreTeamsAllied     = Spring.AreTeamsAllied
+local spGetMyAllyTeamID    = Spring.GetMyAllyTeamID
+local spGetMyTeamID        = Spring.GetMyTeamID
+local spGetSpectatingState = Spring.GetSpectatingState
+local spGetUnitLosState    = Spring.GetUnitLosState
+
+function gadget:UnitDestroyed (unitID, unitDefID, unitTeam)
+	if not spAreTeamsAllied(unitTeam, spGetMyTeamID()) then
+		local spec, specFullView = spGetSpectatingState()
+		if ((spec and specFullView) or spGetUnitLosState(unitID, spGetMyAllyTeamID()).los) then
+			Script.LuaUI.UnitDestroyed (unitID, unitDefID, unitTeam)
+		end
+	end
+end

--- a/LuaUI/Widgets/unit_bounty_marketplace_icons.lua
+++ b/LuaUI/Widgets/unit_bounty_marketplace_icons.lua
@@ -107,7 +107,8 @@ end
 
 
 function widget:UnitDestroyed(unitID, unitDefID, unitTeam)
-	
+	if not Spring.IsUnitAllied(unitID) then return end
+
 	for _,iconType in ipairs( iconTypes ) do
 		for _, teamID in ipairs(Spring.GetTeamList()) do
 			WG.icons.SetUnitIcon( unitID, {name=iconType.. teamID, texture=nil} )

--- a/LuaUI/Widgets/unit_central_build_AI.lua
+++ b/LuaUI/Widgets/unit_central_build_AI.lua
@@ -919,6 +919,7 @@ end
 --  Concept borrowed from Dave Rodger (trepan) MetalMakers widget
 
 function widget:UnitDestroyed(unitID, unitDefID, unitTeam)
+	if not Spring.IsUnitAllied(unitID) then return end
 	UnitGoByeBye(unitID,unitDefID)
 end
 

--- a/LuaUI/Widgets/unit_decoration_handler.lua
+++ b/LuaUI/Widgets/unit_decoration_handler.lua
@@ -146,6 +146,7 @@ function widget:UnitCreated( unitID,  unitDefID,  unitTeam)
 end
 
 function widget:UnitDestroyed( unitID,  unitDefID,  unitTeam)
+	if not Spring.IsUnitAllied(unitID) then return end
 	RemovePossibleCommander(unitID,  unitDefID)
 end
 


### PR DESCRIPTION
Similar to what Send Enemy Death was supposed to do, but working and done properly (calls UnitDestroyed directly without any input needed whereas SED required widgets to explicitly subscribe a separate function to the API and employed some weird redirection through synced).

Updated widgets that assumed the contrary not to break.
Updated Attrition Counter widget to use the new detection method, which also enables it not to count as losses units that didn't actually die (eg. morphs or factory cancels).