### PR TITLE
Impulse jump improvement

### DIFF
--- a/LuaRules/Configs/jump_defs.lua
+++ b/LuaRules/Configs/jump_defs.lua
@@ -14,6 +14,9 @@ for id, ud in pairs (UnitDefs) do
 			rotateMidAir = (tonumber(cp.jump_rotate_midair) == 1),
 			cannotJumpMidair = (tonumber(cp.jump_from_midair) == 0),
 			JumpSpreadException = (tonumber(cp.jump_spread_exception) == 1),
+			
+			--exclusive to Impulse jump:
+			impulseTank = tonumber(cp.jump_impulse_tank) ,
 		}
 	end
 end

--- a/LuaRules/Gadgets/unit_impulsejumpjets.lua
+++ b/LuaRules/Gadgets/unit_impulsejumpjets.lua
@@ -314,6 +314,9 @@ local function Jump(unitID, goal, cmdTag, origCmdParams)
 			k = k + 1
 			if not Spring.ValidUnitID(unitID) or Spring.GetUnitIsDead(unitID) then return end
 			if (not jumping[unitID] ) or ( jumping[unitID]=='landed' ) then
+				if (collideTime <= k) then --haven't smash for a while
+					Spring.UnitScript.CallAsUnit(unitID,env.endJump) --sumo smash
+				end
 				break --jump aborted (skip to refreshing reload bar)
 			end
 			
@@ -401,9 +404,6 @@ local function Jump(unitID, goal, cmdTag, origCmdParams)
 		end
 		if tankDesignMode then
 			Spring.Echo(1000-impulseTank)
-		end
-		if impulseTank > 0  or collideTime > k then --successful landing? or collision ending?
-			Spring.UnitScript.CallAsUnit(unitID,env.endJump) --sumo smash
 		end
 		lastJumpPosition[unitID] = origCmdParams
 		jumping[unitID] = nil

--- a/LuaRules/Gadgets/unit_prevent_lab_hax.lua
+++ b/LuaRules/Gadgets/unit_prevent_lab_hax.lua
@@ -37,6 +37,7 @@ local spGetFeaturePosition     = Spring.GetFeaturePosition
 local spSetFeaturePosition     = Spring.SetFeaturePosition
 local spSetFeatureVelocity     = Spring.SetFeatureVelocity
 local spMoveCtrlGetTag         = Spring.MoveCtrl.GetTag
+local spGetUnitRulesParam     = Spring.GetUnitRulesParam
 
 local abs = math.abs
 local min = math.min
@@ -79,7 +80,7 @@ function checkLabs(checkFeatures)
 			local unitDefID = spGetUnitDefID(unitID)
 			local ud = UnitDefs[unitDefID]
 			local movetype = Spring.Utilities.getMovetype(ud)
-			local fly = ud.canFly
+			local fly = ud.canFly or (spGetUnitRulesParam(unitID, 'is_jumping') == 1)
 			local ally = spGetUnitAllyTeam(unitID)
 			local team = spGetUnitTeam(unitID)
 			if not fly and spMoveCtrlGetTag(unitID) == nil then

--- a/LuaRules/gadgets.lua
+++ b/LuaRules/gadgets.lua
@@ -173,6 +173,7 @@ local callInLists = {
 	-- Feature CallIns
 	"FeatureCreated",
 	"FeatureDestroyed",
+	"FeaturePreDamaged",
 
 	-- Projectile CallIns
 	"ProjectileCreated",
@@ -1713,6 +1714,27 @@ function gadgetHandler:FeatureDestroyed(featureID, allyTeam)
   return
 end
 
+function gadgetHandler:FeaturePreDamaged(fID, fDefID,fTeam, 
+                       damage, weaponDefID, projectileID,
+                       attackerID, attackerDefID, attackerTeam)
+  local rDam = damage
+  local rImp = 1.0
+
+  for _,g in ipairs(self.FeaturePreDamagedList) do
+    dam, imp = g:FeaturePreDamaged(fID, fDefID, fTeam,
+                  rDam, weaponDefID,
+                  projectileID, attackerID, attackerDefID,
+                  attackerTeam)
+    if (dam ~= nil) then
+        rDam = dam
+    end
+    if (imp ~= nil) then
+      rImp = math.min(imp, rImp)
+    end
+  end
+
+  return rDam, rImp
+end
 
 --------------------------------------------------------------------------------
 --

--- a/units/armaak.lua
+++ b/units/armaak.lua
@@ -22,6 +22,7 @@ unitDef = {
     jump_speed         = 6,
     jump_reload        = 10,
     jump_from_midair   = 0,
+    jump_impulse_tank = 24, --resist 1/2 Newton
 
     description_bp = [[Robô anti-ar pesado]],
     description_de = [[Flugabwehr Springer]],

--- a/units/corcan.lua
+++ b/units/corcan.lua
@@ -22,6 +22,7 @@ unitDef = {
     jump_speed         = 4,
     jump_reload        = 10,
     jump_from_midair   = 1,
+    jump_impulse_tank = 39, --resist 2 Newton
 
     description_bp = [[Robô de assaulto]],
     description_fr = [[Robot d'Assaut]],

--- a/units/corfast.lua
+++ b/units/corfast.lua
@@ -27,6 +27,7 @@ unitDef = {
     jump_speed         = 6,
     jump_reload        = 10,
     jump_from_midair   = 1,
+    jump_impulse_tank = 31, -- resist 1/2 Newton
 
     description_bp = [[Construtor saltador, produz a 5 m/s]],
     description_es = [[Constructor jumpjet, construye a 5 m/s]],

--- a/units/corpyro.lua
+++ b/units/corpyro.lua
@@ -23,6 +23,7 @@ unitDef = {
     jump_speed         = 6,
     jump_reload        = 10,
     jump_from_midair   = 1,
+    jump_impulse_tank = 29, --resist 1/2 Newton 
 
     description_es = [[Invasor Caminante Jumpjet]],
     description_fr = [[Marcheur Pilleur r Jetpack]],

--- a/units/corsktl.lua
+++ b/units/corsktl.lua
@@ -30,6 +30,7 @@ unitDef = {
     jump_speed       = 5.2,
     jump_reload      = 10,
     jump_from_midair = 0,
+    jump_impulse_tank = 32, --resist 1 Newton
 
     description_bp = [[Bomba rastejante avançada e camuflável]],
     description_fr = [[Bombe Rampante Avancée Camouflable]],

--- a/units/corsumo.lua
+++ b/units/corsumo.lua
@@ -30,6 +30,7 @@ unitDef = {
     jump_reload        = 15,
     jump_from_midair   = 0,
     jump_rotate_midair = 0,
+    jump_impulse_tank = 35, --resist 3 Newton
 
     --description_bp = [[Robô dispersador]],
     description_fr = [[Robot Émeutier]],


### PR DESCRIPTION
Rewrite of impulse jump rule toward broader user interactivity. Allow:
  1) easier skuttle launch. Newton interaction now quantifiable and repeatable (aka: a better ramp).
  2) more damage when sumo squash enemy structure. Collision is detected properly (that trigger explosive anim) & lesser bounce

Minor tweak
  1) add teleport exception to factory_hax gadget
  2) reduce tree bounciness (for skidding unit only) using fall_damage gadget