### PR TITLE
Fix #811: wrong Ctrl+C behaviour.

### DIFF
--- a/LuaUI/Widgets/gui_chili_core_selector.lua
+++ b/LuaUI/Widgets/gui_chili_core_selector.lua
@@ -709,9 +709,15 @@ local function StripNanos()
 end
 ]]--
 
+-- this prevents SelectComm from firing off multiple times per key press.
+local alreadyFired = false
+function widget:KeyPress() alreadyFired = false end
+
 -- comm selection functionality
 local commIndex = 1
 local function SelectComm()
+	if alreadyFired then return end
+	alreadyFired = true
 	if #comms <= 0 then return end	-- no comms, don't bother
 	if commIndex > #comms then commIndex = #comms end
 	local unitID


### PR DESCRIPTION
Actually a workaround because the cause seems to be in engine (it didn't happen in 91). Currently the linked function gets called multiple times per Ctrl+C which can cause some commanders to be always skipped. The workaround prevents it from being called more than once per keypress.