### PR TITLE
Fix inconsistent com morph BP

### DIFF
--- a/LuaRules/Configs/morph_defs.lua
+++ b/LuaRules/Configs/morph_defs.lua
@@ -184,7 +184,7 @@ for id, playerData in pairs(customComms) do
 				--if morphOption then
 					morphOption.into = array[i+1]
 					-- set time
-					morphOption.time = math.floor( (targetDef.metalCost - originDef.metalCost) / (6 * (i+1)) ) or morphOption.time
+					morphOption.time = math.floor( (targetDef.metalCost - originDef.metalCost) / (5 * (i+1)) ) or morphOption.time
 					--morphOption.time = math.floor((targetDef.metalCost - originDef.metalCost)/10) or morphOption.time
 					--morphOption.time = math.floor(15 + i*5) or morphOption.time
 					morphOption.combatMorph = true

--- a/gamedata/modularcomms/unitdefgen.lua
+++ b/gamedata/modularcomms/unitdefgen.lua
@@ -404,7 +404,7 @@ for name, data in pairs(commDefs) do
 
 	-- set morph time
 	if data.customparams.morphto then
-		local morph_time = (commDefs[data.customparams.morphto].buildtime - data.buildtime) / (5 * (data.customparams.level + 1))
+		local morph_time = (commDefs[data.customparams.morphto].buildtime - data.buildtime) / (5 * (data.customparams.level + 2))
 		data.customparams.morphtime = tostring(math.floor(morph_time))
 	end
 end


### PR DESCRIPTION
All comms now:
(targetLevel + 1) * 5
Previously custom comms:
(targetLevel + 1) * 6
Previously trainer comms:
targetLevel * 5