### PR TITLE
Fix division by 0 in dante's script

### DIFF
--- a/scripts/dante.lua
+++ b/scripts/dante.lua
@@ -380,8 +380,6 @@ end
 
 function script.FireWeapon(num)
 	if num == 3 then
-		local speedmult = 1/(Spring.GetUnitRulesParam(unitID,"slowState") or 1)
-		Spring.SetUnitWeaponState(unitID, 1, "reloadFrame", Spring.GetGameFrame() + reloadTime*speedmult)
 		dgunning = true
 		Spring.SetUnitRulesParam(unitID, "selfTurnSpeedChange", 0)
 		GG.UpdateUnitAttributes(unitID)


### PR DESCRIPTION
These lines don't do anything anyway, since everything is overridden by unit_attributes.lua