### PR TITLE
targets set manually using the set target command do not clear when using stop command

### DIFF
--- a/LuaUI/Widgets/cmd_keep_target.lua
+++ b/LuaUI/Widgets/cmd_keep_target.lua
@@ -2,8 +2,8 @@ function widget:GetInfo()
   return {
     name      = "Keep Target",
     desc      = "Simple and slowest usage of target on the move",
-    author    = "Google Frog",
-    date      = "29 Sep 2011",
+    author    = "Google Frog, Klon",
+    date      = "3 Jul 2015",
     license   = "GNU GPL, v2 or later",
     layer     = 0,
     enabled   = true  --  loaded by default?
@@ -13,37 +13,58 @@ end
 local CMD_UNIT_SET_TARGET = 34923
 local CMD_UNIT_CANCEL_TARGET = 34924
 
+local unitsWithWeakTargetLink = {}
+
 local function isValidType(ud)
 	return ud and not (ud.isBomber or ud.isFactory)
 end
 
-function widget:CommandNotify(id, params, options)
-    if id == CMD.SET_WANTED_MAX_SPEED then
-        return false -- FUCK CMD.SET_WANTED_MAX_SPEED
+function widget:CommandNotify(id, params, options)  
+	if id == CMD.SET_WANTED_MAX_SPEED then
+        return false -- FUCK CMD.SET_WANTED_MAX_SPEED what?
     end
-    if id == CMD.MOVE then
-        local units = Spring.GetSelectedUnits()
-        for i = 1, #units do
-            local unitID = units[i]
+	if id == CMD.ATTACK then
+		local units = Spring.GetSelectedUnits()
+		for i = 1, #units do
+			local unitID = units[i]
 			local unitDefID = Spring.GetUnitDefID(unitID)
 			local ud = UnitDefs[unitDefID]
-            if isValidType(ud) and Spring.ValidUnitID(unitID) then
-                local cmd = Spring.GetCommandQueue(unitID, 1)
-                if cmd and #cmd ~= 0 and cmd[1].id == CMD.ATTACK and #cmd[1].params == 1 and not cmd[1].options.internal then
-					Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,cmd[1].params,{})
-                end
-            end
-        end
-    elseif id ~= CMD_UNIT_SET_TARGET and id ~= CMD_UNIT_CANCEL_TARGET then
-        local units = Spring.GetSelectedUnits()
+			if isValidType(ud) and Spring.ValidUnitID(unitID) then
+				if #params == 1 and not options.internal then
+					Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,params,{})
+					unitsWithWeakTargetLink[unitID] = true
+				end
+			end
+		end
+	elseif id == CMD.STOP or id == CMD.FIGHT then
+		local units = Spring.GetSelectedUnits()
         for i = 1, #units do
             local unitID = units[i]
-			local unitDefID = Spring.GetUnitDefID(unitID)
-			local ud = UnitDefs[unitDefID]
-            if isValidType(ud) and Spring.ValidUnitID(unitID) then
-                Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{})
-            end
-        end
-    end
+			if (unitsWithWeakTargetLink[unitID]) then 
+				local unitDefID = Spring.GetUnitDefID(unitID)
+				local ud = UnitDefs[unitDefID]
+				if isValidType(ud) and Spring.ValidUnitID(unitID) then				
+					Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{})
+					unitsWithWeakTargetLink[unitID] = nil
+				end
+			end
+		end
+	elseif id == CMD_UNIT_SET_TARGET or id == CMD_UNIT_CANCEL_TARGET then    
+		local units = Spring.GetSelectedUnits()
+        for i = 1, #units do
+            local unitID = units[i]
+			if (unitsWithWeakTargetLink[unitID]) then 
+				local unitDefID = Spring.GetUnitDefID(unitID)
+				local ud = UnitDefs[unitDefID]
+				if isValidType(ud) and Spring.ValidUnitID(unitID) then					
+					unitsWithWeakTargetLink[unitID] = nil
+				end
+			end
+		end	
+	end	
     return false
+end
+
+function widget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
+	if (unitsWithWeakTargetLink[unitID]) then unitsWithWeakTargetLink[unitID] = nil end
 end


### PR DESCRIPTION
attack commands will now always set a (weak) target, which will be cleared through stop and fight commands. manually set targets will be overriden by attack, but persist in the latter case.

note that this only occurs when attacking units. attacks on ground will be ignored by the widget and thus wont set a target, nor will they remove any existing target (this needs some consideration, units show strange behaviour when they have both a target and an active attack order somewhere else in range).

