### PR TITLE
keep target widget update

### DIFF
--- a/LuaUI/Widgets/cmd_keep_target.lua
+++ b/LuaUI/Widgets/cmd_keep_target.lua
@@ -2,8 +2,8 @@ function widget:GetInfo()
   return {
     name      = "Keep Target",
     desc      = "Simple and slowest usage of target on the move",
-    author    = "Google Frog",
-    date      = "29 Sep 2011",
+    author    = "Google Frog, Klon",
+    date      = "3 Jul 2015",
     license   = "GNU GPL, v2 or later",
     layer     = 0,
     enabled   = true  --  loaded by default?
@@ -13,37 +13,58 @@ end
 local CMD_UNIT_SET_TARGET = 34923
 local CMD_UNIT_CANCEL_TARGET = 34924
 
+local unitsWithWeakTargetLink = {}
+
 local function isValidType(ud)
 	return ud and not (ud.isBomber or ud.isFactory)
 end
 
-function widget:CommandNotify(id, params, options)
-    if id == CMD.SET_WANTED_MAX_SPEED then
-        return false -- FUCK CMD.SET_WANTED_MAX_SPEED
+function widget:CommandNotify(id, params, options)  
+	if id == CMD.SET_WANTED_MAX_SPEED then
+        return false -- FUCK CMD.SET_WANTED_MAX_SPEED what?
     end
-    if id == CMD.MOVE then
-        local units = Spring.GetSelectedUnits()
-        for i = 1, #units do
-            local unitID = units[i]
+	if id == CMD.ATTACK then
+		local units = Spring.GetSelectedUnits()
+		for i = 1, #units do
+			local unitID = units[i]
 			local unitDefID = Spring.GetUnitDefID(unitID)
 			local ud = UnitDefs[unitDefID]
-            if isValidType(ud) and Spring.ValidUnitID(unitID) then
-                local cmd = Spring.GetCommandQueue(unitID, 1)
-                if cmd and #cmd ~= 0 and cmd[1].id == CMD.ATTACK and #cmd[1].params == 1 and not cmd[1].options.internal then
-					Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,cmd[1].params,{})
-                end
-            end
-        end
-    elseif id ~= CMD_UNIT_SET_TARGET and id ~= CMD_UNIT_CANCEL_TARGET then
-        local units = Spring.GetSelectedUnits()
+			if isValidType(ud) and Spring.ValidUnitID(unitID) then
+				if #params == 1 and not options.internal then
+					Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,params,{})
+					unitsWithWeakTargetLink[unitID] = true
+				end
+			end
+		end
+	elseif id == CMD.STOP or id == CMD.FIGHT then
+		local units = Spring.GetSelectedUnits()
         for i = 1, #units do
             local unitID = units[i]
-			local unitDefID = Spring.GetUnitDefID(unitID)
-			local ud = UnitDefs[unitDefID]
-            if isValidType(ud) and Spring.ValidUnitID(unitID) then
-                Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{})
-            end
-        end
-    end
+			if (unitsWithWeakTargetLink[unitID]) then 
+				local unitDefID = Spring.GetUnitDefID(unitID)
+				local ud = UnitDefs[unitDefID]
+				if isValidType(ud) and Spring.ValidUnitID(unitID) then				
+					Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{})
+					unitsWithWeakTargetLink[unitID] = nil
+				end
+			end
+		end
+	elseif id == CMD_UNIT_SET_TARGET or id == CMD_UNIT_CANCEL_TARGET then    
+		local units = Spring.GetSelectedUnits()
+        for i = 1, #units do
+            local unitID = units[i]
+			if (unitsWithWeakTargetLink[unitID]) then 
+				local unitDefID = Spring.GetUnitDefID(unitID)
+				local ud = UnitDefs[unitDefID]
+				if isValidType(ud) and Spring.ValidUnitID(unitID) then					
+					unitsWithWeakTargetLink[unitID] = nil
+				end
+			end
+		end	
+	end	
     return false
+end
+
+function widget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
+	if (unitsWithWeakTargetLink[unitID]) then unitsWithWeakTargetLink[unitID] = nil end
 end

--- a/LuaUI/Widgets/cmd_keep_target.lua
+++ b/LuaUI/Widgets/cmd_keep_target.lua
@@ -10,79 +10,130 @@ function widget:GetInfo()
   }
 end
 
+VFS.Include("LuaRules/Configs/customcmds.h.lua")
+
+-- included CMD.DGUN because of the wonky way some units with dgun behave when dgunning something other than their current target
+-- (most notably dante)
+-- will not override manual target
+
+local AttackCommand = {
+	[CMD.ATTACK] = true,
+	[CMD.DGUN] = true,
+	[CMD.AREA_ATTACK] =true, -- does it need to be here?
+}	
+
+local TargetCancelingCommand = {
+	[CMD.STOP] = true,
+	[CMD.FIGHT] = true,
+	[CMD.GUARD] = true,
+	[CMD.PATROL] = true,
+}
+
+local TargetOverrideCommand = {
+	[CMD_UNIT_SET_TARGET] = true,
+	[CMD_UNIT_CANCEL_TARGET] = true,
+	[CMD_UNIT_SET_TARGET_CIRCLE] = true,
+}
+
+local COMMANDOPTIONS_SHIFT_BIT = 32
+
+--[[
+	0? = "coded"  (int)
+	0 = "internal", -- this does not really make sense. maybe the value got lost somewhere along the way
+	4 = "meta",
+	16 = "right",
+	32 = "shift",
+	64 = "ctrl",
+	128 = "alt",
+]]--
+
+
 
 local unitsWithWeakTargetLink = {}
+local myTeamID
 
-local function isValidType(ud)
-	return ud and not (ud.isBomber or ud.isFactory)
-end
-
-local function isValidUnit(unitID)
-	local unitDefID = Spring.GetUnitDefID(unitID)
-	if unitDefID and Spring.ValidUnitID(unitID) then
+local function isValidUnit(unitID, unitDefID)	
+	if Spring.ValidUnitID(unitID) then
 		local ud = UnitDefs[unitDefID]
 		return ud and not (ud.isBomber or ud.isFactory)
 	end
 	return false
 end
 
-function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
-	
+function widget:initialize()
+	myTeamID = Spring.GetMyTeamID()
 end
 
-function widget:CommandNotify(id, params, options)  	
-	if (options.internal) then return false end
+-- cannot check for internal flag anymore because it seems to be zero in the bitfield, same as no flag at all. doesn't seem to matter tho 
+function widget:UnitCommand(unitID, unitDefID, teamID, id, options, params, tag)	
+	if not teamID == myTeamID then return end -- not sure this is needed?
 	
-	local units = Spring.GetSelectedUnits()
-	for i = 1, #units do
-		local unitID = units[i]			
-		local qq = Spring.GetUnitCommands(unitID)
-		if (#qq>0) then Spring.Echo(qq[1].tag)
-		Spring.Echo()
-	end
-		
-	if id == CMD.ATTACK then
-		local units = Spring.GetSelectedUnits()
-		for i = 1, #units do
-			local unitID = units[i]			
-			if isValidUnit(unitID) then
-				if #params == 1 then					
-					--Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,params,{CMD.OPT_INTERNAL})
-					--Spring.GiveOrderToUnit(UnitID,CMD.INSERT,
-					--	{,CMD_UNIT_SET_TARGET, {CMD.OPT_SHIFT,CMD.OPT_INTERNAL}, params},{unitID})
-					--unitsWithWeakTargetLink[unitID] = true
+	if AttackCommand[id] then
+		if isValidUnit(unitID, unitDefID) then				
+			if #params == 1 then			
+					-- if this is a shift-attack order, only set target if it is the first order in queue
+					-- setting target for an attack further down the line could lead to suicidal unit behaviour 			
+				if math.bit_and(options,COMMANDOPTIONS_SHIFT_BIT) == COMMANDOPTIONS_SHIFT_BIT then 
+					local cmd = Spring.GetUnitCommands(unitID)
+					if not cmd or #cmd<1 then
+						Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,params,{internal=true})
+						unitsWithWeakTargetLink[unitID] = true
+					end
+					
+				else
+					Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,params,{internal=true})
+					unitsWithWeakTargetLink[unitID] = true
 				end
-			end
-		end
-	elseif id == CMD.STOP or id == CMD.FIGHT then
-		local units = Spring.GetSelectedUnits()
-        for i = 1, #units do
-            local unitID = units[i]
-			if (unitsWithWeakTargetLink[unitID]) then 
-				local unitDefID = Spring.GetUnitDefID(unitID)
-				local ud = UnitDefs[unitDefID]
-				if isValidType(ud) and Spring.ValidUnitID(unitID) then				
-					Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{})
-					unitsWithWeakTargetLink[unitID] = nil
-				end
-			end
-		end
-	elseif id == CMD_UNIT_SET_TARGET or id == CMD_UNIT_CANCEL_TARGET then    
-		local units = Spring.GetSelectedUnits()
-        for i = 1, #units do
-            local unitID = units[i]
-			if (unitsWithWeakTargetLink[unitID]) then 
-				local unitDefID = Spring.GetUnitDefID(unitID)
-				local ud = UnitDefs[unitDefID]
-				if isValidType(ud) and Spring.ValidUnitID(unitID) then					
-					unitsWithWeakTargetLink[unitID] = nil
+				
+			elseif unitsWithWeakTargetLink[unitID] then -- if attacking anything other than exactly 1 unit, remove existing auto target
+				if math.bit_and(options,COMMANDOPTIONS_SHIFT_BIT) == COMMANDOPTIONS_SHIFT_BIT then -- unless we are queing it somewhere after an existing attack order
+					local cmdQ = Spring.GetUnitCommands(unitID)
+					local hasAttackOrder = false
+					for cmd, t in ipairs(cmdQ) do
+						if AttackCommand[t.id] and #t.params==1 then hasAttackOrder = true end
+					end
+					if not hasAttackOrder then
+						Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{internal=true})
+						unitsWithWeakTargetLink[unitID] = nil
+					end
+					
+				else					
+					Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{internal=true})
+					unitsWithWeakTargetLink[unitID] = nil				
 				end
 			end
 		end	
+		
+	elseif TargetCancelingCommand[id] then -- shifted stop commands never get here
+		if unitsWithWeakTargetLink[unitID] then 
+			if isValidUnit(unitID, unitDefID) then										
+				if math.bit_and(options,COMMANDOPTIONS_SHIFT_BIT) ~= COMMANDOPTIONS_SHIFT_BIT or id == CMD.STOP then
+					Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{internal=true})
+					unitsWithWeakTargetLink[unitID] = nil						
+				
+				else -- if there is an attack command somewhere down the line we keep its target if we are queueing a fight, guard, patrol after it										
+					local cmdQ = Spring.GetUnitCommands(unitID) 
+					local hasAttackOrder = false
+					for cmd, t in ipairs(cmdQ) do
+						if AttackCommand[t.id] and #t.params==1 then hasAttackOrder = true end
+					end
+					if not hasAttackOrder then
+						Spring.GiveOrderToUnit(unitID,CMD_UNIT_CANCEL_TARGET,params,{internal=true})
+						unitsWithWeakTargetLink[unitID] = nil
+					end	
+				end
+			end
+		end
+		
+	elseif TargetOverrideCommand[id] then
+		if unitsWithWeakTargetLink[unitID] then 
+			if isValidUnit(unitID, unitDefID) then					
+				unitsWithWeakTargetLink[unitID] = nil			
+			end
+		end	
 	end	
-    return false
 end
 
 function widget:UnitDestroyed(unitID, unitDefID, unitTeam, attackerID, attackerDefID, attackerTeam)
-	if (unitsWithWeakTargetLink[unitID]) then unitsWithWeakTargetLink[unitID] = nil end
+	if unitsWithWeakTargetLink[unitID] then unitsWithWeakTargetLink[unitID] = nil end
 end

--- a/LuaUI/Widgets/cmd_keep_target.lua
+++ b/LuaUI/Widgets/cmd_keep_target.lua
@@ -10,8 +10,6 @@ function widget:GetInfo()
   }
 end
 
-local CMD_UNIT_SET_TARGET = 34923
-local CMD_UNIT_CANCEL_TARGET = 34924
 
 local unitsWithWeakTargetLink = {}
 
@@ -19,20 +17,40 @@ local function isValidType(ud)
 	return ud and not (ud.isBomber or ud.isFactory)
 end
 
-function widget:CommandNotify(id, params, options)  
-	if id == CMD.SET_WANTED_MAX_SPEED then
-        return false -- FUCK CMD.SET_WANTED_MAX_SPEED what?
-    end
+local function isValidUnit(unitID)
+	local unitDefID = Spring.GetUnitDefID(unitID)
+	if unitDefID and Spring.ValidUnitID(unitID) then
+		local ud = UnitDefs[unitDefID]
+		return ud and not (ud.isBomber or ud.isFactory)
+	end
+	return false
+end
+
+function widget:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdTag, cmdParams, cmdOpts)
+	
+end
+
+function widget:CommandNotify(id, params, options)  	
+	if (options.internal) then return false end
+	
+	local units = Spring.GetSelectedUnits()
+	for i = 1, #units do
+		local unitID = units[i]			
+		local qq = Spring.GetUnitCommands(unitID)
+		if (#qq>0) then Spring.Echo(qq[1].tag)
+		Spring.Echo()
+	end
+		
 	if id == CMD.ATTACK then
 		local units = Spring.GetSelectedUnits()
 		for i = 1, #units do
-			local unitID = units[i]
-			local unitDefID = Spring.GetUnitDefID(unitID)
-			local ud = UnitDefs[unitDefID]
-			if isValidType(ud) and Spring.ValidUnitID(unitID) then
-				if #params == 1 and not options.internal then
-					Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,params,{})
-					unitsWithWeakTargetLink[unitID] = true
+			local unitID = units[i]			
+			if isValidUnit(unitID) then
+				if #params == 1 then					
+					--Spring.GiveOrderToUnit(unitID,CMD_UNIT_SET_TARGET,params,{CMD.OPT_INTERNAL})
+					--Spring.GiveOrderToUnit(UnitID,CMD.INSERT,
+					--	{,CMD_UNIT_SET_TARGET, {CMD.OPT_SHIFT,CMD.OPT_INTERNAL}, params},{unitID})
+					--unitsWithWeakTargetLink[unitID] = true
 				end
 			end
 		end


### PR DESCRIPTION
- moved the whole thing to UnitCommand() callin. this was necessary for area/line commands to be 
  properly registered, as they dont appear in CommandNotifiy(). this has some side effects:
   - units get adressed directly and need no longer be looked up in the units list
   - it appears to be no longer possible to check for internal commands as the UnitCommand() function receives no usable value for this
   - line orders now correctly clear targets

- added CMD.DGUN and CMD.AREA_ATTACK to commands which set a target, added CMD.PATROL
  and CMD_UNIT_SET_TARGET_CIRCLE to the commands that remove a target. 

- the widget does respect command queues as good as possible, there are some rules on how the shift key and previously queued commands will be taken into account. targets will only be set if the very first command in the queue is an attack command, otherwise shift key will generally preserve targets. 

it would also be possible to insert set/remove commands into the que such that all attack commands would always set an appropriate target when executed, regardless of their position in the queue. this would however require a bit of synched code(possibly in the unit_target_on_the_move gadget) to catch the CommandFallback function, as target commands normally get handled before they enter the queue. (insertion skips that)