### PR TITLE
Startboxes: let AI pick startpos

### DIFF
--- a/LuaRules/Gadgets/start_boxes.lua
+++ b/LuaRules/Gadgets/start_boxes.lua
@@ -94,7 +94,7 @@ end
 
 function gadget:AllowStartPosition(x, y, z, playerID, readyState)
 	if (playerID == 255) then
-		return false -- custom AI, cannot get its teamID so block it (will get the default startpos at the middle of the box)
+		return true -- custom AI, can't know which team it is on so allow it to place anywhere
 	end
 
 	local teamID = select(4, Spring.GetPlayerInfo(playerID))

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -354,7 +354,7 @@ local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartO
 	local x,y,z
 	local startPosition = luaSetStartPositions[teamID]
 	if not startPosition then
-		if (startboxString and not Spring.GetTeamRulesParam(teamID, "valid_startpos")) or (not startboxString and notAtTheStartOfTheGame and (Game.startPosType == 2)) then
+		if (startboxString and not (Spring.GetTeamRulesParam(teamID, "valid_startpos") or isAI)) or (not startboxString and notAtTheStartOfTheGame and (Game.startPosType == 2)) then
 			x,y,z = getMiddleOfStartBox(teamID)
 		else
 			x,y,z = Spring.GetTeamStartPosition(teamID)

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -358,6 +358,19 @@ local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartO
 			x,y,z = getMiddleOfStartBox(teamID)
 		else
 			x,y,z = Spring.GetTeamStartPosition(teamID)
+			
+			-- clamp invalid positions
+			-- AIs can place them -- remove this once AIs are able to be filtered through AllowStartPosition
+			local boxID = Spring.GetTeamRulesParam(teamID, "start_box_id")
+			if boxID then
+				local box = startboxConfig[boxID]
+				local bx = x / Game.mapSizeX
+				local bz = z / Game.mapSizeZ
+				local valid = (bx > box[1]) and (bz > box[2]) and (bx < box[3]) and (bz < box[4])
+				if not valid then
+					x,y,z = getMiddleOfStartBox(teamID)
+				end
+			end
 		end
 	else
 		x,y,z = startPosition.x, startPosition.y, startPosition.z

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -361,7 +361,7 @@ local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartO
 			
 			-- clamp invalid positions
 			-- AIs can place them -- remove this once AIs are able to be filtered through AllowStartPosition
-			local boxID = Spring.GetTeamRulesParam(teamID, "start_box_id")
+			local boxID = isAI and Spring.GetTeamRulesParam(teamID, "start_box_id")
 			if boxID then
 				local box = startboxConfig[boxID]
 				local bx = x / Game.mapSizeX


### PR DESCRIPTION
See #905

External AI can now pick a startpos.
AI that doesn't pick any or tries to pick an invalid one will still get the middle-of-box default.