### PR TITLE
cmd_keep_target: more movement-related orders will preserve target

### DIFF
--- a/LuaUI/Widgets/cmd_keep_target.lua
+++ b/LuaUI/Widgets/cmd_keep_target.lua
@@ -2,7 +2,7 @@ function widget:GetInfo()
   return {
     name      = "Keep Target",
     desc      = "Simple and slowest usage of target on the move",
-    author    = "Google Frog",
+    author    = "Google Frog, Klon",
     date      = "29 Sep 2011",
     license   = "GNU GPL, v2 or later",
     layer     = 0,
@@ -22,13 +22,13 @@ options = {
 		name = "Keep overridden attack target",
 		type = "bool",
 		value = true,
-		desc = "Units with an attack command will still proritize their target after being given a move command.",
+		desc = "Units with an attack command will proritize their target until a canceling command is given.",
 	},
 	removeTarget = {
 		name = "Stop clears target",
 		type = "bool",
 		value = true,
-		desc = "Issuing the commands Stop, Fight, Guard and Attack cancel priority target orders.",
+		desc = "Issuing the commands Stop, Fight, Guard, Patrol and Attack cancel priority target orders.",
 	},
 }
 
@@ -44,31 +44,30 @@ local function isValidUnit(unitID)
 	return false
 end
 
-local TargetKeepingCommand = {
-	[CMD.MOVE] = true,
-	[CMD_JUMP] = true
-}
-
 local TargetCancelingCommand = {
 	[CMD.STOP] = true,
 	[CMD.ATTACK] = true,
+	[CMD.AREA_ATTACK] = true,
 	[CMD.FIGHT] = true,
 	[CMD.GUARD] = true,
+	[CMD.PATROL] = true,
 }
 
 function widget:CommandNotify(id, params, cmdOptions)
-    if options.keepTarget.value and TargetKeepingCommand[id] then
-        local units = Spring.GetSelectedUnits()
-        for i = 1, #units do
-            local unitID = units[i]
-            if isValidUnit(unitID) then
-                local cmd = Spring.GetCommandQueue(unitID, 1)
-                if cmd and #cmd ~= 0 and cmd[1].id == CMD.ATTACK and #cmd[1].params == 1 and not cmd[1].options.internal then
-					Spring.GiveOrderToUnit(unitID, CMD_UNIT_SET_TARGET, cmd[1].params, {internal = true})
-                end
-            end
-        end
-    elseif options.removeTarget.value and TargetCancelingCommand[id] then
+    if TargetCancelingCommand[id] == nil then
+		if options.keepTarget.value then
+			local units = Spring.GetSelectedUnits()
+			for i = 1, #units do
+				local unitID = units[i]
+				if isValidUnit(unitID) then
+					local cmd = Spring.GetCommandQueue(unitID, 1)
+					if cmd and #cmd ~= 0 and cmd[1].id == CMD.ATTACK and #cmd[1].params == 1 and not cmd[1].options.internal then
+						Spring.GiveOrderToUnit(unitID, CMD_UNIT_SET_TARGET, cmd[1].params, {internal = true})
+					end
+				end
+			end		
+		end	
+    elseif options.removeTarget.value then
         local units = Spring.GetSelectedUnits()
         for i = 1, #units do
             local unitID = units[i]


### PR DESCRIPTION
- included repair, reclaim, ressurect, area mex, and transport operations into the preserving category
- included area attacks and patrol commands into the target breaking catagory

some issues remain, see comment in the file. using the gadget instead would fix most of them :)