### PR TITLE
deluxe player list: show number of alive/total players in team summary

### DIFF
--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -1267,7 +1267,7 @@ SetupPlayerNames = function()
 	-- while we're at it, determine whether or not to show the ally team summary lines
 	--
 	if #allyTeamOrderRank == 0 then
-		if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end
+		if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end -- this appears to be broken
 		for i=1,#allyTeamsSorted do  -- for every ally team
 			local allyTeamID = allyTeamsSorted[i]
 			allyTeamOrderRank[allyTeamID] = 0
@@ -1335,6 +1335,11 @@ SetupPlayerNames = function()
 		AddAllAllyTeamSummaries(allyTeamsSorted)
 		row = row + 0.5
 	elseif options.showSummaries.value then
+		if existsVeryBigTeam or numBigTeams > 2 then
+			AddAllAllyTeamSummaries(allyTeamsSorted)
+			row = row + 0.5
+		end
+		--[[
 		if amSpec then
 			if existsVeryBigTeam or numBigTeams > 2 then
 				AddAllAllyTeamSummaries(allyTeamsSorted)
@@ -1346,6 +1351,7 @@ SetupPlayerNames = function()
 				row = row + 0.5
 			end
 		end
+		--]]
 	end
 
 	-- add the player entities

--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -313,7 +313,7 @@ local function CalculateWidths()
 	x_cf			= x_elo + 32
 	x_status		= cf and x_cf + 20 or x_cf
 	x_name			= x_status + 12
-	x_teamsize		= x_icon_clan + 6
+	x_teamsize		= x_icon_clan
 	x_teamsize_dude	= x_icon_rank 
 	x_share			= x_name + name_width
 	x_m_mobiles		= not amSpec and x_share + 12 or x_share

--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -1267,16 +1267,13 @@ SetupPlayerNames = function()
 	-- while we're at it, determine whether or not to show the ally team summary lines
 	--
 	if #allyTeamOrderRank == 0 then
-		--if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end
-		myTeamIsVeryBig = true
+		if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end		
 		for i=1,#allyTeamsSorted do  -- for every ally team
 			local allyTeamID = allyTeamsSorted[i]
 			allyTeamOrderRank[allyTeamID] = 0
 			if allyTeams[allyTeamID] then
-				--if #allyTeams[allyTeamID] > 2 then existsVeryBigTeam = true end
-				--if #allyTeams[allyTeamID] > 1 then numBigTeams = numBigTeams + 1 end
-				existsVeryBigTeam = true
-				numBigTeams = 2
+				if #allyTeams[allyTeamID] > 2 then existsVeryBigTeam = true end
+				if #allyTeams[allyTeamID] > 1 then numBigTeams = numBigTeams + 1 end				
 				for j=1,#allyTeams[allyTeamID] do  -- for every player team on the ally team
 					local teamID = allyTeams[allyTeamID][j]
 					if teams[teamID] and teams[teamID].roster then

--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -279,6 +279,7 @@ local x_cf
 local x_status
 local x_name
 local x_teamsize
+local x_teamsize_dude
 local x_share
 local x_m_mobiles
 local x_m_defense

--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -1,4 +1,4 @@
--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
 function widget:GetInfo()
@@ -313,8 +313,8 @@ local function CalculateWidths()
 	x_cf			= x_elo + 32
 	x_status		= cf and x_cf + 20 or x_cf
 	x_name			= x_status + 12
-	x_teamsize		= x_icon_clan
-	x_teamsize_dude	= x_icon_rank - 6
+	x_teamsize		= x_icon_clan + 6
+	x_teamsize_dude	= x_icon_rank 
 	x_share			= x_name + name_width
 	x_m_mobiles		= not amSpec and x_share + 12 or x_share
 	x_m_mobiles_width = options.stats_width.value * options.text_height.value / 2 + 10
@@ -747,7 +747,7 @@ local function UpdatePlayerInfo()
 		local teamID
 		if entities[i].isAI then
 			teamID = entities[i].teamID
-		else			
+		else
 			local playerID = entities[i].playerID
 			local name,active,spectator,localteamID,allyTeamID,pingTime,cpuUsage = Spring.GetPlayerInfo(playerID)
 			teamID = localteamID
@@ -773,7 +773,7 @@ local function UpdatePlayerInfo()
 				else
 					tstatus = 'X'
 					tstatuscolor = {1,0,0,1}
-				end			
+				end
 			end
 
 			local displayname
@@ -1014,7 +1014,7 @@ end
 
 local function AddAllAllyTeamSummaries(allyTeamsSorted)
 	local allyTeamResources
-	local allyTeamWins	
+	local allyTeamWins
 	local allyTeamsNumActivePlayers = {}
 	for i=1,#allyTeamsSorted do
 		local allyTeamID = allyTeamsSorted[i]
@@ -1022,8 +1022,8 @@ local function AddAllAllyTeamSummaries(allyTeamsSorted)
 			allyTeamsNumActivePlayers[allyTeamID] = 0			
 			for j=1,#allyTeams[allyTeamID] do
 				local teamID = allyTeams[allyTeamID][j]
-				if teamID then					
-					if 	not teams[teamID].isDead and teams[teamID].isPlaying then --and teams[teamID].isActive
+				if teamID then
+					if not teams[teamID].isDead and teams[teamID].isPlaying then --and teams[teamID].isActive
 						allyTeamsNumActivePlayers[allyTeamID] = allyTeamsNumActivePlayers[allyTeamID] + 1
 					end
 					local s = GetPlayerTeamStats(teamID)
@@ -1051,7 +1051,7 @@ local function AddAllAllyTeamSummaries(allyTeamsSorted)
 					allyTeamColor = {Spring.GetTeamColor(allyTeams[allyTeamID][1])}
 				end
 				MakeNewLabel(allyTeamEntities[allyTeamID],"nameLabel",{x=x_name,width=150,caption = ("Team " .. allyTeamID+1),textColor = allyTeamColor,})
-				MakeNewLabel(allyTeamEntities[allyTeamID],"teamsizeLabel", {x=x_teamsize,width=32,caption = (allyTeamsNumActivePlayers[allyTeamID] .. "/" .. #allyTeams[allyTeamID]), textColor = {1,1,1,1}, align = "right"})				
+				MakeNewLabel(allyTeamEntities[allyTeamID],"teamsizeLabel", {x=x_teamsize,width=32,caption = (allyTeamsNumActivePlayers[allyTeamID] .. "/" .. #allyTeams[allyTeamID]), textColor = {.85,.85,.85,1}, align = "right"})
 				DrawPlayerTeamStats(allyTeamEntities[allyTeamID],allyTeamColor,allyTeamResources[allyTeamID])
 				local rstring = "smurf"
 				if elo then 
@@ -1267,13 +1267,13 @@ SetupPlayerNames = function()
 	-- while we're at it, determine whether or not to show the ally team summary lines
 	--
 	if #allyTeamOrderRank == 0 then
-		if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end		
+		if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end
 		for i=1,#allyTeamsSorted do  -- for every ally team
 			local allyTeamID = allyTeamsSorted[i]
 			allyTeamOrderRank[allyTeamID] = 0
 			if allyTeams[allyTeamID] then
 				if #allyTeams[allyTeamID] > 2 then existsVeryBigTeam = true end
-				if #allyTeams[allyTeamID] > 1 then numBigTeams = numBigTeams + 1 end				
+				if #allyTeams[allyTeamID] > 1 then numBigTeams = numBigTeams + 1 end
 				for j=1,#allyTeams[allyTeamID] do  -- for every player team on the ally team
 					local teamID = allyTeams[allyTeamID][j]
 					if teams[teamID] and teams[teamID].roster then

--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -1,11 +1,11 @@
---------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
 function widget:GetInfo()
   return {
-    name      = "Chili Deluxe Player List - Alpha 2.02",
+    name      = "Chili Deluxe Player List - Alpha 2.03",
     desc      = "v0.210 Chili Deluxe Player List, Alpha Release",
-    author    = "CarRepairer, KingRaptor, CrazyEddie",
+    author    = "CarRepairer, KingRaptor, CrazyEddie, Klon",
     date      = "2012-06-30",
     license   = "GNU GPL, v2 or later",
     layer     = 50,
@@ -278,6 +278,7 @@ local x_elo
 local x_cf
 local x_status
 local x_name
+local x_teamsize
 local x_share
 local x_m_mobiles
 local x_m_defense
@@ -311,6 +312,8 @@ local function CalculateWidths()
 	x_cf			= x_elo + 32
 	x_status		= cf and x_cf + 20 or x_cf
 	x_name			= x_status + 12
+	x_teamsize		= x_icon_clan
+	x_teamsize_dude	= x_icon_rank - 6
 	x_share			= x_name + name_width
 	x_m_mobiles		= not amSpec and x_share + 12 or x_share
 	x_m_mobiles_width = options.stats_width.value * options.text_height.value / 2 + 10
@@ -743,7 +746,7 @@ local function UpdatePlayerInfo()
 		local teamID
 		if entities[i].isAI then
 			teamID = entities[i].teamID
-		else
+		else			
 			local playerID = entities[i].playerID
 			local name,active,spectator,localteamID,allyTeamID,pingTime,cpuUsage = Spring.GetPlayerInfo(playerID)
 			teamID = localteamID
@@ -769,7 +772,7 @@ local function UpdatePlayerInfo()
 				else
 					tstatus = 'X'
 					tstatuscolor = {1,0,0,1}
-				end
+				end			
 			end
 
 			local displayname
@@ -1010,13 +1013,18 @@ end
 
 local function AddAllAllyTeamSummaries(allyTeamsSorted)
 	local allyTeamResources
-	local allyTeamWins
+	local allyTeamWins	
+	local allyTeamsNumActivePlayers = {}
 	for i=1,#allyTeamsSorted do
 		local allyTeamID = allyTeamsSorted[i]
 		if allyTeams[allyTeamID] then
+			allyTeamsNumActivePlayers[allyTeamID] = 0			
 			for j=1,#allyTeams[allyTeamID] do
 				local teamID = allyTeams[allyTeamID][j]
-				if teamID then
+				if teamID then					
+					if 	not teams[teamID].isDead and teams[teamID].isPlaying then --and teams[teamID].isActive
+						allyTeamsNumActivePlayers[allyTeamID] = allyTeamsNumActivePlayers[allyTeamID] + 1
+					end
 					local s = GetPlayerTeamStats(teamID)
 					allyTeamResources = allyTeamResources or {}
 					allyTeamResources[allyTeamID] = allyTeamResources[allyTeamID] or { eCurr = 0, eStor = 0, eInco = 0, mCurr = 0, mStor = 0, mInco = 0, mMobs = 0, mDefs = 0 }
@@ -1042,8 +1050,17 @@ local function AddAllAllyTeamSummaries(allyTeamsSorted)
 					allyTeamColor = {Spring.GetTeamColor(allyTeams[allyTeamID][1])}
 				end
 				MakeNewLabel(allyTeamEntities[allyTeamID],"nameLabel",{x=x_name,width=150,caption = ("Team " .. allyTeamID+1),textColor = allyTeamColor,})
+				MakeNewLabel(allyTeamEntities[allyTeamID],"teamsizeLabel", {x=x_teamsize,width=32,caption = (allyTeamsNumActivePlayers[allyTeamID] .. "/" .. #allyTeams[allyTeamID]), textColor = {1,1,1,1}, align = "right"})				
 				DrawPlayerTeamStats(allyTeamEntities[allyTeamID],allyTeamColor,allyTeamResources[allyTeamID])
-				if elo then MakeNewLabel(allyTeamEntities[allyTeamID],"eloLabel",{x=x_elo,caption = elo,textColor = eloCol,}) end
+				local rstring = "smurf"
+				if elo then 
+					MakeNewLabel(allyTeamEntities[allyTeamID],"eloLabel",{x=x_elo,caption = elo,textColor = eloCol,}) 
+					if elo > 1800 then rstring = "napoleon"
+					elseif elo > 1600 then rstring = "soldier"
+					elseif elo > 1400 then rstring = "user"
+					end
+				end
+				MakeNewIcon(allyTeamEntities[allyTeamID],"teamsizeIcon", {x=x_teamsize_dude,file="LuaUI/Images/Ranks/dude_"..rstring..".png",})
 				AddCfCheckbox(allyTeamID)
 				if allyTeamsDead[allyTeamID] then MakeNewLabel(allyTeamEntities[allyTeamID],"statusLabel",{x=x_status,width=16,caption = "X",textColor = {1,0,0,1},}) end
 
@@ -1249,13 +1266,16 @@ SetupPlayerNames = function()
 	-- while we're at it, determine whether or not to show the ally team summary lines
 	--
 	if #allyTeamOrderRank == 0 then
-		if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end
+		--if #allyTeams[localAlliance] > 2 then myTeamIsVeryBig = true end
+		myTeamIsVeryBig = true
 		for i=1,#allyTeamsSorted do  -- for every ally team
 			local allyTeamID = allyTeamsSorted[i]
 			allyTeamOrderRank[allyTeamID] = 0
 			if allyTeams[allyTeamID] then
-				if #allyTeams[allyTeamID] > 2 then existsVeryBigTeam = true end
-				if #allyTeams[allyTeamID] > 1 then numBigTeams = numBigTeams + 1 end
+				--if #allyTeams[allyTeamID] > 2 then existsVeryBigTeam = true end
+				--if #allyTeams[allyTeamID] > 1 then numBigTeams = numBigTeams + 1 end
+				existsVeryBigTeam = true
+				numBigTeams = 2
 				for j=1,#allyTeams[allyTeamID] do  -- for every player team on the ally team
 					local teamID = allyTeams[allyTeamID][j]
 					if teams[teamID] and teams[teamID].roster then


### PR DESCRIPTION
is placed above the clan/rank/flag icons in the team summary row. just like the rest of the summary only shows if teams are sufficiently large and the corresponding config option is selected..

http://imgur.com/qP58H5D