### PR TITLE
Tick more sight distance 160->240

### DIFF
--- a/units/armtick.lua
+++ b/units/armtick.lua
@@ -69,7 +69,7 @@ unitDef = {
 
   },
 
-  sightDistance          = 160,
+  sightDistance          = 240,
   turnRate               = 3000,
   
   featureDefs            = {


### PR DESCRIPTION
I chose 240 sight range because that's what Roach is using.

This is to make using Ticks feel more enjoyable and to slightly buff it without changing AoE, EMP-damage or stun time (which were already adjusted in the past, see http://zero-k.info/Forum/Thread/17630#137427).

Before this change Tick had the lowest sight distance of all units at 160. Roach comes second with 240, then Mason with 255 and Skuttle/Welder with 280.