### PR TITLE
Cleaned up index mistakes in gui_lasso_terraform.lua, added terraTag …

### DIFF
--- a/LuaRules/Gadgets/unit_terraform.lua
+++ b/LuaRules/Gadgets/unit_terraform.lua
@@ -404,7 +404,7 @@ local function setupTerraTag(unitID, terraTag, i, count)
 	end
 end
 
-local function setupTerraunit(unitID, team, x, y, z, terraTag)
+local function setupTerraunit(unitID, team, x, y, z)
 
 	local y = y or CallAsTeam(team, function () return spGetGroundHeight(x,z) end)
 
@@ -811,7 +811,7 @@ local function TerraformRamp(x1, y1, z1, x2, y2, z2, terraform_width, unit, unit
 				rampLevels.data[rampLevels.count].data[rampLevels.data[rampLevels.count].count] = id
 			
 				terraunitX, terraunitZ = getPointInsideMap(terraunitX,terraunitZ)				
-				setupTerraunit(id, team, terraunitX, false, terraunitZ, terraTag)
+				setupTerraunit(id, team, terraunitX, false, terraunitZ)
 				setupTerraTag(id, terraTag, i, n-1)
 			
 				blocks = blocks + 1
@@ -1299,7 +1299,7 @@ local function TerraformWall(terraform_type, mPoint, mPoints, terraformHeight, u
 			
             if id then			
 				terraunitX, terraunitZ = getPointInsideMap(terraunitX,terraunitZ)
-				setupTerraunit(id, team, terraunitX, false, terraunitZ, terraTag)
+				setupTerraunit(id, team, terraunitX, false, terraunitZ)
 				setupTerraTag(id, terraTag, i, n-1)				
 			
 				blocks = blocks + 1
@@ -1864,7 +1864,7 @@ local function TerraformArea(terraform_type, mPoint, mPoints, terraformHeight, u
 				aveZ = aveZ + segment[i].position.z
 				
 				terraunitX, terraunitZ = getPointInsideMap(terraunitX,terraunitZ)
-				setupTerraunit(id, team, terraunitX, false, terraunitZ, terraTag)
+				setupTerraunit(id, team, terraunitX, false, terraunitZ)
 				setupTerraTag(id, terraTag, i, n-1)
 			
 				blocks = blocks + 1

--- a/LuaUI/Widgets/gui_lasso_terraform.lua
+++ b/LuaUI/Widgets/gui_lasso_terraform.lua
@@ -238,6 +238,12 @@ local function completelyStopCommand()
 	terraform_type = 0
 end
 
+local terraTag=-1
+function WG.Terraform_GetNextTag()
+	terraTag=terraTag + 1
+	return terraTag
+end
+
 local function SendCommand()
 	local constructor = spGetSelectedUnits()
 
@@ -259,12 +265,13 @@ local function SendCommand()
 				i = i + 3
 			end
 					
-			i = i + 2
 			for j = 1, #constructor do
 				params[i] = constructor[j]
 				i = i + 1
 			end
 			
+			params[#params + 1] = WG.Terraform_GetNextTag()
+
 			local a,c,m,s = spGetModKeyState()
 			
 			if s then
@@ -293,11 +300,12 @@ local function SendCommand()
 				i = i + 2
 			end
 			
-			i = i + 2
 			for j = 1, #constructor do
 				params[i] = constructor[j]
 				i = i + 1
 			end
+			
+			params[#params + 1] = WG.Terraform_GetNextTag()
 			
 			local a,c,m,s = spGetModKeyState()
 			


### PR DESCRIPTION
…and few supporting attributes. terraTag is an optional terraform action identifier. It could be set and stored on a widget side and then retrieved/compared upon receipt of UnitFinished(of terraunit) or custom callin called TerraformUnitCreated. The use of this attribute (or strictly speaking UnitRulesParam) will allow for better interaction of terraform with follow-up construction events.

The problem with previous terraform implementation was that resulting terraunit didn't give any hint of what kind of work it was. It was not possible to know the shape, the height, the type or the location of the actual terraform construction volume. Now it'll be possible to match work issued through widget with custom unit parameters (UnitRulesParam) set by gadget through use of the shared terraTag value. The proposed implementation adds WG.Terraform_GetNextTag(), that is a simple value autoincrement function. Other widgets might either use it or supply own values.

The use case would be to:
1. obtain terraTag on widget side,
2. send it as a part of CMD_TERRAFORM_INTERNAL parameters,
3. use it as a hash key for storing any relevant information widget author would like to store (e.g. terraform type, height, shape, coordinates, followup construction, etc), 
4. next use either UnitFinished(check fo unitDefID==terraunit) or custom callin called TerraformUnitCreated, read/match terraTag;
5. retrieve info stored in the mentioned hash, do some follow-up action.

The use of terraTag is optional, so it won't break any 3rd party widgets.
Additional attributes "terraTagSegment" and "terraTagSegmentsCount" are set to values >1, if a terraform action, identified by terraTag, requires creation of more than one terraunits. Respectively if a widget author foresees such occasion, they should check if all terraunits have been created, finished, progressed to particular stage, or whatever they would like to check.