### PR TITLE
fix for attrition counter

### DIFF
--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -1,4 +1,4 @@
-local version = 2.13
+local version = 2.131
 function widget:GetInfo()
   return {
     name      = "Attrition Counter",
@@ -289,10 +289,17 @@ end
 
 local deadUnits = {} -- in spec mode UnitDestroyed would sometimes be called twice for the same unit, so we need to prevent it from counting twice
 
-function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, attTeamID)		
+function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, attTeamID)	
 	
-	if deadUnits[unitID] then deadUnits[unitID] = nil; return end	
-	deadUnits[unitID] = true
+	if deadUnits[unitID] and deadUnits[unitID] == unitDefID then
+		deadUnits[unitID] = nil
+		return end
+		-- if its also the same kind of unit, its safe to assume that it is the very same unit
+		-- else it is most likely not the same unit but an old table entry and a re-used unitID. we just keep the entry
+		-- small margin of error remains
+	end
+	
+	deadUnits[unitID] = unitDefID
 	
 	if teamID == gaiaTeam then return end
 		-- might just ignore gaia, it will set up a table for it and track its losses but nothing else will happen?

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -291,12 +291,12 @@ local deadUnits = {} -- in spec mode UnitDestroyed would sometimes be called twi
 
 function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, attTeamID)	
 	
+	-- if its also the same kind of unit, its safe to assume that it is the very same unit
+	-- else it is most likely not the same unit but an old table entry and a re-used unitID. we just keep the entry
+	-- small margin of error remains
 	if deadUnits[unitID] and deadUnits[unitID] == unitDefID then
 		deadUnits[unitID] = nil
-		return end
-		-- if its also the same kind of unit, its safe to assume that it is the very same unit
-		-- else it is most likely not the same unit but an old table entry and a re-used unitID. we just keep the entry
-		-- small margin of error remains
+		return 		
 	end
 	
 	deadUnits[unitID] = unitDefID


### PR DESCRIPTION
made sure re-used unit IDs will be detected (most of the time) and not filitered out.

(last merged commit filters duplicate calls on unitdestroyed by remembering unit IDs, but didnt clear entries.)