### PR TITLE
added UnitDestroyedByTeam() callin

### DIFF
--- a/LuaRules/Gadgets/api_widget_events.lua
+++ b/LuaRules/Gadgets/api_widget_events.lua
@@ -3,7 +3,7 @@ if gadgetHandler:IsSyncedCode() then return end
 function gadget:GetInfo() return {
 	name      = "Widget Events",
 	desc      = "Tells widgets about events they can know about",
-	author    = "Sprung",
+	author    = "Sprung, Klon",
 	date      = "2015-05-27",
 	license   = "PD",
 	layer     = 0,
@@ -11,16 +11,28 @@ function gadget:GetInfo() return {
 } end
 
 local spAreTeamsAllied     = Spring.AreTeamsAllied
-local spGetMyAllyTeamID    = Spring.GetMyAllyTeamID
+-- local spGetMyAllyTeamID    = Spring.GetMyAllyTeamID
 local spGetMyTeamID        = Spring.GetMyTeamID
 local spGetSpectatingState = Spring.GetSpectatingState
 local spGetUnitLosState    = Spring.GetUnitLosState
 
-function gadget:UnitDestroyed (unitID, unitDefID, unitTeam)
-	if not spAreTeamsAllied(unitTeam, spGetMyTeamID()) then
-		local spec, specFullView = spGetSpectatingState()
-		if (not (spec and specFullView) and spGetUnitLosState(unitID, spGetMyAllyTeamID()).los) then
+function gadget:UnitDestroyed (unitID, unitDefID, unitTeam, attUnitID, attUnitDefID, attTeamID)
+	local myTeamID = spGetMyTeamID()	
+	local spec, specFullView = spGetSpectatingState()
+	local isAllyUnit = spAreTeamsAllied(unitTeam, myTeamID)
+	
+	if spec then
+		Script.LuaUI.UnitDestroyedByTeam (unitID, unitDefID, unitTeam, attTeamID)		
+		if not specFullView and not isAllyUnit and spGetUnitLosState(unitID, myTeamID).los then
 			Script.LuaUI.UnitDestroyed (unitID, unitDefID, unitTeam)
 		end
+	else
+		local attackerInLos = attUnitID and spGetUnitLosState(attUnitID, myTeamID).los
+		if isAllyUnit then			
+			Script.LuaUI.UnitDestroyedByTeam (unitID, unitDefID, unitTeam, attackerInLos and attTeamID or nil)
+		elseif spGetUnitLosState(unitID, myTeamID).los then
+				Script.LuaUI.UnitDestroyed (unitID, unitDefID, unitTeam)
+				Script.LuaUI.UnitDestroyedByTeam (unitID, unitDefID, unitTeam, attackerInLos and attTeamID or nil)
+		end		
 	end
 end

--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -164,6 +164,7 @@ local flexCallIns = {
   'UnitFinished',
   'UnitFromFactory',
   'UnitDestroyed',
+  'UnitDestroyedByTeam',
   'UnitExperience',
   'UnitTaken',
   'UnitGiven',
@@ -1962,6 +1963,14 @@ end
 function widgetHandler:UnitDestroyed(unitID, unitDefID, unitTeam)
   for _,w in ipairs(self.UnitDestroyedList) do
     w:UnitDestroyed(unitID, unitDefID, unitTeam)
+  end
+  return
+end
+
+
+function widgetHandler:UnitDestroyedByTeam(unitID, unitDefID, unitTeam, attTeamID)
+  for _,w in ipairs(self.UnitDestroyedByTeamList) do
+    w:UnitDestroyedByTeam(unitID, unitDefID, unitTeam, attTeamID)
   end
   return
 end


### PR DESCRIPTION
reveals teamID of attacker to player(if within los) and to specs(always).
unlike UnitDestroyed(), specs will always receive full information no matter what mode they are in.

i want to add radar support for both this and the original callin. meaning that if an enemy unit that was previously identified
a) dies within radar los, you get information about that kill. 
b) kills one of your units, you get the attacker id

and c) if an unidentified enemy unit dies in radar los, you get informed about that something died, but not what.

a and c however reveal a bit of information that the player doesnt necessarily know: if the unit actually died or just disappeared from the radar for some other reason. 

regarding the widgethandler change, it seems necessary to do that or register the callin in some other way. without this the engine will complain about unlinked callin and not call it at all.
conceivably the whole thing could use some other way of communication if changes to the handler are not wanted.
