### PR TITLE
fix #977: waited cons showing full pull

### DIFF
--- a/LuaRules/Gadgets/unit_priority.lua
+++ b/LuaRules/Gadgets/unit_priority.lua
@@ -248,8 +248,8 @@ function CheckMiscPriorityBuildStep(unitID, teamID, toSpend)
 end
 
 function gadget:AllowUnitBuildStep(builderID, teamID, unitID, unitDefID, step) 
-	if (step<0) then
-		--// Reclaiming isn't prioritized
+	if (step<=0) then
+		--// Reclaiming and null buildpower (waited cons) aren't prioritized
 		return true
 	end
 	


### PR DESCRIPTION
Waited cons still apply BP (to prevent nanoframe decay in BA, for example) in 0 amount which is then fed to AllowUnitBuildStep. The unit still has full nominal BP so unlike eg. disarm it counted fully.