### PR TITLE
buff welder dps by 50%

### DIFF
--- a/units/coracv.lua
+++ b/units/coracv.lua
@@ -107,8 +107,8 @@ unitDef = {
       craterMult              = 0,
 
       damage                  = {
-        default = 10,
-        planes  = 10,
+        default = 15,
+        planes  = 15,
         subs    = 0.5,
       },
 


### PR DESCRIPTION
to make it win vs a single scorcher. 

this may help tank lab a bit to get through the early game without having to rely on panthers or static defenses as much, both of which are expensive and of limited effectivity - and slow down expansion even more.


