### PR TITLE
Ctrl+Repair now does pure repair (no construction)

### DIFF
--- a/LuaUI/Widgets/cmd_commandinsert.lua
+++ b/LuaUI/Widgets/cmd_commandinsert.lua
@@ -6,9 +6,9 @@ function widget:GetInfo()
   return {
     name = "CommandInsert",
     desc = "[v" .. version .. "] Allow you to add command into existing queue. Based on FrontInsert by jK"..
-			"\n• SPACEBAR+SHIFT insert command to arbitrary places in queue."..
-			"\n• SPACEBAR insert command in front of queue."..
-			"\n• CTRL+Reclaim force reclaim your own unit in an area.",
+			"\nâ€¢ SPACEBAR+SHIFT insert command to arbitrary places in queue."..
+			"\nâ€¢ SPACEBAR insert command in front of queue."..
+			"\nâ€¢ CTRL+Reclaim force reclaim your own unit in an area.",
 	author = "dizekat",
     date = "Jan,2008", --16 October 2013
     license = "GNU GPL, v2 or later",
@@ -83,7 +83,7 @@ end
 
 local function ProcessCommand(id, params, options)
   local alt,ctrl,meta,shift = Spring.GetModKeyState() --must use this because "options" table turn into different format when right+click. Similar problem with different trigger see: https://code.google.com/p/zero-k/issues/detail?id=1824 (options in online game coded different than in local game)
-  if (ctrl) and not (meta) and id==CMD.RECLAIM then --Reclaim + CTRL
+  if (ctrl) and not (meta) and (id==CMD.RECLAIM or id==CMD.REPAIR) then --Reclaim + CTRL
 	local opt = 0
 	if options.alt or alt then opt = opt + CMD.OPT_ALT end
 	opt = opt + CMD.OPT_META; --add META. Force-reclaim-own-unit
@@ -97,7 +97,7 @@ local function ProcessCommand(id, params, options)
     local insertfront=false
     if options.alt or alt then opt = opt + CMD.OPT_ALT end
 	if options.ctrl or ctrl then
-		if id~=CMD.RECLAIM then  
+		if (id~=CMD.RECLAIM and id~=CMD.REPAIR) then  
 			opt = opt + CMD.OPT_CTRL --add CTRL like normal
 		else --add CTRL+Reclaim as force-reclaim
 			opt = opt + CMD.OPT_META; --add META. Force-reclaim-own-unit(originally META+Reclaim). Can't change CommandInsert() to other modifier because META is already established (culturally) for CommandInsert()


### PR DESCRIPTION
Will only repair live units. Does not cause construction assist.

Spring supplies this functionality natively through space (ie. META key) but Insert overrides that without providing an alternative.
This patch replaces native Ctrl behaviour with the native META behaviour for repair.
Reclaim is handled by Insert the same way (engine META behaviour is now achieved through Ctrl, engine Ctrl not accessible).
Native behaviour of Ctrl+Repair causes repair not to ignore units currently being reclaimed which I don't think is of much use.
For comparison, native Ctrl+Reclaim was used to reclaim "own" wreckage like Dragon Teeth.