### PR TITLE
Fix attrition

### DIFF
--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -434,7 +434,7 @@ function widget:Initialize()
 		label_self.y = label_self.y+18;
 	end
 	
-	if not allyTeams[myAllyTeam].name:find("\n") then
+	if not allyTeams[enemyAllyTeam].name:find("\n") then
 		label_other.y = label_other.y+18;
 	end
 	

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -11,6 +11,9 @@ function widget:GetInfo()
   }
 end
 
+include("colors.h.lua")
+VFS.Include("LuaRules/Configs/constants.lua")
+
 options_path = 'Settings/HUD Panels/Attrition Counter'
 options_order = {'updateFrequency'}
 options = {
@@ -83,7 +86,7 @@ local teams = {
 	-- 		rate = (allyTeams[other].lostMetal / #allyTeams[other].teamIDs) / lostMetal : <number> -- unused
 	--		friendAllyTeamID = teamID <number>
 	--		enemyAllyTeamID = teamID <number>
-	--		color = {R,G,B,A, asString} <table<number, ..., string>>
+	--		color = {R,G,B,A} <table<number, ..., string>>
 	--		name = playername <string>
 }setmetatable(teams, {__index = function (t, k) rawset(t, k, {lostUnits = 0, lostMetal = h, rate = -1}); return t[k] end})
 
@@ -93,10 +96,11 @@ local allyTeams = {
 	--		lostMetal = <number>
 	-- 		rate = allyTeams[other].lostMetal / lostMetal : <number>
 	--		teamIDs = { <number>  teamID = true, ... }
-	--		color = teams[highestElo].color {R,G,B,A, asString} <table<number, ..., string>>
+	--		color = {R,G,B,A}
 	--		name = allyteam# or playername <string>
 	--		numPlayers = <number>
 	--		highestElo = teamID <number>
+	--      name = <string>
 }setmetatable(allyTeams, {__index = function (t, k) rawset(t, k, {lostUnits = 0, lostMetal = h, rate = -1, numPlayers = 0, teamIDs = {}}); return t[k] end}) -- 
 
 local frame = 0 -- options.updateFrequency.value
@@ -107,8 +111,170 @@ local doUpdate = false
 --------------- local functions
 ------------------------------------------------------------------------------------------------------------------------------------
 
-local function rgbToString(r, g, b) return '\255'..string.char(floor(r*255))..string.char(floor(g*255))..string.char(floor(b*255)) end
+local function rgbToString(c) 
+	if(c) then
+		return '\255'..string.char(floor(c[1]*255))..string.char(floor(c[2]*255))..string.char(floor(c[3]*255))
+	else
+		return rgbToString({1,1,1,1});
+	end
+end
+
 local function cap (x) return math.max(math.min(x,1),0) end
+
+local function GetWinString(name)
+	local winTable = WG.WinCounter_currentWinTable
+	if winTable and winTable[name] and winTable[name].wins then
+		return (winTable[name].wonLastGame and "*" or "") .. winTable[name].wins
+	end
+	return false
+end
+
+local function GetTeamName(teamID)
+	local _,leader,_,isAI,_,allyTeamID = Spring.GetTeamInfo(teamID)
+	if teamID == gaiaTeamID then
+		return "gaia"
+	else
+		local name = "player";
+		if isAI then
+			_,name = Spring.GetAIInfo(teamID)
+		else
+			name,_,_,_,_,_,_,_,_,customKeys = GetPlayerInfo(leader)
+		end
+		return name;
+	end
+end
+
+local function GetOpposingAllyTeams()
+	local teams = Spring.GetTeamList()
+	local gaiaTeamID = Spring.GetGaiaTeamID()
+	
+	-- Finds the teams that contain players or skirmish AIs
+	local activeAllyTeams = {}
+	local activeAllyTeamsCount = 0
+	
+	for i = 1, #teams do
+		local teamID = teams[i]
+		local _,leader,_,isAI,_,allyTeamID = Spring.GetTeamInfo(teamID)
+		if teamID ~= gaiaTeamID then
+		
+			if isAI then
+				-- If the team is an AI team then count it as long as it is not chicken.
+				-- The AI names are collected seperately because they are less important.
+				local _,name = Spring.GetAIInfo(teamID)
+				if not name:find("Chicken:") then
+					if not activeAllyTeams[allyTeamID] then
+						activeAllyTeams[allyTeamID] = {aiNames = {}, players = 0, AIs = 0, teamID = teamID}
+						activeAllyTeamsCount = activeAllyTeamsCount + 1
+					end
+					local data = activeAllyTeams[allyTeamID]
+					data.AIs = data.AIs + 1
+					data.aiNames[data.AIs] = name
+				end
+			else
+				local name,_,_,_,_,_,_,_,_,customKeys = GetPlayerInfo(leader)
+				customKeys = customKeys or {}
+				local clan = customKeys.clan or ""
+				if not activeAllyTeams[allyTeamID] then
+					activeAllyTeams[allyTeamID] = {players = 0, AIs = 0, teamID = teamID}
+					activeAllyTeamsCount = activeAllyTeamsCount + 1
+				end
+				
+				local data = activeAllyTeams[allyTeamID]
+				
+				-- The first player provides some representitive information for the team
+				if not data.playerNames then
+					data.playerNames = {}
+					data.teamID = teamID
+					data.winString = GetWinString(name)
+				end
+				
+				data.players = data.players + 1
+				data.playerNames[data.players] = name
+				
+				-- The team is considered a clan until players from distinct clans are found.
+				if (not data.noClan) and data.clan ~= clan then
+					if data.clan then
+						data.noClan = true
+					else
+						data.clanfull = customKeys.clanfull
+						data.clan = clan
+					end
+				end
+			end
+		end
+	end
+	
+	-- The spectator panel is only supported for games against two teams
+	if activeAllyTeamsCount ~= 2 then
+		return false
+	end
+	
+	-- If all players have the same clan then designation by clan is useless.
+	local clans = {}
+	for allyTeamID, data in pairs(activeAllyTeams) do
+		clans[#clans + 1] = data.clan
+	end
+	
+	if clans[1] == clans[2] then
+		for allyTeamID, data in pairs(activeAllyTeams) do
+			data.noClan = true
+		end
+	end
+	
+	-- Create the final allyTeamData
+	local returnData = {}
+	
+	for allyTeamID, data in pairs(activeAllyTeams) do
+		local name = "noname"
+		local nameSize = 1
+		
+		local teamMembers = data.players + data.AIs
+		
+		if (not data.noClan) and data.clan ~= "" and data.players > 1 then
+			-- All players on a team of at least two have the same clan
+			if data.clanfull and string.len(data.clanfull) < options.clanNameLengthCutoff.value then
+				name = data.clanfull
+			else
+				name = data.clan
+			end
+		else
+			if data.players >= 1 then
+				name = data.playerNames[1]
+			else
+				name = data.aiNames[1]
+			end
+			if teamMembers == 2 or data.players == 2 then
+				nameSize = 0.65
+				if data.players >= 2 then
+					name = name .. "\n" .. data.playerNames[2]
+				else
+					name = name .. "\n" .. data.aiNames[2]
+				end
+			elseif teamMembers > 2 then
+				nameSize = 0.65
+				name = name .. "\n and team"
+			end
+		end
+		
+		name = name or "noname"
+		
+		returnData[#returnData + 1] = {
+			allyTeamID = allyTeamID, -- allyTeamID for the team
+			name = name, -- Large display name of the team
+			nameSize = nameSize, -- Display size factor of the team name.
+			teamID = data.teamID, -- representitive teamID
+			color = {Spring.GetTeamColor(data.teamID)} or {1,1,1,1}, -- color of the teams text (color of first player)
+			playerName = data.playerName, -- representitive player name (for win counter)
+			winString = data.winString or "0", -- Win string from win counter
+		}
+	end
+	
+	if returnData[1].allyTeamID > returnData[2].allyTeamID then
+		returnData[1], returnData[2] = returnData[2], returnData[1]
+	end
+	
+	return returnData
+end
 
 local function UpdateCounters()
 
@@ -147,20 +313,20 @@ end
 
 local function UpdateTooltips()
 	local at = allyTeams[myAllyTeam]			
-	local ttip = at.color.asString..at.name..'\n\n'..'\008'..'Units Lost: \t\t\t'..floor(at.lostUnits)
+	local ttip = rgbToString(at.color)..at.name..'\n\n'..'\008'..'Units Lost: \t\t\t'..floor(at.lostUnits)
 		..'\nMetal Lost: \t\t\t'..floor(at.lostMetal)..'\n\n\nLost Units / Metal by Player:\n\n'
 	for team, _ in pairs (at.teamIDs) do
 		local t = teams[team]
-		ttip = ttip..t.color.asString..(t.name or 'Unnamed Player')..'\008'..':  '..floor(t.lostUnits)..' / '..floor(t.lostMetal).."\n"
+		ttip = ttip..rgbToString(t.color)..(t.name or 'Unnamed Player')..'\008'..':  '..floor(t.lostUnits)..' / '..floor(t.lostMetal).."\n"
 	end
 	label_self.tooltip = ttip
 	
 	at = allyTeams[enemyAllyTeam]			
-	ttip = at.color.asString..at.name..'\n\n'..'\008'..'Units Lost: \t\t\t'..floor(at.lostUnits)
+	ttip = rgbToString(at.color)..at.name..'\n\n'..'\008'..'Units Lost: \t\t\t'..floor(at.lostUnits)
 		..'\nMetal Lost: \t\t\t'..floor(at.lostMetal)..'\n\n\nLost Units / Metal by Player:\n\n'
 	for team, _ in pairs (at.teamIDs) do
 		local t = teams[team]
-		ttip = ttip..t.color.asString..(t.name or 'Unnamed Player')..'\008'..':  '..floor(t.lostUnits)..' / '..floor(t.lostMetal).."\n"
+		ttip = ttip..rgbToString(t.color)..(t.name or 'Unnamed Player')..'\008'..':  '..floor(t.lostUnits)..' / '..floor(t.lostMetal).."\n"
 	end
 	label_other.tooltip = ttip
 end
@@ -202,74 +368,52 @@ function widget:Initialize()
 	
 	font = Chili.Font:New{} -- need this to call GetTextWidth without looking up an instance
 	
-	-- set up all the teams and allyteams and find out gamemode	
-	local playerlist = Spring.GetPlayerList()
-	
 	myAllyTeam = Spring.GetMyAllyTeamID()
 	myTeam = Spring.GetMyTeamID()
 	gaiaTeam = Spring.GetGaiaTeamID()
-	
-	local name, spectator, teamID, allyTeamID, keys, elo
-	local i = 1; 
-	while (i <= #playerlist) do
-		local playerID = playerlist[i]
-		name,_,spectator,teamID,allyTeamID,_,_,_,_,keys = GetPlayerInfo(playerID)
-		elo = keys.elo
-		i = i + 1
-		if not spectator and teamID ~= gaiaTeam then
-			if not enemyAllyTeam then -- need to first find out enemy allyteams' ID before we can fill tables
-				if allyTeamID ~= myAllyTeam then
-					enemyAllyTeam = allyTeamID; i = 1	-- found enemyAllyTeam team, now need to restart loop
-				elseif i == #playerlist then -- most likely chicken game etc
-					Echo("<AttritionCounter>: could not find enemy team, disabling")
-					widgetHandler:RemoveWidget()
-					return
-				end
+
+	local _teams = Spring.GetTeamList()
+	local opposingTeams = GetOpposingAllyTeams();
+
+	if(opposingTeams) then
+		for i,td in pairs(opposingTeams) do
+			allyTeams[td.allyTeamID].color = td.color;
+			allyTeams[td.allyTeamID].name = td.name;
+			allyTeams[td.allyTeamID].numPlayers = td.name;
+			if(myAllyTeam ~= td.allyTeamID) then enemyAllyTeam = td.allyTeamID end
+		end
+		
+		for i, t in pairs(_teams) do
+			local _,leader,_,isAI,_,allyTeamID,_ = Spring.GetTeamInfo(t);
+			local elo = 0;
+			
+			allyTeams[allyTeamID].teamIDs[t] = true;
+			teams[t].name = GetTeamName(t);
+			teams[t].friendlyAllyTeam = allyTeamID;
+			teams[t].enemyAllyTeam = (allyTeamID == myAllyTeam and enemyAllyTeam or myAllyTeam);
+
+			
+			if(isAI) then
+				elo = 1000;
 			else
-				if allyTeamID ~= myAllyTeam and allyTeamID ~= enemyAllyTeam then --ffa
-					Echo("<AttritionCounter>: found more than one enemy team, disabling")
-					widgetHandler:RemoveWidget()
-					return
+				local keys = select(10,GetPlayerInfo(leader));
+				elo = (keys and keys.elo) or 1000;
+			end
+			
+			teams[t].elo = elo;
+			
+			if allyTeams[allyTeamID].highestElo then
+				if elo > teams[allyTeams[allyTeamID].highestElo].elo then 
+					allyTeams[allyTeamID].highestElo = teamID 
 				end
-				teams[teamID].name = name
-				teams[teamID].elo = elo
-				teams[teamID].friendlyAllyTeam = allyTeamID
-				teams[teamID].enemyAllyTeam = (allyTeamID == myAllyTeam and enemyAllyTeam or myAllyTeam)
-				local r,g,b,a = GetTeamColor(teamID)
-				teams[teamID].color = {r, g, b, a, asString = rgbToString(r,g,b)}
-				--Echo (teamID.." - "..name..' ID: '..teamID.." friend: "..teams[teamID].friendlyAllyTeam.." enemyAllyTeam: "..teams[teamID].enemyAllyTeam..' elo: '..elo)				
-				allyTeams[allyTeamID].teamIDs[teamID] = true
-				allyTeams[allyTeamID].numPlayers = allyTeams[allyTeamID].numPlayers + 1
-				if allyTeams[allyTeamID].highestElo then
-					if elo > teams[allyTeams[allyTeamID].highestElo].elo then 
-						allyTeams[allyTeamID].highestElo = teamID 
-					end
-				else 
-					allyTeams[allyTeamID].highestElo = teamID
-				end							
+			else 
+				allyTeams[allyTeamID].highestElo = teamID
 			end
 		end
-	end
-	
-	if allyTeams[myAllyTeam].numPlayers == 1 and allyTeams[enemyAllyTeam].numPlayers == 1 then 	-- 1v1
-		allyTeams[myAllyTeam].name = teams[allyTeams[myAllyTeam].highestElo].name
-		allyTeams[enemyAllyTeam].name = teams[allyTeams[enemyAllyTeam].highestElo].name
-	else																						--teams
-		allyTeams[myAllyTeam].name = spectating and ("Team "..myAllyTeam) or 'Your Team'
-		allyTeams[enemyAllyTeam].name = spectating and ("Team "..enemyAllyTeam) or 'Enemy Team'
-	end
-	
-	allyTeams[myAllyTeam].color = teams[allyTeams[myAllyTeam].highestElo].color
-	allyTeams[enemyAllyTeam].color = teams[allyTeams[enemyAllyTeam].highestElo].color
-	
-	--Echo ("done players, found "..#playerlist..' / '..(#teams + 1)..' players') --< #teams discounts id 0
-	--Echo (myAllyTeam.." - "..enemyAllyTeam)
-	
-	--Echo("Friend team is: "..allyTeams[myAllyTeam].name..'with '..allyTeams[myAllyTeam].numPlayers..' players')
-	--Echo("Enemy team team is: "..allyTeams[enemyAllyTeam].name..'with '..allyTeams[enemyAllyTeam].numPlayers..' players')
-			
-	if spectating then
-		Echo('<Attrition Counter>:Running as Spectator'); -- this doesnt seem to do anything
+	else
+		Echo("<AttritionCounter>: unsupported team configuration (FFA?), disabling");
+		widgetHandler:RemoveWidget()
+		return
 	end
 	
 	CreateWindow()


### PR DESCRIPTION
Rewrites attrition counter team detection wholesale, uses modified specpanel naming scheme with additional top player detection; now works for ai vs player, ai vs ai, player vs player and varying team sizes.

The team description generator function should probably be moved to an utility include. The way i've hacked it should keep it more or less compatible with specpanel aside from storing player subtables rather than only player names.