### PR TITLE
Firewalker "Artillery/Skirmish" -> "Artillery/Riot"

### DIFF
--- a/units/firewalker.lua
+++ b/units/firewalker.lua
@@ -18,10 +18,10 @@ unitDef = {
   corpse                 = [[DEAD]],
 
   customParams           = {
-    description_de = [[Roboter mit Feuerunterst?zung (Artillerie/Skrimish)]],
+    description_de = [[Roboter mit Feuerunterstützung (Artillerie/Riot)]],
     description_pl = [[Robot wsparcia artyleryjskiego]],
     helptext       = [[The Firewalker's medium range mortars immolate a small area, denying use of that terrain for brief periods of time. The bot itself is somewhat clumsy and slow to maneuver.]],
-	helptext_de    = [[Der Firewalker verschießt seine Mörser auf mittlerer Distanz und erzeugt in den betroffenen Arealen eine Unbrauchbarkeit des Geländes f? kurze Zeiträume. Die Einheit selber ist etwas schwerfällig und langsam im Manövrieren.]],
+	helptext_de    = [[Der Firewalker setzt mit seinem Mörser auf mittlerer Distanz Gebiete in Brand und macht sie somit für kurze Zeit unpassierbar. Die Einheit selber ist etwas schwerfällig und langsam im Manövrieren.]],
 	helptext_pl    = [[Firewalker uzywa swoich dzial sredniego zasiegu do podpalania wyznaczonych obszarow, co zadaje obrazenia jednostkom, ktore tam pozostana.]],
   },
 

--- a/units/firewalker.lua
+++ b/units/firewalker.lua
@@ -1,7 +1,7 @@
 unitDef = {
   unitname               = [[firewalker]],
   name                   = [[Firewalker]],
-  description            = [[Fire Support Walker (Artillery/Skirmish)]],
+  description            = [[Fire Support Walker (Artillery/Riot)]],
   acceleration           = 0.12,
   brakeRate              = 0.24,
   buildCostEnergy        = 900,
@@ -21,7 +21,7 @@ unitDef = {
     description_de = [[Roboter mit Feuerunterst?zung (Artillerie/Skrimish)]],
     description_pl = [[Robot wsparcia artyleryjskiego]],
     helptext       = [[The Firewalker's medium range mortars immolate a small area, denying use of that terrain for brief periods of time. The bot itself is somewhat clumsy and slow to maneuver.]],
-	helptext_de    = [[Der Firewalker verschieﬂt seine Mˆrser auf mittlerer Distanz und erzeugt in den betroffenen Arealen eine Unbrauchbarkeit des Gel‰ndes f? kurze Zeitr‰ume. Die Einheit selber ist etwas schwerf‰llig und langsam im Manˆvrieren.]],
+	helptext_de    = [[Der Firewalker verschie√üt seine M√∂rser auf mittlerer Distanz und erzeugt in den betroffenen Arealen eine Unbrauchbarkeit des Gel√§ndes f? kurze Zeitr√§ume. Die Einheit selber ist etwas schwerf√§llig und langsam im Man√∂vrieren.]],
 	helptext_pl    = [[Firewalker uzywa swoich dzial sredniego zasiegu do podpalania wyznaczonych obszarow, co zadaje obrazenia jednostkom, ktore tam pozostana.]],
   },
 


### PR DESCRIPTION
Small adjustment to Firewalker's short description. It's some sort of Artillery/Skirmish/Riot, but I've decided to leave out the "skirmish" part because most artillery can be used as a skirmisher anyway and "Artillery/Skirmish/Riot" sounds silly. Also because Firewalker is (in my limited experience) definitely not a "give a fight command to and forget about it" unit like many skirmishers can be (unless you don't mind Firewalker shooting at your own army/base or not shooting at all because of "Hold fire").

On the other hand, the "Riot" part is very important. Firewalker excels at taking out large groups of cheap units/buildings, that's probably its biggest strength. It not having "Riot" in its description would be a big mistake.