### PR TITLE
Hidden units: don't show unit states

### DIFF
--- a/LuaUI/Widgets/unit_state_icons.lua
+++ b/LuaUI/Widgets/unit_state_icons.lua
@@ -119,6 +119,10 @@ function SetUnitStateIcons(unitID)
 		ud = UnitDefs[ud]
 	end
 	
+	if ud and ud.customParams.completely_hidden then
+		return
+	end
+	
 	if options.showstateonshift.value then
 		if ud then
 			if ud.canAttack or ud.isFactory then

--- a/units/fakeunit.lua
+++ b/units/fakeunit.lua
@@ -17,6 +17,9 @@ unitDef = {
   canPatrol                     = false,
   canstop                       = [[0]],
   category                      = [[SINK]],
+  customparams                  = {
+    completely_hidden = 1,
+  },
   footprintX                    = 1,
   footprintZ                    = 1,
   iconType                      = [[none]],

--- a/units/fakeunit_los.lua
+++ b/units/fakeunit_los.lua
@@ -20,6 +20,7 @@ unitDef = {
   
   customParams          = {
       dontcount = [[1]],
+      completely_hidden = 1, -- for widget-senpai not to notice me
   },
   
   explodeAs             = [[TINY_BUILDINGEX]],


### PR DESCRIPTION
Campaign uses fake units to eg. provide LoS and Unit States would show their unit states.