### PR TITLE
Add an API for maps to define arbitrary startboxes

### DIFF
--- a/LuaRules/Gadgets/ai_CAI.lua
+++ b/LuaRules/Gadgets/ai_CAI.lua
@@ -3849,14 +3849,29 @@ end
 
 local function setAllyteamStartLocations(allyTeam)
 	if Game.startPosType == 2 then -- Apparently this is 'choose ingame'
-		
+
+		local teamList = Spring.GetTeamList(allyTeam)
+		if (not teamList) or (#teamList == 0) then return end
+
+		local at = allyTeamData[allyTeam]
+		local listOfAis = at.listOfAis
+
+		if GG.manualStartposConfig then
+			local boxID = Spring.GetTeamRulesParam(teamList[1], "start_box_id")
+			local boxConfig = GG.manualStartposConfig[boxID]
+			for i = 1, listOfAis.count do
+				local team = listOfAis.data[i]
+				local startpos = boxConfig[i] or boxConfig[1]
+				GG.SetStartLocation (team, startpos[1], startpos[2])
+			end
+			return
+		end
+
 		local x1, z1, x2, z2 = Spring.GetAllyTeamStartBox(allyTeam)
-		
+
 		local startboxString = Spring.GetModOptions().startboxes
 		if startboxString then -- new boxes
 			local startboxConfig = loadstring(startboxString)()
-			local teamList = Spring.GetTeamList(allyTeam)
-			if (not teamList) or (#teamList == 0) then return end
 			local boxID = Spring.GetTeamRulesParam(teamList[1], "start_box_id")
 			local box = boxID and startboxConfig[boxID] or {0,0,1,1}
 			x1 = box[1] * Game.mapSizeX
@@ -3865,12 +3880,9 @@ local function setAllyteamStartLocations(allyTeam)
 			z2 = box[4] * Game.mapSizeZ
 		end
 
-		local at = allyTeamData[allyTeam]
-		local listOfAis = at.listOfAis
-		
 		local width = x2 - x1
 		local height = z2 - z1
-		
+
 		if width > height then
 			local mid = (z1+z2)*0.5
 			local mult = width/(listOfAis.count + 1)

--- a/LuaUI/Widgets/api_startboxes.lua
+++ b/LuaUI/Widgets/api_startboxes.lua
@@ -1,0 +1,36 @@
+function widget:GetInfo() return {
+	name    = "Startbox API",
+	desc    = "Processes and exposes startboxes",
+	author  = "Sprung",
+	layer   = -9001,
+	enabled = true,
+	api     = true,
+	hidden  = true,
+} end
+
+if VFS.FileExists("mission.lua") then return end
+
+local startBoxConfig
+local mapsideBoxes = "mapconfig/map_startboxes.lua"
+
+if VFS.FileExists (mapsideBoxes) then
+	startBoxConfig = VFS.Include (mapsideBoxes)
+else
+	startBoxConfig = { }
+	local startboxString = Spring.GetModOptions().startboxes
+	if startboxString then
+		local springieBoxes = loadstring(startboxString)()
+		for id, box in pairs(springieBoxes) do
+			box[1] = box[1]*Game.mapSizeX
+			box[2] = box[2]*Game.mapSizeZ
+			box[3] = box[3]*Game.mapSizeX
+			box[4] = box[4]*Game.mapSizeZ
+			startBoxConfig[id] = {
+				{box[1], box[2], box[1], box[4], box[3], box[4]}, -- must be counterclockwise
+				{box[1], box[2], box[3], box[4], box[3], box[2]}
+			}
+		end
+	end
+end
+
+WG.startBoxConfig = startBoxConfig


### PR DESCRIPTION
Fully backwards-compatible (ie. maps that don't define their own startboxes see no change).

Maps can include a file which describes the boxes (similar to the mex layout file). Being Lua code these can read the game setup to allow any arbitrary setups based on what the teams are (for example Throne could detect whether the FFA is 7-way or 5-way and expose either the first or the second floor to start on).

The boxes are defined through sets of triangles which allows any arbitrary starting area shapes (including concave and disjoint areas).

The mapper also defines a set of start positions for CAI and lagger purposes. Currently laggers drop in the middle of the box and CAI distributes itself evenly over it. With the new API a set of startpoints is used for that which makes sure laggers and CAI are distributed to sensible places (eg. near mex clusters and not on a cliffside).