### PR TITLE
An implementation of wading wakes.

### DIFF
--- a/scripts/amphaa.lua
+++ b/scripts/amphaa.lua
@@ -37,6 +37,11 @@ local SIG_RESTORE = 8
 local SIG_FLOAT = 16
 local SIG_BOB = 32
 
+SIG_WADE = 64
+WADE_SFX = SFXTYPE_WAKE1
+WADE_PIECE = {rfoot, lfoot}
+include "wade.lua"
+
 --------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------
 -- Swim functions
@@ -291,9 +296,15 @@ end
 
 function script.StartMoving()
 	StartThread(Walk)
+	isMoving = true
+	if inWater then 
+		StartThread(Wade);
+	end
 end
 
 function script.StopMoving()
+	Signal(SIG_WADE)
+	isMoving = false
 	Signal(SIG_START_FLOAT)
 	StartThread(Stopping)
 	GG.Floating_StopMoving(unitID)

--- a/scripts/amphassault.lua
+++ b/scripts/amphassault.lua
@@ -282,10 +282,10 @@ local function Stopping()
 end
 
 function script.StartMoving()
-	isMoving = true
 	StartThread(Walk)
+	isMoving = true
 	if inWater then 
-		StartThread(WADE);
+		StartThread(Wade);
 	end
 end
 

--- a/scripts/amphassault.lua
+++ b/scripts/amphassault.lua
@@ -5,12 +5,18 @@ local rbarrel1, rbarrel2, lbarrel1, lbarrel2, rflare, lflare, mflare = piece('rb
 local rfleg, rffoot, lfleg, lffoot, rbleg, rbfoot, lbleg, lbfoot = piece('rfleg', 'rffoot', 'lfleg', 'lffoot', 'rbleg', 'rbfoot', 'lbleg', 'lbfoot')
 
 local vents = {rffoot, lffoot, rbfoot, lbfoot, piece('ventf1', 'ventf2', 'ventr1', 'ventr2', 'ventr3')}
+local feet = {rffoot, lffoot, rbfoot, lbfoot}
 
 local SIG_WALK = 1
 local SIG_AIM = 2
 local SIG_RESTORE = 4
 local SIG_BOB = 8
 local SIG_FLOAT = 32
+
+SIG_WADE = 64
+WADE_SFX = SFXTYPE_WAKE1
+WADE_PIECE = feet
+include "wade.lua"
 
 --------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------
@@ -276,10 +282,16 @@ local function Stopping()
 end
 
 function script.StartMoving()
+	isMoving = true
 	StartThread(Walk)
+	if inWater then 
+		StartThread(WADE);
+	end
 end
 
 function script.StopMoving()
+	Signal(SIG_WADE)
+	isMoving = false
 	StartThread(Stopping)
 	GG.Floating_StopMoving(unitID)
 end

--- a/scripts/amphtele.lua
+++ b/scripts/amphtele.lua
@@ -17,6 +17,11 @@ local SIG_WALK = 1
 local SIG_DEPLOY = 2
 local SIG_BEACON = 2
 
+SIG_WADE = 4
+WADE_SFX = SFXTYPE_WAKE1
+WADE_PIECE = {rfoot, lfoot}
+include "wade.lua"
+
 --------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------
 -- Create beacon animation and delay
@@ -258,9 +263,15 @@ function script.StartMoving()
 	deployed = false
 	GG.tele_undeployTeleport(unitID)
 	StartThread(Walk)
+	isMoving = true
+	if inWater then 
+		StartThread(Wade);
+	end
 end
 
 function script.StopMoving()
+	Signal(SIG_WADE)
+	isMoving = false
 	Signal(SIG_WALK)
 	StartThread(Stopping)
 end

--- a/scripts/wade.lua
+++ b/scripts/wade.lua
@@ -2,12 +2,11 @@ inWater = false
 isMoving = false
 
 function script.setSFXoccupy (terrainType)
-	Spring.Echo("SetSFXOccupy: "..terrainType);
 	local nowInWater = (terrainType == 2 or terrainType == 1)
 	
 	if nowInWater then
 		if not inWater and isMoving then
-			StartThread(WADE);
+			StartThread(Wade);
 		end
 	else
 		Signal(SIG_WADE)
@@ -15,7 +14,7 @@ function script.setSFXoccupy (terrainType)
 	inWater = nowInWater
 end
 
-function WADE()
+function Wade()
 	local spGetUnitPosition = Spring.GetUnitPosition
 	local maxWadeDepth = -Spring.GetUnitHeight(unitID)
 	

--- a/scripts/wade.lua
+++ b/scripts/wade.lua
@@ -1,0 +1,36 @@
+inWater = false
+isMoving = false
+
+function script.setSFXoccupy (terrainType)
+	Spring.Echo("SetSFXOccupy: "..terrainType);
+	local nowInWater = (terrainType == 2 or terrainType == 1)
+	
+	if nowInWater then
+		if not inWater and isMoving then
+			StartThread(WADE);
+		end
+	else
+		Signal(SIG_WADE)
+	end
+	inWater = nowInWater
+end
+
+function WADE()
+	local spGetUnitPosition = Spring.GetUnitPosition
+	local maxWadeDepth = -Spring.GetUnitHeight(unitID)
+	
+	if not (WADE_PIECE and WADE_PIECE[1]) then 
+		return 
+	end
+	
+	SetSignalMask(SIG_WAKE);
+	
+	while true do
+		local x,y,z = spGetUnitPosition(unitID)
+		if (y > maxWadeDepth) then -- emit wakes only when not completely submerged
+			EmitSfx(WADE_PIECE[math.random(1,#WADE_PIECE)], WADE_SFX)
+		end
+		Sleep(math.random(5,10)*33)
+	end
+end
+

--- a/scripts/wade.lua
+++ b/scripts/wade.lua
@@ -22,7 +22,7 @@ function Wade()
 		return 
 	end
 	
-	SetSignalMask(SIG_WAKE);
+	SetSignalMask(SIG_WADE);
 	
 	while true do
 		local x,y,z = spGetUnitPosition(unitID)


### PR DESCRIPTION
This provides an include function with some ugly globals, which should be easily applicable to most LUS in ZK. 

It uses a poll to determine when unit is between `0` and `-unitHeight` altitude to spawn wake sfx of required kind. The poll is deactivated when unit is above `0` by use of `SetSfxOccupy`. Seeing how no unit currently uses `SetSfxOccupy`, the include takes full control of that callin.

It is applied to Grizzly, Angler, and Djinn here. For some reason, Djinn does not terminate the wake spamming on StopMoving while others do.

The end goal would be to apply this to every non-ship non-hover non-flying mobile unit in ZK.

The questions:
- is the ugliness really worth the performance savings of not running the poll above zero?
- is there a way to reduce ugliness without massive copypasta?
- why does Djinn refuse to terminate wake spam? I've checked the signals, and they match; there's no cross-contamination between individual unitscripts and Djinn script doesn't seem to use any globals that the include relies on.