### PR TITLE
fix ddm getting stuck

### DIFF
--- a/scripts/cordoom.lua
+++ b/scripts/cordoom.lua
@@ -102,7 +102,7 @@ end
 
 function script.QueryWeapon1() return flare1 end
 
-function script.AimFromWeapon1() return cannon end
+function script.AimFromWeapon1() return cannonbase end
 
 function script.AimWeapon1(heading, pitch)
 	if not on then return false end


### PR DESCRIPTION
DDM's aimpoint is on the tip of the barrel, so once inside some allied unit, aim raytraces always collide with its colvol and thus the DDM won't move the barrel away by itself because it thinks friendly fire would happen.

It mostly occurs when there is an adjacent Stinger.