### PR TITLE
DDM: require power for heatray

### DIFF
--- a/scripts/cordoom.lua
+++ b/scripts/cordoom.lua
@@ -142,7 +142,7 @@ function script.AimWeapon2(heading, pitch)
 	Turn(heatray, x_axis, -pitch, 2)
 	WaitForTurn (heatraybase, y_axis)
 	WaitForTurn (heatray, x_axis)
-	return true
+	return (spGetUnitRulesParam(unitID, "lowpower") == 0)
 end
 
 function script.FireWeapon2()


### PR DESCRIPTION
* is quant's (grid reliance is a weakness - disabled heatray allows to capitalize on it eg. by enabling raider usage)
* consistency: unpowered is now always harmless