### PR TITLE
Prevent jumping for orbital dropping units

### DIFF
--- a/LuaRules/Gadgets/mission_orbital_drop.lua
+++ b/LuaRules/Gadgets/mission_orbital_drop.lua
@@ -122,7 +122,9 @@ function GG.DropUnit(unitDefName, x, y, z, facing, teamID,useSetUnitVelocity,tim
 		Spring.MoveCtrl.SetGravity(unitID,0)
 	end
 	units[unitID] = {2,absBrakeHeight+gy,heading,useSetUnitVelocity,speedProfile} --store speed profile index, store braking height , store heading , store speed profile
-	
+
+	Spring.SetUnitRulesParam(unitID, "orbitalDrop", 1, LOS_ACCESS)
+
 	-- prevent units from shooting while falling
 	if GG.UpdateUnitAttributes then
 		Spring.SetUnitRulesParam(unitID, "selfReloadSpeedChange", 0, LOS_ACCESS)
@@ -174,8 +176,9 @@ function gadget:GameFrame(frame)
 		Spring.GiveOrderToUnit(unitID, CMD.WAIT, emptyTable, 0)
 		--Spring.Echo(units[unitID][1]) --see if it match desired timeToGround
 		if GG.UpdateUnitAttributes then
-		      Spring.SetUnitRulesParam(unitID, "selfReloadSpeedChange", 1, LOS_ACCESS)
-		      GG.UpdateUnitAttributes(unitID)
+			Spring.SetUnitRulesParam(unitID, "selfReloadSpeedChange", 1, LOS_ACCESS)
+			Spring.SetUnitRulesParam(unitID, "orbitalDrop", 0, LOS_ACCESS)
+			GG.UpdateUnitAttributes(unitID)
 		end
 		units[unitID]= nil --remove from watchlist
       elseif y < brakeAltitude+10  then

--- a/LuaRules/Gadgets/unit_jumpjets.lua
+++ b/LuaRules/Gadgets/unit_jumpjets.lua
@@ -525,6 +525,10 @@ function gadget:CommandFallback(unitID, unitDefID, teamID, cmdID, cmdParams, cmd
 		return true, true
 	end
 
+	if ((Spring.GetUnitRulesParam(unitID, "orbitalDrop") or 0) == 1) then
+		return true, false
+	end
+
 	if (jumping[unitID]) then
 		return true, false -- command was used but don't remove it (unit is still jumping)
 	end


### PR DESCRIPTION
Jump and orbital drop conflict each other.
Mostly affects Recon comms picked late in multiplayer, but some campaign missions drop jumpies too.