### PR TITLE
Add Emit Height to Field Radar Module

### DIFF
--- a/gamedata/modularcomms/moduledefs.lua
+++ b/gamedata/modularcomms/moduledefs.lua
@@ -527,6 +527,7 @@ upgrades = {
 		func = function(unitDef)
 				unitDef.radardistance = (unitDef.radardistance or 0)
 				if unitDef.radardistance < 1800 then unitDef.radardistance = 1800 end
+				if unitDef.radaremitheight < 100 then unitDef.radaremitheight = 100 end
 			end,
 	},
 	module_heavy_armor = {


### PR DESCRIPTION
By default, the emit height of a radar is 20. 20 causes bad radar coverage -- a single little hill (even 3 (!) elmos high!) will cause blockage.

This, hopefully, sets the emit height of Field Radar to 100, the same as a basic radar.