### PR TITLE
Improved Outline and Xray Shader when refracted

### DIFF
--- a/LuaUI/Widgets/gfx_xray_shader.lua
+++ b/LuaUI/Widgets/gfx_xray_shader.lua
@@ -244,7 +244,7 @@ end
               
 function widget:DrawWorldRefraction()
   local oldZMin, oldZMax = zMin, zMax
-  zMin, zMax = zMin/3, zMax/3
+  zMin, zMax = zMin/1.2, zMax/1.2
   DrawWorldFunc()
   zMin, zMax = oldZMin, oldZMax 
 end


### PR DESCRIPTION
* Outline renders fewer lines that aren't outlines underwater (bumpwaterrefraction = 2)
* Outline widget now properly checks if CreateShader exists
* XrayShader power reduced underwater, since outline is more correct