### PR TITLE
Fix ground collision damage

### DIFF
--- a/LuaRules/Gadgets/unit_fall_damage.lua
+++ b/LuaRules/Gadgets/unit_fall_damage.lua
@@ -223,9 +223,7 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 		local vx,vy,vz = Spring.GetUnitVelocity(unitID)
 		local x,y,z = Spring.GetUnitPosition(unitID)
 		local nx, ny, nz = Spring.GetGroundNormal(x,z)
-		
-		nx, ny, nz = -nx, -ny, -nz -- For some reason normal is reversed
-		
+
 		local nMag = math.sqrt(nx^2 + ny^2 + nz^2)
 		local nx, ny, nz = nx/nMag, ny/nMag, nz/nMag -- normal to unit vector
 		nx, ny, nz = vx*nx, vy*ny, vz*nz -- normal is now a component of velocity


### PR DESCRIPTION
This reverts 602ca7182171926f8b6aaabf235980e6a4e39b30

The normal should not be reversed. This causes complete damage mitigation if the unit is colliding exactly along the normal. For a practical example see http://zero-k.info/Battles/Detail/384893

Explanation: let's say the normal is 0 / 1 / 0. Unit velocity is 0 / X / 0. ZK uses 0.5 multiplier for the tangent damage.
So the situation that should happen, the normal component is X * 1 == X, and the tangent component is X-X == 0. The damage is X + 0.5 * 0 == X.
Now with the normal reversed the normal component becomes X*(-1) == -X. The tangent thus becomes X - (-X) = 2X. The damage is (-X) + 0.5 * (2X) == 0.