### PR TITLE
Cleaner COFC smoothmeshscroll fix with better UX

### DIFF
--- a/LuaUI/Widgets/gui_chili_minimap.lua
+++ b/LuaUI/Widgets/gui_chili_minimap.lua
@@ -50,7 +50,7 @@ local iconsize = 20
 local bgColor_panel = {nil, nil, nil, 1}
 local final_opacity = 0
 local last_alpha = 1 --Last set alpha value for the actual clickable minimap image
-local default_fog_brightness = 0.5
+local default_fog_brightness = 5.0
 
 local tabbedMode = false
 
@@ -766,7 +766,7 @@ function widget:MousePress(x, y, button)
 			end
 			if coord then
 				if (WG.COFC_SetCameraTarget) then
-					WG.COFC_SetCameraTarget(coord[1],coord[2],coord[3],0)
+					WG.COFC_SetCameraTarget(coord[1],coord[2],coord[3],0,true)
 				else
 			 		Spring.SetCameraTarget(coord[1],coord[2],coord[3],0)
 				end
@@ -786,7 +786,7 @@ function widget:MouseMove(x, y, dx, dy, button)
 		end
 		if coord then
 			if (WG.COFC_SetCameraTarget) then
-				WG.COFC_SetCameraTarget(coord[1],coord[2],coord[3],0)
+				WG.COFC_SetCameraTarget(coord[1],coord[2],coord[3],0,true)
 			else
 		 		Spring.SetCameraTarget(coord[1],coord[2],coord[3],0)
 			end

--- a/LuaUI/Widgets/init_start_point_remover.lua
+++ b/LuaUI/Widgets/init_start_point_remover.lua
@@ -36,7 +36,7 @@ function widget:GameFrame(f)
 				local x, y, z = Spring.GetUnitPosition(unitID)
 				Spring.MarkerErasePosition(x, y, z)
 				if WG.COFC_SetCameraTarget then
-					WG.COFC_SetCameraTarget(x, y, z, 1, 1000)
+					WG.COFC_SetCameraTarget(x, y, z, 1, true, 1000)
 				else 
 					Spring.SetCameraTarget(x, y, z)
 				end


### PR DESCRIPTION
* COFC smoothMeshScroll just affects scrolling again.
  Bouncing bug on scroll start after zooming is still fixed,
  but issues that arose with rotation targeting smooth mesh
  rather than ground are also resolved.
  NB: camera will still bounce a bit if and only if it is
  below the smooth mesh when scrolling starts
* Cleaned up some of the COFC functions around lockspots