### PR TITLE
Give Spring AIs a Strike Trainer

### DIFF
--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -227,7 +227,7 @@ local function GetStartUnit(teamID, playerID, isAI)
   local startUnit
 
   if isAI then -- AI that didn't pick comm type gets default comm
-    return (Spring.GetTeamRulesParam(teamID, "start_unit") or "armcom1")
+    return (Spring.GetTeamRulesParam(teamID, "start_unit") or "comm_trainer_strike_0")
   end
 
   if (teamID and teamSides[teamID]) then 


### PR DESCRIPTION
For consistency with humans but also because the current one is not to be used. It has "buggy" behaviour (eg. does not get more expensive with morph despite having nonzero cost) but this is intended as it serves as a template for custom comms.