### PR TITLE
Remove Funnelweb in-combat autoheal

### DIFF
--- a/units/funnelweb.lua
+++ b/units/funnelweb.lua
@@ -4,7 +4,6 @@ unitDef = {
   description            = [[Drone/Shield Support Strider]],
   acceleration           = 0.0552,
   activateWhenBuilt      = true,
-  autoheal               = 20,
   brakeRate              = 0.1375,
   buildCostEnergy        = 4500,
   buildCostMetal         = 4500,


### PR DESCRIPTION
autoheal was 20, idleAutoHeal unchanged

There's not really a good reason for autoheal, especially since Funnel already has a shield. Almost no other unit has it. Dante, Scorpion and Reef don't. The only other striders with autoheal seem to be Ultimatum, Detriment and Strike comm (if that even counts).

It kinda makes sense for Detriment (seeing as it's supposed to end games anyway) and is a special chassis feature on strike comm. I'm not really sure on Ultimatum, should probably be removed on it as well. No idea.

To clarify: I assume that this def is an unplanned leftover that has not been noticed before.