### PR TITLE
Pyro: death explosion AoE radius back to 128

### DIFF
--- a/units/corpyro.lua
+++ b/units/corpyro.lua
@@ -145,7 +145,7 @@ unitDef = {
 
 	PYRO_DEATH = {
 		name                    = [[Napalm Blast]],
-		areaofeffect            = 192,
+		areaofeffect            = 256,
 		craterboost             = 1,
 		cratermult              = 3.5,
 


### PR DESCRIPTION
Same as before the napalm change