### PR TITLE
Add cylinderTargeting = 1 to Flail

### DIFF
--- a/units/hoveraa.lua
+++ b/units/hoveraa.lua
@@ -25,7 +25,7 @@ unitDef = {
     description_de = [[Fulgabwehrgleiter]],
     description_pl = [[Poduszkowiec przeciwlotniczy]],
     helptext       = [[The Flail launches a single large, short-medium range SAM that does heavy damage.]],
-	helptext_de    = [[Der Flail verschieﬂt ein einzige, groﬂe SAM auf mittlerer Distanz, die wirklich groﬂen Schaden anrichtet.]],
+	helptext_de    = [[Der Flail verschie√üt eine einzige, gro√üe Flugabwehrrakete auf mittlerer Distanz, die wirklich gro√üen Schaden anrichtet.]],
 	helptext_pl    = [[Flail wystrzeliwuje rakiety przeciwlotnicze sredniego zasiegu, ktore zadaja wysokie obrazenia.]],
 	modelradius    = [[20]],
 	midposoffset   = [[0 8 0]],
@@ -86,6 +86,7 @@ unitDef = {
       collideFriendly         = false,
       craterBoost             = 1,
       craterMult              = 2,
+      cylinderTargeting       = 1,
 
 	  customParams        	  = {
 		isaa = [[1]],


### PR DESCRIPTION
Most AA units have cylinderTargeting set to 1.
Exceptions: Swift has it set to 6, Defender to 5 and Hacksaw to 3.

I assume someone just accidentally forgot to add cylinderTargeting for Flail.

I also sneaked in a little helptext change. For some reason github marked the helptext line green even before I changed anything so while reading through it I decided to change it a bit. I hope the fact that the line was green even without any changes doesn't break anything.