### PR TITLE
Add numpad_enter support for chat

### DIFF
--- a/LuaUI/Configs/zk_keys.lua
+++ b/LuaUI/Configs/zk_keys.lua
@@ -13,14 +13,26 @@ return {
 		{	"edit_backspace",	"Any+backspace",},
 		{	"toggleoverview",	"Any+tab",},
 		{	"edit_complete",	"Any+tab",},
-		{	"chatally",	"Alt+enter",},
-		{	"chatswitchally",	"Alt+enter",},
-		{	"chatall",	"Ctrl+enter",},
-		{	"chatswitchall",	"Ctrl+enter",},
+		{
+			"chatally", 			{"Alt+enter", "Alt+numpad_enter"}, 
+		}, 
+		{
+			"chatswitchally", 			{"Alt+enter", "Alt+numpad_enter"}, 
+		}, 
+		{
+			"chatall", 			{"Ctrl+enter", "Ctrl+numpad_enter"}, 
+		}, 
+		{
+			"chatswitchall", 			{"Ctrl+enter", "Ctrl+numpad_enter"}, 
+		}, 
 		{	"chatspec",	"None"},
 		{	"chatswitchspec",	"None"},
-		{	"chat",	"Any+enter",},
-		{	"edit_return",	"Any+enter",},
+		{
+			"chat", 			{"Any+enter", "Any+numpad_enter"}, 
+		}, 
+		{
+			"edit_return", 			{"Any+enter", "Any+numpad_enter"}, 
+		}, 
 		{	"pause",	"pause",},
 		{	"crudemenu",	"esc",},
 		{	"exitwindow",	"shift+esc",},


### PR DESCRIPTION
Adds Alt+numpad_enter, Ctrl+numpad_enter and Any+numpad_enter for the different chat actions.

spec chat remains unchanged, so no Shift+numpad_enter. Indents after commands are messed up because that's how ZK makes them - zk_keys.lua is overwritten after every game.