### PR TITLE
Regeneration patch.

### DIFF
--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -833,26 +833,19 @@ for name, ud in pairs(UnitDefs) do
     end   
 end
 
--- Set default out of combat autorepair
+-- Replace regeneration with Lua
 local autoheal_defaults = VFS.Include("gamedata/unitdef_defaults/autoheal_defs.lua")
 for name, ud in pairs(UnitDefs) do
-	if not ud.autoheal then
-		ud.autoheal = autoheal_defaults.autoheal
+	if (ud.autoheal and (ud.autoheal > 0)) then
+		ud.customparams.idle_regen = ud.autoheal
+		ud.idletime = 0
+	else
+		ud.customparams.idle_regen = ud.idleautoheal or autoheal_defaults.idleautoheal
+		ud.idletime = ud.idletime or autoheal_defaults.idletime
 	end
-	if not ud.idletime then
-		ud.idletime = autoheal_defaults.idletime
-	end
-	if not ud.idleautoheal then
-		ud.idleautoheal = autoheal_defaults.idleautoheal
-	end
-end
 
--- Fix inconsistent idle regeneration for air units
-for name, ud in pairs(UnitDefs) do
-	if ud.canfly then
-		ud.customparams.idle_regen = ud.idleautoheal
-		ud.idleautoheal = 0
-	end
+	ud.idleautoheal = 0
+	ud.autoheal = 0
 end
 
 -- Set defaults for area cloak


### PR DESCRIPTION
 * idle regen and combat regen (autoheal) obey slow and disarm.
 * tooltip shows regeneration on damaged units (this includes idle, combat, amph and Gauss regen) and charging shields (only the self component, does not count linking). For units with quick idle regen, the timer is shown if counting down. The value shown does not obey status effects (would fluctuate too much) but if this is wanted it's trivial to make it so.
 * both types of engine regen (combat and idle) are reimplemented together so as a side effect units with combat regen no longer have idle regen. Affects Athena, Det, Ulti, and commanders.

![regen1](https://cloud.githubusercontent.com/assets/2573076/12877042/97054624-ce0c-11e5-905f-47410fb7512b.png)
![regen2](https://cloud.githubusercontent.com/assets/2573076/12877045/98ec243a-ce0c-11e5-8df2-33db5a40253d.png)

