### PR TITLE
Feature FX: reenable with smaller size

### DIFF
--- a/LuaRules/Gadgets/feature_fx.lua
+++ b/LuaRules/Gadgets/feature_fx.lua
@@ -14,7 +14,7 @@ function gadget:GetInfo()
     date      = "January 2015",
     license   = "GNU GPL, v2 or later",
     layer     = 0,
-    enabled   = false  --  loaded by default?
+    enabled   = true  --  loaded by default?
   }
 end
 
@@ -32,7 +32,7 @@ function gadget:FeatureDestroyed(id, allyTeam)
 	spSpawnCEG( CEG_SPAWN,
 		x,y,z,
 		0,0,0,
-		1+r, 1+r
+		2+(r/3), 2+(r/3)
 	);
 
 	--This could be used to later play sounds without betraying events or positions of destroyed features


### PR DESCRIPTION
It's good if things don't suddenly disappear without any trace.
The original problem with the poof was the size so here's an attempt with the size reduced.