### PR TITLE
Precision bomber selector

### DIFF
--- a/LuaUI/Widgets/gui_chili_core_selector.lua
+++ b/LuaUI/Widgets/gui_chili_core_selector.lua
@@ -127,7 +127,7 @@ function widget:PlayerChanged()
 end
 
 options_path = 'Settings/HUD Panels/Quick Selection Bar'
-options_order = { 'showCoreSelector', 'maxbuttons', 'monitoridlecomms', 'leftMouseCenter', 'monitoridlenano', 'lblSelection', 'selectcomm', 'selectprecbomber'}
+options_order = { 'showCoreSelector', 'maxbuttons', 'monitoridlecomms', 'leftMouseCenter', 'monitoridlenano', 'selectprecbomber', 'lblSelection', 'selectcomm'}
 options = {
 	showCoreSelector = {
 		name = 'Selection Bar Visibility',
@@ -169,16 +169,16 @@ options = {
 		type = 'bool',
 		value = false,		
 	},
+	selectprecbomber = { type = 'button',
+		name = 'Individual precision bombers',
+		action = 'selectprecbomber',
+		path = 'Game/Selection Hotkeys',
+		dontRegisterAction = true,
+	},
 	lblSelection = { type='label', name='Commander', path='Game/Selection Hotkeys', },
 	selectcomm = { type = 'button',
 		name = 'Select Commander',
 		action = 'selectcomm',
-		path = 'Game/Selection Hotkeys',
-		dontRegisterAction = true,
-	},
-	selectprecbomber = { type = 'button',
-		name = 'Select Precision Bomber',
-		action = 'selectprecbomber',
 		path = 'Game/Selection Hotkeys',
 		dontRegisterAction = true,
 	},

--- a/LuaUI/Widgets/gui_chili_core_selector.lua
+++ b/LuaUI/Widgets/gui_chili_core_selector.lua
@@ -846,7 +846,7 @@ local function isAttackQueued(unitID)
 	if cmdsLen and (cmdsLen > 0) then
 		local cmds=Spring.GetCommandQueue(unitID,-1)
 		for i=1,cmdsLen do
-			if cmds and cmds[i] and (cmds[i].id==CMD.ATTACK) then
+			if cmds and cmds[i] and ((cmds[i].id==CMD.ATTACK) or (cmds[i].id==CMD.AREA_ATTACK)) then
 				return true
 			end
 		end


### PR DESCRIPTION
This PR adds functionality to the Core Selector widget to allow for easier selection and management of precision bombers (Ravens). It creates a new action bindable via Epic Menu: Game -> Selection Hotkeys -> Individual precision bombers, default unbound.

The hotkey selects "ready" Ravens: armed, not being refueled or repaired, and not already tasked with an attack order in their command queue. The hotkey selects one Raven at a time, allowing you to give it a specific attack order and then quickly select another one that's ready to attack. In this manner you can quickly assign individual Ravens to individual targets, ensuring that targets will not be overkilled nor underkilled and that high-priority targets will be hit first.

The hotkey has some intelligence. If you press it once, it will select a ready untasked Raven. If you press it again, it will continue to add ready untasked Ravens to the selection. This allows you to, for example, press the hotkey five times to select a group of five ready untasked Ravens, then click on a factory to hit it with five bombs. So not only can you quickly assign individual Ravens to individual targets, you can quickly assign _the right number_ of Ravens to each individual target.

The Ravens selected will be those that are closest to the mouse pointer.

If you already have a selection containing various types of units, pressing the hotkey will filter out everything except ready untasked Ravens. So you can select all the ready Ravens flying around some area by box-dragging across the area and then pressing the hotkey, or you can select all ready Ravens everywhere by pressing ctrl+A and the hotkey.

This PR does not add any icons to the Core Selector display. It only creates the bindable action.