### PR TITLE
Gadget version of wading wakes.

### DIFF
--- a/LuaRules/Gadgets/wake_fx.lua
+++ b/LuaRules/Gadgets/wake_fx.lua
@@ -67,7 +67,7 @@ function gadget:GameFrame(n)
             if i % n_folds == current_fold then
                 local udn = UnitDefs[Spring.GetUnitDefID(u)].name
                 local x,y,z = Spring.GetUnitPosition(u)
-                if y > -h and y <= 0 and isMoving(u) then -- emit wakes only when moving and not completely submerged
+                if y > -h and y <= 0 and isMoving(u) and not Spring.GetUnitIsCloaked(u) then -- emit wakes only when moving and not completely submerged
                     local radius = Spring.GetUnitRadius(u);
                     local effect = SFXTYPE_WAKE1
                     if radius>50 then sfx = SFXTYPE_WAKE2 end

--- a/LuaRules/Gadgets/wake_fx.lua
+++ b/LuaRules/Gadgets/wake_fx.lua
@@ -19,13 +19,12 @@ function gadget:GetInfo()
     enabled   = true  --  loaded by default?
   }
 end
-
-local units = {}
-local n_units = 0
+local unit = {}
+local units = {count = 0, data = {}}
 
 local fold_frames = 7 -- every seventh frame
 local n_folds = 4 -- check every fourth unit
-local current_fold = 0
+local current_fold = 1
 
 function canWade(unitDefID)
     local moveDef = UnitDefs[unitDefID].moveDef
@@ -47,26 +46,31 @@ end
 function gadget:UnitCreated(unitID, unitDefID)
     if(canWade(unitDefID)) then
         local uddim = Spring.GetUnitDefDimensions(unitDefID)
-        units[unitID] = uddim.height
+		if not unit[unitID] then
+			units.count = units.count + 1
+			units.data[units.count] = unitID
+            unit[unitID] = uddim.height
+		end
     end
-end
-
-function gadget:UnitDestroyed(unitID)
-    units[unitID] = nil
 end
 
 function gadget:GameFrame(n)
     if n%fold_frames == 0 then
+        local listData = units.data
         if current_fold > n_folds then
-            current_fold = 0
+             current_fold = 1
         end
-        
-        local i = 0
-        for u,h in pairs(units) do
-            i = i+1
-            if i % n_folds == current_fold then
-                local udn = UnitDefs[Spring.GetUnitDefID(u)].name
+	    for i=current_fold, units.count, n_folds do
+      		local u = listData[i]
+              
+            if not Spring.ValidUnitID(u) then
+                listData[i] = listData[units.count]
+                listData[units.count] = nil
+                units.count = units.count - 1
+                unit[u] = nil
+            else
                 local x,y,z = Spring.GetUnitPosition(u)
+                local h = unit[u]
                 if y > -h and y <= 0 and isMoving(u) and not Spring.GetUnitIsCloaked(u) then -- emit wakes only when moving and not completely submerged
                     local radius = Spring.GetUnitRadius(u);
                     local effect = SFXTYPE_WAKE1
@@ -77,7 +81,6 @@ function gadget:GameFrame(n)
                 end
             end
         end
-        n_units = i -- this is now usable for dynamic folding 
         current_fold = current_fold+1
     end
 end

--- a/LuaRules/Gadgets/wake_fx.lua
+++ b/LuaRules/Gadgets/wake_fx.lua
@@ -48,8 +48,18 @@ function gadget:UnitCreated(unitID, unitDefID)
         if not unit[unitID] then
             units.count = units.count + 1
             units.data[units.count] = unitID
-            unit[unitID] = uddim.height
+            unit[unitID] = {id=units.count,h=uddim.height}
         end
+    end
+end
+
+function gadget:UnitDestroyed(unitID)
+    if unit[unitID] then
+        units.data[unit[unitID].id] = units.data[units.count]
+        unit[units.data[units.count]].id = unit[unitID].id --shift last entry into empty space
+        units.data[units.count] = nil
+        units.count = units.count - 1
+        unit[unitID] = nil
     end
 end
 
@@ -60,25 +70,18 @@ function gadget:GameFrame(n)
              current_fold = 1
         end
         for i=current_fold, units.count, n_folds do
-              local u = listData[i]
-              
-            if not Spring.ValidUnitID(u) then
-                listData[i] = listData[units.count]
-                listData[units.count] = nil
-                units.count = units.count - 1
-                unit[u] = nil
-            else
-                local x,y,z = Spring.GetUnitPosition(u)
-                local h = unit[u]
-                if y > -h and y <= 0 and isMoving(u) and not Spring.GetUnitIsCloaked(u) then -- emit wakes only when moving and not completely submerged
-                    local radius = Spring.GetUnitRadius(u);
-                    local effect = SFXTYPE_WAKE1
-                    if radius>50 then sfx = SFXTYPE_WAKE2 end
-                    Spring.UnitScript.CallAsUnit(u, function()
-                        Spring.UnitScript.EmitSfx(1,effect);
-                    end);
-                end
+            local u = listData[i]             
+            local x,y,z = Spring.GetUnitPosition(u)
+            local h = unit[u].h
+            if y > -h and y <= 0 and isMoving(u) and not Spring.GetUnitIsCloaked(u) then -- emit wakes only when moving and not completely submerged
+                local radius = Spring.GetUnitRadius(u);
+                local effect = SFXTYPE_WAKE1
+                if radius>50 then sfx = SFXTYPE_WAKE2 end
+                Spring.UnitScript.CallAsUnit(u, function()
+                    Spring.UnitScript.EmitSfx(1,effect);
+                end);
             end
+
         end
         current_fold = current_fold+1
     end

--- a/LuaRules/Gadgets/wake_fx.lua
+++ b/LuaRules/Gadgets/wake_fx.lua
@@ -33,9 +33,8 @@ function canWade(unitDefID)
         if mdFamily == "kbot" or mdFamily == "tank" then
             return true
         end
-    else
-        return false
     end
+    return false
 end
 
 function isMoving(unitID)

--- a/LuaRules/Gadgets/wake_fx.lua
+++ b/LuaRules/Gadgets/wake_fx.lua
@@ -1,7 +1,7 @@
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 if not gadgetHandler:IsSyncedCode() then
-	return
+    return
 end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -46,11 +46,11 @@ end
 function gadget:UnitCreated(unitID, unitDefID)
     if(canWade(unitDefID)) then
         local uddim = Spring.GetUnitDefDimensions(unitDefID)
-		if not unit[unitID] then
-			units.count = units.count + 1
-			units.data[units.count] = unitID
+        if not unit[unitID] then
+            units.count = units.count + 1
+            units.data[units.count] = unitID
             unit[unitID] = uddim.height
-		end
+        end
     end
 end
 
@@ -60,8 +60,8 @@ function gadget:GameFrame(n)
         if current_fold > n_folds then
              current_fold = 1
         end
-	    for i=current_fold, units.count, n_folds do
-      		local u = listData[i]
+        for i=current_fold, units.count, n_folds do
+              local u = listData[i]
               
             if not Spring.ValidUnitID(u) then
                 listData[i] = listData[units.count]

--- a/LuaRules/Gadgets/wake_fx.lua
+++ b/LuaRules/Gadgets/wake_fx.lua
@@ -1,0 +1,83 @@
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+SFXTYPE_WAKE1 = 2
+SFXTYPE_WAKE2 = 3
+
+function gadget:GetInfo()
+  return {
+    name      = "Wade Effects",
+    desc      = "Spawn wakes when non-ship ground units move while partially, but not completely submerged",
+    author    = "Anarchid",
+    date      = "March 2016",
+    license   = "GNU GPL, v2 or later",
+    layer     = 0,
+    enabled   = true  --  loaded by default?
+  }
+end
+
+local units = {}
+local n_units = 0
+
+local fold_frames = 7 -- every seventh frame
+local n_folds = 4 -- check every fourth unit
+local current_fold = 0
+
+function canWade(unitDefID)
+    local moveDef = UnitDefs[unitDefID].moveDef
+    if(moveDef and moveDef.family) then
+        local mdFamily = moveDef.family
+        if mdFamily == "kbot" or mdFamily == "tank" then
+            return true
+        end
+    else
+        return false
+    end
+end
+
+function isMoving(unitID)
+    local _,_,_,velocity = Spring.GetUnitVelocity(unitID);
+    return velocity > 0
+end
+
+function gadget:UnitCreated(unitID, unitDefID)
+    if(canWade(unitDefID)) then
+        local uddim = Spring.GetUnitDefDimensions(unitDefID)
+        units[unitID] = uddim.height
+    end
+end
+
+function gadget:UnitDestroyed(unitID)
+    units[unitID] = nil
+end
+
+function gadget:GameFrame(n)
+    if n%fold_frames == 0 then
+        if current_fold > n_folds then
+            current_fold = 0
+        end
+        
+        local i = 0
+        for u,h in pairs(units) do
+            i = i+1
+            if i % n_folds == current_fold then
+                local udn = UnitDefs[Spring.GetUnitDefID(u)].name
+                local x,y,z = Spring.GetUnitPosition(u)
+                if y > -h and y <= 0 and isMoving(u) then -- emit wakes only when moving and not completely submerged
+                    local radius = Spring.GetUnitRadius(u);
+                    local effect = SFXTYPE_WAKE1
+                    if radius>50 then sfx = SFXTYPE_WAKE2 end
+                    Spring.UnitScript.CallAsUnit(u, function()
+                        Spring.UnitScript.EmitSfx(1,effect);
+                    end);
+                end
+            end
+        end
+        n_units = i -- this is now usable for dynamic folding 
+        current_fold = current_fold+1
+    end
+end


### PR DESCRIPTION
This reimplements the wading wakes proposal as a gadget, which should be much cleaner and less error-prone. Wade-admissible units are autodetected. Wakes are spawned every seventh frame for every fourth unit, so each unit currently generates ~one wake per second.

The part i dislike about this is relying on piece zero (which is nevertheless guaranteed to be present and likely to be the unit's core). Units could specify which of their pieces should emit wakes, but really i hope to see engine 102 include a way to SpawnCEG wakes without having to go down to EmtiSFX level. 

The staggering behaviour could be made dynamic so fewer units spawn wakes per cycle.

This replaces and supercedes #1103.

Eyecandy:

![workspace 1_060](https://cloud.githubusercontent.com/assets/3822768/13760811/b6e0f658-ea3d-11e5-8bb5-af1e1152991f.png)
![workspace 1_058](https://cloud.githubusercontent.com/assets/3822768/13760820/bc05abba-ea3d-11e5-9c4c-5d601cd4a640.png)