### PR TITLE
Silo_valley_v02 metalmap

### DIFF
--- a/LuaRules/Configs/MetalSpots/Silo_valley_v02
+++ b/LuaRules/Configs/MetalSpots/Silo_valley_v02
@@ -1,0 +1,27 @@
+return {
+	spots = {
+		-- Regular metal spots
+		{x = 1624, z = 1368, metal = 2},
+		{x = 88,   z = 280,  metal = 2},
+		{x = 3992, z = 1784, metal = 2},
+		{x = 2472, z = 664,  metal = 2},
+		{x = 1496, z = 584,  metal = 2},
+		{x = 904,  z = 616,  metal = 2},
+		{x = 1208, z = 1752, metal = 2},
+		{x = 3192, z = 1432, metal = 2},
+		{x = 72,   z = 712,  metal = 2},
+		{x = 2040, z = 1720, metal = 2},
+		{x = 2040, z = 328,  metal = 2},
+		{x = 4008, z = 1336, metal = 2},
+		{x = 2584, z = 1464, metal = 2},
+		{x = 2872, z = 280,  metal = 2},
+		{x = 184,  z = 1656, metal = 2},
+		{x = 3912, z = 392,  metal = 2},
+		-- Supermexes
+		{x = 904,  z = 1416, metal = 3.5},
+		{x = 504,  z = 712,  metal = 3.5},
+		{x = 2056, z = 1048, metal = 3.5},
+		{x = 3224, z = 648,  metal = 3.5},
+		{x = 3608, z = 1336, metal = 3.5},
+	}
+}


### PR DESCRIPTION
Metal spots as suggested in http://zero-k.info/Maps/Detail/8122

map defaults were 1.0200001001358 for small and 4.0800004005432 for large metal spots according to dbg_mex_to_infolog.lua