### PR TITLE
Allow AIs to give units to allies

### DIFF
--- a/LuaRules/Gadgets/game_disable_take.lua
+++ b/LuaRules/Gadgets/game_disable_take.lua
@@ -21,6 +21,56 @@ end
 local spIsCheatingEnabled = Spring.IsCheatingEnabled
 local spGetPlayerInfo     = Spring.GetPlayerInfo
 local spGetTeamInfo       = Spring.GetTeamInfo
+local spGetUnitTeam       = Spring.GetUnitTeam
+local spTransferUnit      = Spring.TransferUnit
+local spSendLuaRulesMsg   = Spring.SendLuaRulesMsg
+
+
+function gadget:RecvSkirmishAIMessage(aiTeam, dataStr)
+	-- usage: callback.getLua().callRules("ai_give_unit|" + u.getUnitId() + "|" + team, -1);
+	
+	local dataSplit = {}
+	for str in dataStr:gmatch("(([^\|]+))") do  
+		dataSplit[#dataSplit + 1] = str
+	end 
+	local command = dataSplit[1]
+	local unitID = tonumber(dataSplit[2])
+	local trgTeam = tonumber(dataSplit[3])
+	
+	if command == "ai_give_unit" and unitID ~= nil and trgTeam ~= nil and spGetUnitTeam(unitID) == aiTeam then	
+		
+		local _,_,_,_,_,allyTeamSource = spGetTeamInfo(aiTeam)
+		local _,_,_,_,_,allyTeamTarget = spGetTeamInfo(trgTeam)
+		if (allyTeamSource == allyTeamTarget) then
+			spSendLuaRulesMsg(command..'|'..unitID..'|'..trgTeam..'|'..aiTeam);
+		end
+	end
+end	
+
+
+
+function gadget:RecvLuaMsg(msg, playerID)
+	local dataSplit = {}
+	for str in msg:gmatch("(([^\|]+))") do  
+		dataSplit[#dataSplit + 1] = str
+	end 
+	local command = dataSplit[1]
+	local unitID = tonumber(dataSplit[2])
+	local trgTeam = tonumber(dataSplit[3])
+	local srcTeam = tonumber(dataSplit[4])
+	
+	if command == "ai_give_unit" and unitID ~= nil and trgTeam ~= nil and srcTeam ~= nil and spGetUnitTeam(unitID) == srcTeam then	
+		
+		local _,_,_,isAI,_,allyTeamSource = spGetTeamInfo(srcTeam)
+		local _,_,_,_,_,allyTeamTarget = spGetTeamInfo(trgTeam)
+		local _,_,aiHost = Spring.GetAIInfo(srcTeam)
+		if (allyTeamSource == allyTeamTarget and isAI and aiHost == playerID) then
+			GG.allowTransfer = true
+			spTransferUnit(unitID, trgTeam)
+			GG.allowTransfer = false
+		end
+	end
+end
 
 GG.allowTransfer = false
 function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
@@ -29,7 +79,7 @@ function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
 		return true 
 	end
 	local _,leaderID,isDead,isAI = spGetTeamInfo(oldTeam)
-	if isDead then --DISALLOW /take of AI or dead player
+	if isAI or isDead then --DISALLOW /take of AI or dead player
 		return false
 	end
 	local _, active, spectator = spGetPlayerInfo(leaderID)

--- a/LuaRules/Gadgets/game_disable_take.lua
+++ b/LuaRules/Gadgets/game_disable_take.lua
@@ -29,7 +29,7 @@ function gadget:AllowUnitTransfer(unitID, unitDefID, oldTeam, newTeam, capture)
 		return true 
 	end
 	local _,leaderID,isDead,isAI = spGetTeamInfo(oldTeam)
-	if isAI or isDead then --DISALLOW /take of AI or dead player
+	if isDead then --DISALLOW /take of AI or dead player
 		return false
 	end
 	local _, active, spectator = spGetPlayerInfo(leaderID)


### PR DESCRIPTION
Does this break something else?

Currently it's impossible for AIs to give units to teammates, which is a feature I would like to use for my AI in COOP games.