### PR TITLE
Remove version number from Decloak Range widget

### DIFF
--- a/LuaUI/Widgets/unit_decloak_range.lua
+++ b/LuaUI/Widgets/unit_decloak_range.lua
@@ -1,7 +1,7 @@
 function widget:GetInfo()
 	return {
-		name      = "DecloakArea v1.1",
-		desc      = "Display deacloak area around cloaked units",
+		name      = "Decloak Range",
+		desc      = "Display deacloak range around cloaked units",
 		author    = "banana_Ai",
 		date      = "28 Feb 2016",
 		license   = "GNU GPL v2",


### PR DESCRIPTION
Since the name change is resetting user settings, remove the version
form the name. Do it fast so people is not yet used to this widget and
there are not many settings yet.

Also change "Decloak Area" to "Decloak Range" to be consistent with
filename and naming used in Settings.