### PR TITLE
Remove outdated help tooltip. Fixes #1485

### DIFF
--- a/LuaUI/Widgets/camera_cofc.lua
+++ b/LuaUI/Widgets/camera_cofc.lua
@@ -4,7 +4,7 @@
 function widget:GetInfo()
   return {
     name      = "Combo Overhead/Free Camera (experimental)",
-    desc      = "v0.138 Camera featuring 6 actions. Type \255\90\90\255/luaui cofc help\255\255\255\255 for help.",
+    desc      = "v0.138 Camera featuring 6 actions",
     author    = "CarRepairer, msafwan",
     date      = "2011-03-16", --2014-Sept-25
     license   = "GNU GPL, v2 or later",


### PR DESCRIPTION
Help is a button in the options menu.