### PR TITLE
Allow AIs to check for valid enemy startpos

### DIFF
--- a/LuaRules/Gadgets/start_boxes.lua
+++ b/LuaRules/Gadgets/start_boxes.lua
@@ -313,10 +313,18 @@ function gadget:RecvSkirmishAIMessage(teamID, dataStr)
 		local allyteamid = Spring.GetAllyTeamID(teamID)
 		local allyteams = Spring.GetAllyTeamList()
 		
-		for _,value in pairs(allyteams) do
-			if value ~= allyteamid then
-				local enemyteams = Spring.GetTeamList(value)
-				enemyboxes[Spring.GetTeamRulesParam(enemyteams[1], "start_box_id")] = true
+		if shuffleMode == "allshuffle" then
+			for id,_ in pairs(startboxConfig) do
+				if id ~= boxID then
+					enemyboxes[id] = true
+				end
+			end
+		else
+			for _,value in pairs(allyteams) do
+				if value ~= allyteamid then
+					local enemyteams = Spring.GetTeamList(value)
+					enemyboxes[Spring.GetTeamRulesParam(enemyteams[1], "start_box_id")] = true
+				end
 			end
 		end
 		


### PR DESCRIPTION
Since startboxes are no longer exposed to AIs through rules params they are no longer able to infer enemy start positions. To get around this I added an "ai_is_valid_enemy_startpos:" ai callin so that they can  do the same thing via rules calls.

Note: I haven't tested this because there's no skirmish mode.. additionally it's possible that Spring.GetAllyTeamList() and Spring.GetTeamList() do not return an ordinal list as documented but instead use the ally/team ids as keys, which would require changing the code.