### PR TITLE
Area-reclaim changes:

### DIFF
--- a/LuaUI/Widgets/cmd_commandinsert.lua
+++ b/LuaUI/Widgets/cmd_commandinsert.lua
@@ -7,8 +7,7 @@ function widget:GetInfo()
     name = "CommandInsert",
     desc = "[v" .. version .. "] Allow you to add command into existing queue. Based on FrontInsert by jK"..
 			"\n• SPACEBAR+SHIFT insert command to arbitrary places in queue."..
-			"\n• SPACEBAR insert command in front of queue."..
-			"\n• CTRL+Reclaim force reclaim your own unit in an area.",
+			"\n• SPACEBAR insert command in front of queue.",
 	author = "dizekat",
     date = "Jan,2008", --16 October 2013
     license = "GNU GPL, v2 or later",
@@ -83,10 +82,10 @@ end
 
 local function ProcessCommand(id, params, options)
   local alt,ctrl,meta,shift = Spring.GetModKeyState() --must use this because "options" table turn into different format when right+click. Similar problem with different trigger see: https://code.google.com/p/zero-k/issues/detail?id=1824 (options in online game coded different than in local game)
-  if (ctrl) and not (meta) and (id==CMD.RECLAIM or id==CMD.REPAIR) then --Reclaim + CTRL
+  if (ctrl) and not (meta) and id==CMD.REPAIR then
 	local opt = 0
 	if options.alt or alt then opt = opt + CMD.OPT_ALT end
-	opt = opt + CMD.OPT_META; --add META. Force-reclaim-own-unit
+	opt = opt + CMD.OPT_META
 	if options.right then opt = opt + CMD.OPT_RIGHT end
 	if options.shift or shift then opt = opt + CMD.OPT_SHIFT end
 	Spring.GiveOrder(id,params,opt)
@@ -97,10 +96,10 @@ local function ProcessCommand(id, params, options)
     local insertfront=false
     if options.alt or alt then opt = opt + CMD.OPT_ALT end
 	if options.ctrl or ctrl then
-		if (id~=CMD.RECLAIM and id~=CMD.REPAIR) then  
-			opt = opt + CMD.OPT_CTRL --add CTRL like normal
-		else --add CTRL+Reclaim as force-reclaim
-			opt = opt + CMD.OPT_META; --add META. Force-reclaim-own-unit(originally META+Reclaim). Can't change CommandInsert() to other modifier because META is already established (culturally) for CommandInsert()
+		if id == CMD.REPAIR then  
+			opt = opt + CMD.OPT_META
+		else
+			opt = opt + CMD.OPT_CTRL
 		end
 	end
     if options.right then opt = opt + CMD.OPT_RIGHT end

--- a/LuaUI/Widgets/unit_unit_reclaimer.lua
+++ b/LuaUI/Widgets/unit_unit_reclaimer.lua
@@ -1,18 +1,15 @@
 
 function widget:GetInfo()
   return {
-    name      = "Specific Unit Reclaimer",
+    name      = "Specific Thing Reclaimer",
     desc      = "Reclaims targeted unit types in an area",
     author    = "Google Frog",
     date      = "May 12, 2008",
     license   = "GNU GPL, v2 or later",
     layer     = 0,
-    enabled   = false  --  loaded by default?
+    enabled   = true  --  loaded by default?
   }
 end
-
-local team = Spring.GetMyTeamID()
-local allyTeam = Spring.GetMyAllyTeamID()
 
 -- Speedups
 
@@ -27,68 +24,85 @@ local spGetUnitAllyTeam = Spring.GetUnitAllyTeam
 
 local reclaimEnemy = Game.reclaimAllowEnemies
 
---
-function widget:Initialize()
-	 if (Spring.GetSpectatingState() or Spring.IsReplay()) and (not Spring.IsCheatingEnabled()) then
-		Spring.Echo("<Specific Unit Reclaimer>: disabled for spectators")
-		widgetHandler:RemoveWidget()
+function widget:CommandNotify(cmdID, params, options)
+
+	if not options.ctrl or (cmdID ~= 90) or (#params ~= 4) then
+		return
 	end
-end
 
-function spEcho(text)
-  Spring.Echo(text)
-end
-
-function widget:CommandNotify(id, params, options)
-
-
-  if (id == 90) and (#params == 4) then
-    
 	local cx, cy, cz = params[1], params[2], params[3]
-	
-	local mx,my,mz = spWorldToScreenCoords(cx, cy, cz)
-    local cType,id = spTraceScreenRay(mx,my) 
-	
-	if (cType == "unit") then 
-  
-	  local cr = params[4]
+	local mx,my = spWorldToScreenCoords(cx, cy, cz)
+	local cType, targetID = spTraceScreenRay(mx,my)
 
-	  local selUnits = spGetSelectedUnits()
-	  
-	  local shift = options.shift
-	  
-	  if not shift then
-	    for i, sid in ipairs(selUnits) do 
-		  spGiveOrderToUnit(sid, CMD.STOP, {}, CMD.OPT_RIGHT)
-	    end
-	  end
-	  
-	  if reclaimEnemy and spGetUnitAllyTeam(id) ~= allyTeam then
-	    
-		local areaUnits = spGetUnitsInCylinder(cx ,cz , cr)
-		
-	    for i, aid in ipairs(areaUnits) do 
-		  if spGetUnitAllyTeam(aid) ~= allyTeam then
-		    spGiveOrderToUnitArray( selUnits, CMD.RECLAIM, {aid}, CMD.OPT_SHIFT)
-		  end
-	    end
-	  
-	  else
-	  
-	    local areaUnits = spGetUnitsInCylinder(cx ,cz , cr, team)
-	    local unitDef = spGetUnitDefID(id)
-	  
-        for i, aid in ipairs(areaUnits) do 
-		  if spGetUnitDefID(aid) == unitDef then
-		    spGiveOrderToUnitArray( selUnits, CMD.RECLAIM, {aid}, CMD.OPT_SHIFT)
-		  end
-	    end
-		
-	  end
-	  
-	return true 
-	  
+	if (cType == "unit") then
+
+		local selUnits = spGetSelectedUnits()
+		if not options.shift then
+			for i, sid in ipairs(selUnits) do 
+				spGiveOrderToUnit(sid, CMD.STOP, {}, CMD.OPT_RIGHT)
+			end
+		end
+
+		local cr = params[4]
+		local allyTeam = Spring.GetMyAllyTeamID()
+
+		if reclaimEnemy and spGetUnitAllyTeam(targetID) ~= allyTeam then
+			local areaUnits = spGetUnitsInCylinder(cx, cz, cr)
+			for i, aid in ipairs(areaUnits) do 
+				if spGetUnitAllyTeam(aid) ~= allyTeam then
+					spGiveOrderToUnitArray(selUnits, CMD.RECLAIM, {aid}, CMD.OPT_SHIFT)
+				end
+			end
+		else
+			local team = Spring.GetMyTeamID()
+			local areaUnits = spGetUnitsInCylinder(cx, cz, cr, team)
+			local unitDefID = spGetUnitDefID(targetID)
+			for i, aid in ipairs(areaUnits) do
+				if spGetUnitDefID(aid) == unitDefID then
+					spGiveOrderToUnitArray(selUnits, CMD.RECLAIM, {aid}, CMD.OPT_SHIFT)
+				end
+			end
+		end
+		return true
+	elseif (cType == "feature") then
+		local featureDefID = Spring.GetFeatureDefID(targetID)
+		if FeatureDefs[featureDefID].metal > 0 then
+			return
+		end
+
+		local selUnits = spGetSelectedUnits()
+		if not options.shift then
+			for i, sid in ipairs(selUnits) do 
+				spGiveOrderToUnit(sid, CMD.STOP, {}, CMD.OPT_RIGHT)
+			end
+		end
+
+		local cr = params[4]
+		local potentialTrees = Spring.GetFeaturesInCylinder(cx, cz, cr)
+		local trees = {}
+		for i = 1, #potentialTrees do
+			local featureID = potentialTrees[i]
+			if FeatureDefs[Spring.GetFeatureDefID(featureID)].metal == 0 then
+				trees[#trees+1] = featureID
+			end
+		end
+		while #trees > 0 do
+			local minDist = cr*cr + 1
+			local bestID = 0
+			for i = 1, #trees do
+				local x, y, z = Spring.GetFeaturePosition(trees[i])
+				local dist = (x-cx)*(x-cx) + (z-cz)*(z-cz)
+				if dist < minDist then
+					minDist = dist
+					bestID = i
+				end
+			end
+			local featureID = trees[bestID]
+			spGiveOrderToUnitArray(selUnits, CMD.RECLAIM, {featureID + Game.maxUnits}, CMD.OPT_SHIFT)
+			cx, cy, cz = Spring.GetFeaturePosition(featureID)
+			trees[bestID] = trees[#trees]
+			trees[#trees] = nil
+		end
+		return true
 	end
-	
-  end
 end

--- a/gamedata/featuredefs_post.lua
+++ b/gamedata/featuredefs_post.lua
@@ -175,6 +175,9 @@ for name, def in pairs(FeatureDefs) do
 	if def.resurrectable ~= 1 then
 		def.resurrectable = 0
 	end
+	if not def.metal or def.metal == 0 then
+		def.autoreclaimable = false
+	end
 end
  
 --------------------------------------------------------------------------------


### PR DESCRIPTION
- Ctrl + Area Reclaim to reclaim own units now only works when the center of the area is a unit (like Circle Orbit Guard). Only reclaims that unit type. This converts the area command to a series of individual reclaims (so won't update when units come and leave the area).
- CTRL + Area Reclaim, when hovered over a feature with metal = 0 (usually a tree), will reclaim metal = 0 features only. Also a series of individual reclaims except this time it has no UI consequences because trees cannot move [citation needed].
- Ctrl + Area Reclaim not hovered over a tree or live unit will eat all features unconditionally. This means that in addition to metal, it will reclaim wrecks currently being resurrected and trees.
- Regular Area Reclaim (without CTRL) will no longer reclaim metal = 0 features.
