### PR TITLE
Unit AI: Impaler, Reef, Detri

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -914,7 +914,7 @@ local behaviourConfig = {
 		skirmRadar = true, 
 		swarms = {}, 
 		flees = {},
-		skirmLeeway = 150, 
+		skirmLeeway = 600, 
 	},
 	
 	["cormart"] = {
@@ -922,7 +922,7 @@ local behaviourConfig = {
 		skirmRadar = true,
 		swarms = {}, 
 		flees = {},
-		skirmLeeway = 100, 
+		skirmLeeway = 400, 
 	},
 	
 	["armraven"] = {

--- a/LuaRules/Configs/target_priority_defs.lua
+++ b/LuaRules/Configs/target_priority_defs.lua
@@ -84,6 +84,12 @@ local unitIsFighterOrDrone = {
 	[UnitDefNames["carrydrone"].id] = true,
 }
 
+-- Wolverine mines are stupid targets.
+local unitIsClaw = {
+	[UnitDefNames["wolverine_mine"].id] = true,
+}
+
+
 -- swifts should prefer to target air over ground
 local unitIsBadAgainstGround = {
 	[UnitDefNames["fighter"].id] = true,
@@ -171,9 +177,16 @@ for wdid = 1, #WeaponDefs do
 	end
 end
 
+local starburstWeaponDefs = {
+	[WeaponDefNames["armmerl_cortruck_rocket"].id] = true,
+	[WeaponDefNames["reef_armmship_rocket"].id] = true,
+	[WeaponDefNames["armorco_orcone_rocket"].id] = true,
+}
+
 local radarWobblePenalty = {
-	[WeaponDefNames["armmerl_cortruck_rocket"].id] = 5,
-	[WeaponDefNames["reef_armmship_rocket"].id] = 5,
+	[WeaponDefNames["armmerl_cortruck_rocket"].id] = 100,
+	[WeaponDefNames["reef_armmship_rocket"].id] = 100,
+	[WeaponDefNames["armorco_orcone_rocket"].id] = 5,
 	[WeaponDefNames["armsnipe_shockrifle"].id] = 5,
 	[WeaponDefNames["armanni_ata"].id] = 5,
 	[WeaponDefNames["armmanni_ata"].id] = 5,
@@ -244,6 +257,8 @@ for uid = 1, #UnitDefs do
 	for wid = 1, #WeaponDefs do
 		if unitIsUnarmed[uid] then
 			targetTable[uid][wid] = unitHealthRatio[uid] + 35
+		elseif unitIsClaw[uid] then
+			targetTable[uid][wid] = unitHealthRatio[uid] + 1000
 		elseif (unitIsFighterOrDrone[uid])
 			or (weaponBadCats[wid].fastStuff and unitIsTooFastToHit[uid])
 			or (weaponBadCats[wid].fixedwing and unitIsFixedwing[uid])
@@ -269,4 +284,4 @@ for uid = 1, #UnitDefs do
 	end
 end
 
-return targetTable, captureWeaponDefs, gravityWeaponDefs, proximityWeaponDefs, radarWobblePenalty, transportMult
+return targetTable, captureWeaponDefs, gravityWeaponDefs, proximityWeaponDefs, starburstWeaponDefs, radarWobblePenalty, transportMult

--- a/LuaRules/Gadgets/unit_overkill_prevention.lua
+++ b/LuaRules/Gadgets/unit_overkill_prevention.lua
@@ -77,6 +77,8 @@ local HandledUnitDefIDs = {
 	-- Static only OKP below
 	[UnitDefNames["amphfloater"].id] = true,
 	[UnitDefNames["armmerl"].id] = true,
+	[UnitDefNames["reef"].id] = true,
+	[UnitDefNames["armorco"].id] = true,
 	[UnitDefNames["corstorm"].id] = true,
 	[UnitDefNames["corthud"].id] = true,
 	[UnitDefNames["spiderassault"].id] = true,
@@ -122,7 +124,7 @@ function GG.OverkillPrevention_IsDisarmExpected(targetID)
 	return false
 end
 
-local function IsUnitIdentifiedStructure(identified, unitID)
+local function IsUnitIdentifiedStructure(identified, inLOS, unitID)
 	if not identified then
 		return false
 	end
@@ -130,7 +132,21 @@ local function IsUnitIdentifiedStructure(identified, unitID)
 	if not (unitDefID and UnitDefs[unitDefID]) then
 		return false
 	end
-	return not Spring.Utilities.getMovetype(UnitDefs[unitDefID])
+	
+	if (Spring.Utilities.getMovetype(UnitDefs[unitDefID])) then
+		--for units
+		if (inLOS) then
+			local vx, vy, vz, vl = Spring.GetUnitVelocity(unitID)
+			local isNotMoving = (vx == 0 and vy == 0 and vz == 0 and vl == 0)
+			if isNotMoving then
+				return true
+			end
+		end
+		return false
+	else
+		--for buildings
+		return true
+	end
 end
 
 --[[
@@ -165,7 +181,7 @@ local function CheckBlockCommon(unitID, targetID, gameFrame, fullDamage, disarmD
 	local addToIncomingDamage = true
 	
 	if staticOnly then
-		addToIncomingDamage = IsUnitIdentifiedStructure(targetIdentified, targetID)
+		addToIncomingDamage = IsUnitIdentifiedStructure(targetIdentified, targetInLoS, targetID)
 	end
 	
 	local adjHealth, disarmFrame

--- a/LuaRules/Gadgets/unit_target_priority.lua
+++ b/LuaRules/Gadgets/unit_target_priority.lua
@@ -31,7 +31,7 @@ local spGetAllUnits = Spring.GetAllUnits
 local spGetUnitRulesParam = Spring.GetUnitRulesParam
 local spGetUnitSeparation = Spring.GetUnitSeparation
 
-local targetTable, captureWeaponDefs, gravityWeaponDefs, proximityWeaponDefs, radarWobblePenalty, transportMult = 
+local targetTable, captureWeaponDefs, gravityWeaponDefs, proximityWeaponDefs, starburstWeaponDefs, radarWobblePenalty, transportMult = 
 	include("LuaRules/Configs/target_priority_defs.lua")
 
 -- Low return number = more worthwhile target
@@ -221,6 +221,18 @@ function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerW
 		local unitSeparation = spGetUnitSeparation(unitID,targetID,true)
 		local distAdd = 20 * (unitSeparation/WeaponDefs[attackerWeaponDefID].range)
 		return true, hpAdd + defPrio + distAdd
+	end
+	
+	--// Starburst weapon handling (cruise missiles).
+	-- De-prioritize moving units.
+	if starburstWeaponDefs[attackerWeaponDefID] then
+		local velAdd = 0
+		local vx, vy, vz, vl = Spring.GetUnitVelocity(targetID)
+		if (vx > 0 or vy > 0 or vz > 0 or vl > 0) then
+			velAdd = 30 * vl
+			return false, hpAdd + defPrio + velAdd
+		end
+		return true, hpAdd + defPrio + velAdd
 	end
 	
 	--// All weapons without special handling.

--- a/scripts/armorco.lua
+++ b/scripts/armorco.lua
@@ -241,6 +241,21 @@ function script.Shot(num)
 	end
 end
 
+function script.BlockShot(num, targetID)
+	if not targetID then
+		return false
+	end
+	if GG.DontFireRadar_CheckBlock(unitID, targetID) then
+		return true
+	end
+	-- Seperation check is not required as the physics of the missile seems to result in a
+	-- time to impact of between 140 and 150 frames in almost all cases.
+	if GG.OverkillPrevention_CheckBlock(unitID, targetID, 800.1, 150, false, false, true) then
+		return true
+	end
+	return false
+end
+
 function script.Killed(recentDamage, maxHealth)
 	local severity = recentDamage / maxHealth
 	if (severity <= .5) then

--- a/scripts/reef.lua
+++ b/scripts/reef.lua
@@ -168,6 +168,21 @@ local function ExplodeBay(piece)
 	EmitSfx(piece, 1024)
 end
 
+function script.BlockShot(num, targetID)
+	if not targetID then
+		return false
+	end
+	if GG.DontFireRadar_CheckBlock(unitID, targetID) then
+		return true
+	end
+	-- Seperation check is not required as the physics of the missile seems to result in a
+	-- time to impact of between 140 and 150 frames in almost all cases.
+	if GG.OverkillPrevention_CheckBlock(unitID, targetID, 800.1, 150, false, false, true) then
+		return true
+	end
+	return false
+end
+
 function script.Killed(recentDamage, maxHealth)
 	local severity = recentDamage / maxHealth
 	if severity <= 0.50 then


### PR DESCRIPTION
-OKP vs statics now applies to mobile units that are not moving.
-Impaler, Reef, Detri rockets now disfavor targeting moving units.
-Reef and detri rockets gain OKP vs statics.
-Increased skirmish leeway for impaler so they get closer to targets (and get more targets to choose from).