### PR TITLE
Comm LG tweaks

### DIFF
--- a/gamedata/modularcomms/weapons/lightninggun.lua
+++ b/gamedata/modularcomms/weapons/lightninggun.lua
@@ -19,7 +19,7 @@ local weaponDef = {
 	cylinderTargeting       = 0,
 
 	damage                  = {
-		default = 640,
+		default = 550,
 	},
 
 	explosionGenerator      = [[custom:LIGHTNINGPLOSION]],
@@ -32,7 +32,7 @@ local weaponDef = {
 	paralyzer               = true,
 	paralyzeTime            = 1,
 	range                   = 300,
-	reloadtime              = 1 + 25/30,
+	reloadtime              = 1 + 20/30,
 	rgbColor                = [[0.5 0.5 1]],
 	soundStart              = [[weapon/more_lightning_fast]],
 	soundTrigger            = true,

--- a/gamedata/modularcomms/weapons/lightninggun_improved.lua
+++ b/gamedata/modularcomms/weapons/lightninggun_improved.lua
@@ -19,7 +19,7 @@ local weaponDef = {
 	cylinderTargeting       = 0,
 
 	damage                  = {
-		default = 960,
+		default = 825,
 	},
 
 	explosionGenerator      = [[custom:LIGHTNINGPLOSION]],
@@ -32,7 +32,7 @@ local weaponDef = {
 	paralyzer               = true,
 	paralyzeTime            = 3,
 	range                   = 300,
-	reloadtime              = 1 + 25/30,
+	reloadtime              = 1 + 20/30,
 	rgbColor                = [[0.65 0.65 1]],
 	soundStart              = [[weapon/more_lightning_fast]],
 	soundTrigger            = true,


### PR DESCRIPTION
 * damage 256+640=896 -> 220+550=770 (EMP with flux module accordingly +960 -> +825)
 * reload 1.83 -> 1.66

This has two main effects:
 * Bandit no longer 1-shot. LG feels like a no-brainer against the shieldbot factory since not only is EMP good against shields in general but more importantly Bandit gets 1-shot with almost no overkill.
 * Units around 800 health (eg LLT, Warrior, Banshee) no longer stunned on the first shot. These are fairly common and LG handles them way better than the alternatives.

Derived stats:
 * DPS 140/350 -> 132/330
 * stun uptime 55% -> 60% (duration is 1s)

So against an imaginary target the weapon's power gets slightly shifted away from the period before fully stunned and towards the stun itself.