### PR TITLE
WIP: replace annoying laser meltage groundflash with heatray-like airflash

### DIFF
--- a/effects/beam.lua
+++ b/effects/beam.lua
@@ -472,16 +472,16 @@ local cegs = {
 
   ["beamweapon_hit_red"] = {
     usedefaultexplosions = false,
-    groundflash = {
-      circlealpha        = 1,
-      circlegrowth       = 0.125,
-      flashalpha         = 0.5,
-      flashsize          = 4,
-      ttl                = 32,
-      color = {
-        [1]  = 1,
-        [2]  = 0.5,
-        [3]  = 0,
+    meltage = {
+      air                = true,
+      class              = [[CExpGenSpawner]],
+      count              = 1,
+      ground             = true,
+      water              = true,
+      properties = {
+        delay              = 0,
+        explosiongenerator = [[custom:LASERS_MELT2]],
+        pos                = [[0, 0, 0]],
       },
     },
     pikes = {
@@ -568,16 +568,16 @@ local cegs = {
 
   ["beamweapon_hit_orange"] = {
     usedefaultexplosions = false,
-    groundflash = {
-      circlealpha        = 1,
-      circlegrowth       = 0.08,
-      flashalpha         = 0.5,
-      flashsize          = 4,
-      ttl                = 48,
-      color = {
-        [1]  = 1,
-        [2]  = 0.5,
-        [3]  = 0,
+    meltage = {
+      air                = true,
+      class              = [[CExpGenSpawner]],
+      count              = 1,
+      ground             = true,
+      water              = true,
+      properties = {
+        delay              = 0,
+        explosiongenerator = [[custom:LASERS_MELT2]],
+        pos                = [[0, 0, 0]],
       },
     },
     pikes = {
@@ -664,16 +664,16 @@ local cegs = {
   
   ["beamweapon_hit_purple"] = {
     usedefaultexplosions = false,
-    groundflash = {
-      circlealpha        = 1,
-      circlegrowth       = 0.125,
-      flashalpha         = 0.5,
-      flashsize          = 8,
-      ttl                = 64,
-      color = {
-        [1]  = 1,
-        [2]  = 0.2,
-        [3]  = 1,
+    meltage = {
+      air                = true,
+      class              = [[CExpGenSpawner]],
+      count              = 1,
+      ground             = true,
+      water              = true,
+      properties = {
+        delay              = 0,
+        explosiongenerator = [[custom:LASERS_MELT2]],
+        pos                = [[0, 0, 0]],
       },
     },
     pikes = {
@@ -732,16 +732,16 @@ local cegs = {
 
   ["beamweapon_hit_teal"] = {
     usedefaultexplosions = false,
-    groundflash = {
-      circlealpha        = 1,
-      circlegrowth       = 0.125,
-      flashalpha         = 0.5,
-      flashsize          = 8,
-      ttl                = 64,
-      color = {
-        [1]  = 0,
-        [2]  = 0.4,
-        [3]  = 0.8,
+    meltage = {
+      air                = true,
+      class              = [[CExpGenSpawner]],
+      count              = 1,
+      ground             = true,
+      water              = true,
+      properties = {
+        delay              = 0,
+        explosiongenerator = [[custom:LASERS_MELT2]],
+        pos                = [[0, 0, 0]],
       },
     },
     pikes = {

--- a/effects/lasers.lua
+++ b/effects/lasers.lua
@@ -455,20 +455,8 @@ return {
 
   ["flash1blue"] = {
     usedefaultexplosions = false,
-    groundflash = {
-      circlealpha        = 0,
-      circlegrowth       = 0,
-      flashalpha         = 1,
-      flashsize          = 20,
-      ttl                = 3,
-      color = {
-        [1]  = 0,
-        [2]  = 0,
-        [3]  = 1,
-      },
-    },
     meltage = {
-      air                = true,
+      air                = false,
       class              = [[CExpGenSpawner]],
       count              = 1,
       ground             = true,
@@ -884,16 +872,22 @@ return {
   },
 
   ["lasers_melt2"] = {
-    groundflash = {
-      circlealpha        = 1,
-      circlegrowth       = -0.02,
-      flashalpha         = 0.6,
-      flashsize          = 6,
-      ttl                = 80,
-      color = {
-        [1]  = 1,
-        [2]  = 0.5,
-        [3]  = 0,
+    cinder = {
+      air                = true,
+      class              = [[heatcloud]],
+      count              = 1,
+      ground             = true,
+      water              = true,
+      properties = {
+        alwaysvisible      = false,
+        heat               = [[d1 5]],
+        heatfalloff        = 0.1,
+        maxheat            = 15,
+        pos                = 0,
+        size               = [[5]],
+        sizegrowth         = -0.05,
+        speed              = [[0, 0, 0]],
+        texture            = [[redexplo]],
       },
     },
   },


### PR DESCRIPTION
In current stable ZK, a Lotus or a Bandit shooting at a solar will generate a flat ground flash under the projectile's impact point (shifted a significant distance vertically!).

This is obsolete and unnecessary because we now have actual flashes from dynamic lighting (even though they could extend to explosions as well as to projectiles).

Also i hate groundflashes.

The meltage effect, however, is pretty, especially when it doesn't snap  to ground. This attempts to reproduce the effect using heatcloud particles. This extends to all or nearly all lasers and lasercannons in ZK.

This is a WIP thing. Stuff left to do:
- Color variations instead of uniform orange
- Find unaffected lasers, and affect them.
