### PR TITLE
Add smart bombers widget.

### DIFF
--- a/LuaRules/Gadgets/unit_bomber_command.lua
+++ b/LuaRules/Gadgets/unit_bomber_command.lua
@@ -317,6 +317,11 @@ local function RequestRearm(unitID, team, forceNow, replaceExisting)
 			return false
 		end
 	end
+	-- remove fight orders if the bomber is not set to repeat (otherwise fight commands will behave like they're on repeat)
+	local _,_, rpstate, _,_,_,_,_,_ = Spring.GetUnitStates(unitID)
+	if not rpstate then
+		spGiveOrderToUnit(unitID, CMD.REMOVE, {CMD.FIGHT}, {"alt"})
+	end
 	--Spring.Echo(unitID.." requesting rearm")
 	local detectedRearm = false
 	local queue = spGetCommandQueue(unitID, -1) or emptyTable

--- a/LuaUI/Widgets/unit_smart_bombers.lua
+++ b/LuaUI/Widgets/unit_smart_bombers.lua
@@ -1,0 +1,131 @@
+-- $Id: cmd_unit_mover.lua 3171 2008-11-06 09:06:29Z det $
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+--
+--  file:    cmd_unit_mover.lua
+--  brief:   Allows combat engineers to use repeat when building mobile units (use 2 or more build spots)
+--  author:  Owen Martindell
+--
+--  Copyright (C) 2007.
+--  Licensed under the terms of the GNU GPL, v2 or later.
+--
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function widget:GetInfo()
+  return {
+    name      = "Smart Bombers",
+    desc      = "Automatically sets bombers to fire at will when following fight or patrol orders, and hold fire otherwise.",
+    author    = "aeonios",
+    date      = "Nov, 2016",
+    license   = "GNU GPL, v2 or later",
+    layer     = 0,
+    enabled   = true  --  loaded by default?
+  }
+end
+
+--------------------------------------------------------------------------------
+
+local spGetCommandQueue = Spring.GetCommandQueue
+local GetPlayerInfo = Spring.GetPlayerInfo
+local GetUnitPosition = Spring.GetUnitPosition
+local GiveOrderToUnit = Spring.GiveOrderToUnit
+local myTeamID = Spring.GetMyTeamID()
+local Echo = Spring.Echo
+
+--------------------------------------------------------------------------------
+
+local fightingBombers = {}
+local reservedBombers = {}
+local myID
+
+local function checkSpec()
+  local _, _, spec = GetPlayerInfo(myID)
+  if spec then
+	Echo("Spectating: Widget Removed")
+    widgetHandler:RemoveWidget()
+  end
+end
+
+--	Borrowed this from CarRepairer's Retreat.  Returns only first command in queue.
+function GetFirstCommand(unitID)
+	local queue = spGetCommandQueue(unitID, 1)
+	return queue[1]
+end
+
+function widget:Initialize()
+	myID = Spring.GetMyPlayerID()
+	checkSpec()
+end
+
+function widget:GameFrame(frame)
+	if frame % 15 == 0 then
+		checkSpec()
+		checkBombers()
+	end
+end
+
+function widget:UnitFinished(unitID, unitDefID, unitTeam)
+	if (unitTeam ~= myTeamID) then
+		return
+	end
+	CheckUnit(unitID, unitDefID)
+end
+
+function widget:UnitTaken(unitID, unitDefID, oldTeam, newTeam)
+	if newTeam == myTeamID then
+		CheckUnit(unitID, unitDefID)
+	end
+end
+
+function CheckUnit(unitID, unitDefID)
+	local ud = UnitDefs[unitDefID]
+	if (ud and (ud.name == "corshad" or ud.name == "corhurc2" or ud.name == "armstiletto_laser" or ud.name == "armcybr")) then
+		local cmd = GetFirstCommand(unitID)
+		if cmd and (cmd.id == 16 or cmd.id == 15) then
+			GiveOrderToUnit(unitID, 45, {2}, {""})
+			fightingBombers[unitID] = true
+		else
+			GiveOrderToUnit(unitID, 45, {0}, {""})
+			reservedBombers[unitID] = true
+		end
+	end
+end
+
+function checkBombers()
+	for unitID, _ in pairs(fightingBombers) do
+	-- clean dead or captured bombers
+		if (not Spring.ValidUnitID(unitID) or Spring.GetUnitTeam(unitID) ~= myTeamID) then
+			fightingBombers[unitID] = nil
+		else
+		-- swap bombers whose commands have changed and update their firestate
+			local cmd = GetFirstCommand(unitID)
+			if cmd and (cmd.id == 16 or cmd.id == 15) then
+				-- do nothing
+			else
+				GiveOrderToUnit(unitID, 45, {0}, {""})
+				fightingBombers[unitID] = nil
+				reservedBombers[unitID] = true
+			end
+		end
+	end
+	
+	for unitID, _ in pairs(reservedBombers) do
+	-- clean dead or captured bombers
+		if (not Spring.ValidUnitID(unitID) or Spring.GetUnitTeam(unitID) ~= myTeamID) then
+			reservedBombers[unitID] = nil
+		else
+		-- swap bombers whose commands have changed and update their firestate
+			local cmd = GetFirstCommand(unitID)
+			if cmd and (cmd.id == 16 or cmd.id == 15) then
+				GiveOrderToUnit(unitID, 45, {2}, {""})
+				fightingBombers[unitID] = true
+				reservedBombers[unitID] = nil
+			else
+				-- do nothing
+			end
+		end
+	end
+end
+
+--------------------------------------------------------------------------------

--- a/LuaUI/Widgets/unit_smart_bombers.lua
+++ b/LuaUI/Widgets/unit_smart_bombers.lua
@@ -19,20 +19,19 @@ end
 --------------------------------------------------------------------------------
 
 local spGetCommandQueue = Spring.GetCommandQueue
-local GetPlayerInfo = Spring.GetPlayerInfo
-local GetUnitPosition = Spring.GetUnitPosition
-local GiveOrderToUnit = Spring.GiveOrderToUnit
+local spGetPlayerInfo = Spring.GetPlayerInfo
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local myTeamID = Spring.GetMyTeamID()
 local Echo = Spring.Echo
-
---------------------------------------------------------------------------------
 
 local fightingBombers = {}
 local reservedBombers = {}
 local myID
 
+--------------------------------------------------------------------------------
+
 local function checkSpec()
-  local _, _, spec = GetPlayerInfo(myID)
+  local _, _, spec = spGetPlayerInfo(myID)
   if spec then
 	Echo("Spectating: Widget Removed")
     widgetHandler:RemoveWidget()
@@ -50,9 +49,12 @@ function widget:Initialize()
 	checkSpec()
 end
 
+function widget:PlayerChanged(playerID)
+	checkSpec()
+end
+
 function widget:GameFrame(frame)
 	if frame % 15 == 0 then
-		checkSpec()
 		checkBombers()
 	end
 end
@@ -74,11 +76,11 @@ function CheckUnit(unitID, unitDefID)
 	local ud = UnitDefs[unitDefID]
 	if (ud and (ud.name == "corshad" or ud.name == "corhurc2" or ud.name == "armstiletto_laser" or ud.name == "armcybr")) then
 		local cmd = GetFirstCommand(unitID)
-		if cmd and (cmd.id == 16 or cmd.id == 15) then
-			GiveOrderToUnit(unitID, 45, {2}, {""})
+		if cmd and (cmd.id == CMD.FIGHT or cmd.id == CMD.PATROL) then
+			spGiveOrderToUnit(unitID, CMD.FIRE_STATE, {2}, {""}) -- fire at will
 			fightingBombers[unitID] = true
 		else
-			GiveOrderToUnit(unitID, 45, {0}, {""})
+			spGiveOrderToUnit(unitID, CMD.FIRE_STATE, {0}, {""}) -- hold fire
 			reservedBombers[unitID] = true
 		end
 	end
@@ -92,10 +94,10 @@ function checkBombers()
 		else
 		-- swap bombers whose commands have changed and update their firestate
 			local cmd = GetFirstCommand(unitID)
-			if cmd and (cmd.id == 16 or cmd.id == 15) then
+			if cmd and (cmd.id == CMD.FIGHT or cmd.id == CMD.PATROL) then
 				-- do nothing
 			else
-				GiveOrderToUnit(unitID, 45, {0}, {""})
+				spGiveOrderToUnit(unitID, CMD.FIRE_STATE, {0}, {""})
 				fightingBombers[unitID] = nil
 				reservedBombers[unitID] = true
 			end
@@ -109,8 +111,8 @@ function checkBombers()
 		else
 		-- swap bombers whose commands have changed and update their firestate
 			local cmd = GetFirstCommand(unitID)
-			if cmd and (cmd.id == 16 or cmd.id == 15) then
-				GiveOrderToUnit(unitID, 45, {2}, {""})
+			if cmd and (cmd.id == CMD.FIGHT or cmd.id == CMD.PATROL) then
+				spGiveOrderToUnit(unitID, CMD.FIRE_STATE, {2}, {""})
 				fightingBombers[unitID] = true
 				reservedBombers[unitID] = nil
 			else

--- a/LuaUI/Widgets/unit_smart_bombers.lua
+++ b/LuaUI/Widgets/unit_smart_bombers.lua
@@ -1,12 +1,4 @@
--- $Id: cmd_unit_mover.lua 3171 2008-11-06 09:06:29Z det $
---------------------------------------------------------------------------------
---------------------------------------------------------------------------------
---
---  file:    cmd_unit_mover.lua
---  brief:   Allows combat engineers to use repeat when building mobile units (use 2 or more build spots)
---  author:  Owen Martindell
---
---  Copyright (C) 2007.
+--  Copyright (C) 2016.
 --  Licensed under the terms of the GNU GPL, v2 or later.
 --
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The widget itself is very simple and has no settings. It detect what orders your bombers (raven, phoenix, tbird, wyvern) are currently following and if they're following fight or patrol orders it sets them to fire at will, and to hold fire otherwise. The idea is to make bombers easier and more intuitive to control.

The only issue it has is that bombers that have been given a fight command keep it persistently after the bomber drops its bombs, which can lead to unexpected behavior/suicide. (on the other hand that's not something this widget does, just something that it could potentially fix)

EDIT: I actually had to modify the bomber command gadget because otherwise it would override anything I tried to do with the widget. Now bombers will no longer treat fight orders as being on repeat unless the bomber is actually set to repeat orders.