### PR TITLE
-Add okp vs statics for ravens.

### DIFF
--- a/LuaRules/Gadgets/unit_overkill_prevention.lua
+++ b/LuaRules/Gadgets/unit_overkill_prevention.lua
@@ -74,6 +74,7 @@ local HandledUnitDefIDs = {
 	[UnitDefNames["cormist"].id] = true,
 	[UnitDefNames["tawf114"].id] = true, --HT's banisher
 	[UnitDefNames["shieldarty"].id] = true, --Shields's racketeer
+	[UnitDefNames["corshad"].id] = true,
 	-- Static only OKP below
 	[UnitDefNames["amphfloater"].id] = true,
 	[UnitDefNames["armmerl"].id] = true,

--- a/scripts/corshad.lua
+++ b/scripts/corshad.lua
@@ -189,6 +189,9 @@ function script.BlockShot(num, targetID)
 		Move(drop, z_axis, dz)
 		dy = math.max(dy, -30)
 		Move(drop, y_axis, dy)
+		if GG.OverkillPrevention_CheckBlock(unitID, targetID, 800.1, 120, false, false, true) then
+			return true
+		end
 		return false
 	end
 	return true


### PR DESCRIPTION
This only partially improves raven usability, but I don't know how to control unit chase behavior or if it's even possible with the current engine. OKP is still necessary to keep ravens from overkilling during a flyby even if they're targeting something else, so either way.