### PR TITLE
API-ified some widgets which should trivially not be disabled.

### DIFF
--- a/LuaUI/Widgets/api_chili_docking.lua
+++ b/LuaUI/Widgets/api_chili_docking.lua
@@ -10,7 +10,9 @@ function widget:GetInfo()
     layer     = 50,
     experimental = false,
     handler   = true, -- to read widget status. eg: "widgetHandler.knownWidgets[name]"
-    enabled   = true  --  loaded by default?
+    enabled   = true,  --  loaded by default?
+    alwaysStart = true,
+	hidden    = true,
   }
 end
 

--- a/LuaUI/Widgets/api_chili_widgetselector.lua
+++ b/LuaUI/Widgets/api_chili_widgetselector.lua
@@ -10,6 +10,7 @@ function widget:GetInfo()
     experimental = false,	
     enabled   = true,
 	alwaysStart = true,
+	hidden    = true,
   }
 end
 

--- a/LuaUI/Widgets/api_gadget_icons.lua
+++ b/LuaUI/Widgets/api_gadget_icons.lua
@@ -10,6 +10,8 @@ function widget:GetInfo()
     license   = "GNU GPL, v2 or later",
     layer     = 5,
     enabled   = true,
+    alwaysStart = true,
+	hidden    = true,
   }
 end
 

--- a/LuaUI/Widgets/api_mexspot_fetcher.lua
+++ b/LuaUI/Widgets/api_mexspot_fetcher.lua
@@ -7,7 +7,9 @@ function widget:GetInfo()
     date      = "22 April 2012",
     license   = "GNU GPL, v2 or later",
     layer     = -30000,
-    enabled   = true  --  loaded by default?
+    enabled   = true,  --  loaded by default?
+    alwaysStart = true,
+	hidden    = true,
   }
 end
 

--- a/LuaUI/Widgets/api_selectionsend.lua
+++ b/LuaUI/Widgets/api_selectionsend.lua
@@ -9,7 +9,9 @@ function widget:GetInfo()
     date      = "2009-4-27",
     license   = "GNU GPL, v2 or later",
     layer     = 5,
-    enabled   = true  --  loaded by default?
+    enabled   = true,  --  loaded by default?
+    alwaysStart = true,
+	hidden    = true,
   }
 end
 


### PR DESCRIPTION
-Chili docking, because most of chili depends on/uses it so it behaves like an api.
-The widget selector widget, because if you turn it off you can't turn it back on.
-The gadget icon drawer, because it serves gadgets which are not optional.
-Mex spot fetcher, because it only bridges synced and unsynced for other widgets and depends on the synced api. (like api_startboxes)
-Selection send, because turning it off will prevent other players/replays from receiving information that they normally would always receive, while conversely it has no effect on the person actually running it.