### PR TITLE
Modoption primarily for testing different raid defense building ranges

### DIFF
--- a/ModOptions.lua
+++ b/ModOptions.lua
@@ -389,6 +389,18 @@ local options = {
     max    = 10000,
     step   = 0.05,
   },
+    {
+    key    = 'raidDefenseBuildingRangeMult',
+    name   = 'Range Multiplier for Raid-Damaging Buildings',
+    desc   = 'Multiplies the ranges of all buildings that are able to directly damage ground-based raids, excluding ' ..
+    'superweapons, nuclear weapons and the missile silo.',
+    type   = 'number',
+    section= 'experimental',
+    def    = 1,
+    min    = 0,
+    max    = 100000,
+    step   = 0.05,
+  },
   {
     key    = 'defeatmode',
     name   = 'Defeat Mode',

--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -819,6 +819,38 @@ end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+-- Raid defense building range multiplier modoption
+-- 
+
+
+local raidDefenseBuildings = {}
+
+local raidDefenseBuildingStrings = {"corrl", "corllt", "armdeva", "armartic", "armpb", "corhlt", "corgrav", "turrettorp", 
+"cordoom", "armanni"}
+
+for i = 1, #raidDefenseBuildingStrings do
+    raidDefenseBuildings[raidDefenseBuildingStrings[i]] = true
+end
+
+if modOptions and modOptions.raidDefenseBuildingRangeMult and modOptions.raidDefenseBuildingRangeMult ~= 1 then
+    local defenseMult = modOptions.raidDefenseBuildingRangeMult
+    Spring.Echo("Multiplying raid defense building ranges by " .. defenseMult)
+    for unitDefID, unitDef in pairs(UnitDefs) do
+        if unitDef.weapons and unitDef.weapondefs and raidDefenseBuildings[unitDef.unitname] then
+            for defName, def in pairs(unitDef.weapondefs) do
+                if def.range then
+                    Spring.Echo("Multiplying the range of the " .. unitDef.name .. " weapon \"" .. def.name .. 
+                    "\" by " .. defenseMult)
+                    def.range = math.max(def.range*defenseMult, 1)
+                end
+            end
+        end
+    end
+end
+
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 -- Remove Restore
 -- 
 

--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -834,13 +834,13 @@ end
 
 if modOptions and modOptions.raidDefenseBuildingRangeMult and modOptions.raidDefenseBuildingRangeMult ~= 1 then
     local defenseMult = modOptions.raidDefenseBuildingRangeMult
-    Spring.Echo("Multiplying raid defense building ranges by " .. defenseMult)
+    --Spring.Echo("Multiplying raid defense building ranges by " .. defenseMult)
     for unitDefID, unitDef in pairs(UnitDefs) do
         if unitDef.weapons and unitDef.weapondefs and raidDefenseBuildings[unitDef.unitname] then
             for defName, def in pairs(unitDef.weapondefs) do
                 if def.range then
-                    Spring.Echo("Multiplying the range of the " .. unitDef.name .. " weapon \"" .. def.name .. 
-                    "\" by " .. defenseMult)
+                    --Spring.Echo("Multiplying the range of the " .. unitDef.name .. " weapon \"" .. def.name .. 
+                    --"\" by " .. defenseMult)
                     def.range = math.max(def.range*defenseMult, 1)
                 end
             end

--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -826,7 +826,7 @@ end
 local raidDefenseBuildings = {}
 
 local raidDefenseBuildingStrings = {"corrl", "corllt", "armdeva", "armartic", "armpb", "corhlt", "corgrav", "turrettorp", 
-"cordoom", "armanni"}
+"cordoom", "armanni", "corbhmth"}
 
 for i = 1, #raidDefenseBuildingStrings do
     raidDefenseBuildings[raidDefenseBuildingStrings[i]] = true


### PR DESCRIPTION
All relevant buildings except for the Big Bertha, the superweapons, the missile  silo and the nuclear silo are affected. Additionally, the modoption only affects structures that can directly damage ground-based raids. That is, it doesn't do anything to things that can merely harm raiding. Ranges are multiplied by the modoption value but they cannot go below 1. The exact units the modoption touches are the Defender, the Lotus, the Stardust, the Gauss, the Faraday, the Stinger, the Newton, the Urchin, the Doomsday Machine, the Annihilator and the Behemoth.