### PR TITLE
Trees no longer autoreclaimed

### DIFF
--- a/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
+++ b/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
@@ -1471,6 +1471,7 @@ local function GetResources(tooltip_type, unitID, ud)
 		if unitID then
 			local m, _, e, _, _ = Spring.GetFeatureResources(unitID)
 			metal = m or metal
+			if (metal < 1) then metal = 0 end
 			energy =  e or energy
 		end
 	else --tooltip_type == 'unit' or 'selunit'

--- a/LuaUI/Widgets/gui_metal_features.lua
+++ b/LuaUI/Widgets/gui_metal_features.lua
@@ -51,7 +51,7 @@ local function DrawWorldFunc()
   local features = Spring.GetVisibleFeatures()
   for _, fID in pairs(features) do
     local metal = Spring.GetFeatureResources(fID)
-    if (metal and (metal > 0)) then
+    if (metal and (metal > 1)) then
       -- local aTeam = Spring.GetFeatureAllyTeam(fID)
       -- if (aTeam ~= myAllyTeam) then
         local x100  = 100  / (100  + metal)

--- a/LuaUI/Widgets/unit_tree_reclaim.lua
+++ b/LuaUI/Widgets/unit_tree_reclaim.lua
@@ -1,0 +1,22 @@
+function widget:GetInfo() return {
+	name = "Area-reclaim trees",
+	desc = "Area-reclaim will also eat trees if the order is centered on a tree",
+	layer = -1337, -- before insert
+	enabled = true,
+} end
+
+function widget:CommandNotify(id, params, options)
+	if id ~= CMD.RECLAIM or #params ~= 4 then return end
+
+	local targetType, targetID = Spring.TraceScreenRay(Spring.WorldToScreenCoords(params[1], params[2], params[3]))
+
+	if (targetType ~= "feature") then return end
+	local fd = FeatureDefs[Spring.GetFeatureDefID(targetID)]
+	if not fd.reclaimable or fd.autoreclaim then return end
+
+	options.ctrl = true
+	if not WG.CommandInsert or not WG.CommandInsert(id, params, options) then
+		Spring.GiveOrder(id, params, options)
+	end
+	return true
+end

--- a/gamedata/featuredefs_post.lua
+++ b/gamedata/featuredefs_post.lua
@@ -181,6 +181,10 @@ for name, def in pairs(FeatureDefs) do
 	if def.resurrectable ~= 1 then
 		def.resurrectable = 0
 	end
+	if not def.metal or def.metal == 0 then
+		def.metal = 0.001 -- engine deprioritises things with 0m in force-reclaim mode
+		def.autoreclaimable = false
+	end
 end
  
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Trees are only reclaimed if:
 * the center of the command is a tree, OR
 * CTRL is held and the center is not a unit.

There's a technical hax that makes trees worth 0.001 metal because else Spring disprioritises them.

Trees tend to live in wide forests or on the map edge a decoration. In both cases there's a fair amount of walking for a con with trees in its area reclaim command. Meanwhile Energy is abundant so it is wasted. This patch makes trees not reclaimed by default but still leaves ways to reclaim them if need be.

Compared to #1506 (not the recent PR but the one before that was merged and reverted) the feedback is implemented:
 * right-click and drag a tree reclaims trees,
 * trees are not deprioritised in the tree-reclaim mode
 * feedback related to force-reclaiming own units implemented separately (trees are a different issue), directly to the repo (because the existing behaviour was outright dangerous) - https://github.com/ZeroK-RTS/Zero-K/commit/379a19a14ab12a5662c20d788b06a8c8d281286d