### PR TITLE
WIP: Remove groundflash trails from heatrays.

### DIFF
--- a/effects/heatray.lua
+++ b/effects/heatray.lua
@@ -2,23 +2,6 @@
 -- heatray_hit
 
 return {
-  ["heatray_ceg"] = {
-    light = {
-      air                = true,
-      class              = [[CSimpleGroundFlash]],
-      count              = 1,
-      ground             = true,
-      water              = true,
-      properties = {
-        colormap           = [[1 0.5 0 0.03  0 0 0 0.01]],
-        size               = 80,
-        sizegrowth         = 0,
-        texture            = [[groundflash]],
-        ttl                = 5,
-      },
-    },
-  },
-
   ["heatray_hit"] = {
     usedefaultexplosions = false,
     cinder = {

--- a/gamedata/modularcomms/weapons/heatray.lua
+++ b/gamedata/modularcomms/weapons/heatray.lua
@@ -3,7 +3,6 @@ local weaponDef = {
 	name                    = [[Heat Ray]],
 	accuracy                = 512,
 	areaOfEffect            = 20,
-	cegTag                  = [[HEATRAY_CEG]],
 	coreThickness           = 0.5,
 	craterBoost             = 0,
 	craterMult              = 0,

--- a/units/cordoom.lua
+++ b/units/cordoom.lua
@@ -99,7 +99,6 @@ unitDef = {
       name                    = [[Heat Ray]],
       accuracy                = 512,
       areaOfEffect            = 20,
-      cegTag                  = [[HEATRAY_CEG]],
       coreThickness           = 0.5,
       craterBoost             = 0,
       craterMult              = 0,

--- a/units/corgator.lua
+++ b/units/corgator.lua
@@ -88,7 +88,6 @@ unitDef = {
       name                    = [[Heat Ray]],
       accuracy                = 512,
       areaOfEffect            = 20,
-      cegTag                  = [[HEATRAY_CEG]],
       coreThickness           = 0.5,
       craterBoost             = 0,
       craterMult              = 0,

--- a/units/corsumo.lua
+++ b/units/corsumo.lua
@@ -271,7 +271,6 @@ unitDef = {
       name                    = [[Heat Ray]],
       accuracy                = 512,
       areaOfEffect            = 20,
-      cegTag                  = [[HEATRAY_CEG]],
       coreThickness           = 0.5,
       craterBoost             = 0,
       craterMult              = 0,

--- a/units/dante.lua
+++ b/units/dante.lua
@@ -157,7 +157,6 @@ unitDef = {
       name                    = [[Heat Ray]],
       accuracy                = 512,
       areaOfEffect            = 20,
-      cegTag                  = [[HEATRAY_CEG]],
       coreThickness           = 0.5,
       craterBoost             = 0,
       craterMult              = 0,


### PR DESCRIPTION
This removes groundflash trails on heatrays that are used to emulate lighting, because we already have proper lighting instead, and doing double lights just causes problems with any attempts at fancier light processing (like HDR).

PR because untested blindcommit.