### PR TITLE
Made transition into bloom smoother

### DIFF
--- a/LuaUI/Widgets/Shaders/bloom_bright.fs
+++ b/LuaUI/Widgets/Shaders/bloom_bright.fs
@@ -7,11 +7,13 @@ void main(void) {
 	vec2 C0 = vec2(gl_TexCoord[0]);
 	vec3 color = vec3(texture2D(texture0, C0));
 	float illum = dot(color, vec3(0.2990, 0.5870, 0.1140));
+	vec3 luma = vec3(0.2990, 0.5870, 0.1140);
 
 	if (illum > illuminationThreshold) {
 		// tone mapping, because running blurs on HDR float textures would be expensive.
-		color = vec3(1.0) - exp(-color * 1.5);
-		color = mix(vec3(dot(color, vec3(0.299, 0.587, 0.114))), color, 1.15); // increase saturation because exponential exposure reduces it.
+		color = color - color*(illuminationThreshold/max(illum, 0.00001));
+		// color = vec3(1.0) - exp(-color * 1.5);
+		// color = mix(vec3(dot(color, vec3(0.299, 0.587, 0.114))), color, 1.15); // increase saturation because exponential exposure reduces it.
 		gl_FragColor = vec4(color, 1.0);
 	} else {
 		gl_FragColor = vec4(0.0, 0.0, 0.0, 1.0);

--- a/LuaUI/Widgets/Shaders/bloom_combine.fs
+++ b/LuaUI/Widgets/Shaders/bloom_combine.fs
@@ -4,7 +4,19 @@ uniform float fragMaxBrightness;
 uniform int useBloom;
 
 vec3 toneMapEXP(vec3 color){
-	return vec3(1.0) - exp(-color * 1.4);
+	float L = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
+	float nL = (1.0 - exp(-L * 0.7)) * 1.5;
+	float scale = nL / L;
+	return color * scale;
+	// return vec3(1.0) - exp(-color * 1.4);
+}
+
+vec3 toneMapRein(vec3 color)
+{
+	float L = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
+	float nL = (L * (1.0 + L/1.5)) / (1.0 + L);
+	float scale = nL / L;
+	return color * scale;
 }
 
 vec3 levelsControl(vec3 color, float blackPoint, float whitePoint){
@@ -27,9 +39,10 @@ void main(void) {
 	}
 
 	// tone mapping and color correction
-	hdr.rgb = toneMapEXP(hdr.rgb);
-	hdr.rgb = levelsControl(hdr.rgb, 0.15, 0.85);
-	hdr.rgb = mix(vec3(dot(hdr.rgb, vec3(0.299, 0.587, 0.114))), hdr.rgb, 1.05);
+	// hdr.rgb = toneMapEXP(hdr.rgb);
+	hdr.rgb = toneMapRein(hdr.rgb);
+	hdr.rgb = levelsControl(hdr.rgb, 0.02, 0.87);
+	hdr.rgb = mix(vec3(dot(hdr.rgb, vec3(0.299, 0.587, 0.114))), hdr.rgb, 0.94);
 
 	vec4 map = vec4(hdr.rgb, 1.0);
 					


### PR DESCRIPTION
* Also returned to Reinhard tonemapping, since it produces a more consistent look between engine-rendered LDR and projectile lights rendered HDR. Exponential tonemapping is in the shader but unused, for further testing