### PR TITLE
Fixed HDR.

### DIFF
--- a/LuaUI/Widgets/Shaders/bloom_combine.fs
+++ b/LuaUI/Widgets/Shaders/bloom_combine.fs
@@ -19,6 +19,10 @@ vec3 levelsControl(vec3 color, float blackPoint, float whitePoint){
 	return min(max(color - vec3(blackPoint), vec3(0.0)) / (vec3(whitePoint) - vec3(blackPoint)), vec3(1.0));
 }
 
+vec3 saturate(vec3 color, float saturation){
+	return mix(vec3(dot(color, vec3(0.299, 0.587, 0.114))), color, saturation);
+}
+
 void main(void) {
 	vec2 C0 = vec2(gl_TexCoord[0]);
 	vec4 hdr = bool(useBloom) ? texture2D(texture0, C0) + (texture2D(texture1, C0) * fragMaxBrightness) : texture2D(texture0, C0);
@@ -33,7 +37,6 @@ void main(void) {
 	float mx = max(hdr.r, max(hdr.g, hdr.b));
 	if (mx > whiteStart) {
 		hdr.rgb = mix(hdr.rgb, vec3(mx), (mx - whiteStart)/(((mx - whiteStart) * whiteScale) + 1.0));
-		//hdr.rgb += min(((mx - whiteStart) * whiteScale), vec3(whiteMax));
 	}
 
 	// tone mapping and color correction
@@ -43,7 +46,7 @@ void main(void) {
 	// but causes HSV shifting in the resulting color which is difficult to correct and impossible to correct completely.
 	//hdr.rgb = toneMapEXP(hdr.rgb);
 	//hdr.rgb = levelsControl(hdr.rgb, 0.15, 0.85);
-	//hdr.rgb = mix(vec3(dot(hdr.rgb, vec3(0.299, 0.587, 0.114))), hdr.rgb, 1.05);
+	//hdr.rgb = saturate(hdr.rgb, 1.05); // satuation
 
 	vec4 map = vec4(hdr.rgb, 1.0);
 					

--- a/LuaUI/Widgets/Shaders/bloom_combine.fs
+++ b/LuaUI/Widgets/Shaders/bloom_combine.fs
@@ -4,19 +4,15 @@ uniform float fragMaxBrightness;
 uniform int useBloom;
 
 vec3 toneMapEXP(vec3 color){
-	float L = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
-	float nL = (1.0 - exp(-L * 0.7)) * 1.5;
-	float scale = nL / L;
-	return color * scale;
-	// return vec3(1.0) - exp(-color * 1.4);
+	return vec3(1.0) - exp(-color * 1.4);
 }
 
-vec3 toneMapRein(vec3 color)
-{
-	float L = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
-	float nL = (L * (1.0 + L/1.5)) / (1.0 + L);
-	float scale = nL / L;
-	return color * scale;
+vec3 toneMapReinhard(vec3 color){
+	// float whitePoint = 1.0/exposure;
+	const float whitePoint = 1.0;
+	float lum = dot(color, vec3(0.2990, 0.5870, 0.1140));
+	float ilum = (lum * (1.0 + (lum/(whitePoint * whitePoint))))/(lum + 1.0);
+	return color * ilum/lum;
 }
 
 vec3 levelsControl(vec3 color, float blackPoint, float whitePoint){
@@ -32,17 +28,22 @@ void main(void) {
 	const float whiteStart = 1.0; // the minimum color intensity for starting white point transition
 	const float whiteMax = 0.85; // the maximum amount of white shifting applied
 	const float whiteScale = 10.0; // the rate at which to transition to white 
-
+	//const float whiteScale = 0.001;
+	
 	float mx = max(hdr.r, max(hdr.g, hdr.b));
 	if (mx > whiteStart) {
 		hdr.rgb = mix(hdr.rgb, vec3(mx), (mx - whiteStart)/(((mx - whiteStart) * whiteScale) + 1.0));
+		//hdr.rgb += min(((mx - whiteStart) * whiteScale), vec3(whiteMax));
 	}
 
 	// tone mapping and color correction
-	// hdr.rgb = toneMapEXP(hdr.rgb);
-	hdr.rgb = toneMapRein(hdr.rgb);
-	hdr.rgb = levelsControl(hdr.rgb, 0.02, 0.87);
-	hdr.rgb = mix(vec3(dot(hdr.rgb, vec3(0.299, 0.587, 0.114))), hdr.rgb, 0.94);
+	hdr.rgb = toneMapReinhard(hdr.rgb);
+	
+	//Experimental exponential exposure tone mapping. It produces much smoother lighting 
+	// but causes HSV shifting in the resulting color which is difficult to correct and impossible to correct completely.
+	//hdr.rgb = toneMapEXP(hdr.rgb);
+	//hdr.rgb = levelsControl(hdr.rgb, 0.15, 0.85);
+	//hdr.rgb = mix(vec3(dot(hdr.rgb, vec3(0.299, 0.587, 0.114))), hdr.rgb, 1.05);
 
 	vec4 map = vec4(hdr.rgb, 1.0);
 					

--- a/LuaUI/Widgets/Shaders/dof.fs
+++ b/LuaUI/Widgets/Shaders/dof.fs
@@ -1,0 +1,25 @@
+uniform sampler2D origTex;
+uniform sampler2D blurTex;
+uniform sampler2D mapdepths;
+
+uniform vec3 eyePos;
+uniform mat4 viewProjectionInv;
+
+void main(void) {
+	vec2 C0 = gl_TexCoord[0].st;
+	vec4 orig = texture2D(origTex, C0);
+	vec4 blur = texture2D(blurTex, C0);
+	
+	// use the depth from the terrain depth buffer because reading 2x 32 bit buffers is _insane_.
+	vec4 worldPos = vec4(vec3(gl_TexCoord[0].st, texture2D(mapdepths, C0).x) * 2.0 - 1.0, 1.0);
+	
+	// then convert to worldspace coords
+	worldPos = viewProjectionInv * worldPos;
+	worldPos.xyz = worldPos.xyz / worldPos.w;
+	
+	float dist = length(eyePos.xz - worldPos.xz);
+	float depthFactor = min(dist/(6000.0 + eyePos.y), 0.85);
+	
+	vec4 color = mix(orig, blur, depthFactor);
+	gl_FragColor = vec4(color.rgb, 1.0);
+}

--- a/LuaUI/Widgets/gfx_dof.lua
+++ b/LuaUI/Widgets/gfx_dof.lua
@@ -1,0 +1,169 @@
+function widget:GetInfo()
+	return {
+		name      = "Depth of Field Shader",
+		version	  = 1.0,
+		desc      = "Blurs far away objects.",
+		author    = "aeonios",
+		date      = "Nov. 2016",
+		license   = "GPL",
+		layer     = -1,
+		enabled   = true
+	}
+end
+
+options_path = 'Settings/Graphics/Effects/Depth of Field'
+
+options_order = {'useDoF'}
+
+options = {
+	useDoF = { type='bool', name='Apply Depth of Field Effect', value=true,	noHotkey = true, advanced = false}
+}
+
+local function onChangeFunc()
+	if options.useDoF.value then
+		widget:Initialize()
+	else
+		if glDeleteTexture then
+			glDeleteTexture(blurTex or "")
+			glDeleteTexture(screenTex or "")
+			blurTex, screenTex = nil, nil
+		end
+	end
+end
+
+options.useDoF.OnChange = onChangeFunc
+
+-----------------------------------------------------------------
+-- Engine Functions
+-----------------------------------------------------------------
+
+local spGetCameraPosition    = Spring.GetCameraPosition
+
+local glCopyToTexture        = gl.CopyToTexture
+local glCreateShader         = gl.CreateShader
+local glCreateTexture        = gl.CreateTexture
+local glDeleteShader         = gl.DeleteShader
+local glDeleteTexture        = gl.DeleteTexture
+local glGetShaderLog         = gl.GetShaderLog
+local glTexture              = gl.Texture
+local glTexRect              = gl.TexRect
+local glRenderToTexture		 = gl.RenderToTexture
+local glUseShader            = gl.UseShader
+local glGetUniformLocation   = gl.GetUniformLocation
+local glUniform				 = gl.Uniform
+local glUniformMatrix		 = gl.UniformMatrix
+
+-----------------------------------------------------------------
+
+
+-----------------------------------------------------------------
+-- Global Vars
+-----------------------------------------------------------------
+
+local vsx = nil	-- current viewport width
+local vsy = nil	-- current viewport height
+local dofShader = nil
+local screenTex = nil
+local blurTex = nil
+
+-- shader uniform handles
+local eyePosLoc = nil
+local viewProjectionInvLoc = nil
+
+-----------------------------------------------------------------
+
+function widget:ViewResize(x, y)
+	vsx, vsy = gl.GetViewSizes()
+	glDeleteTexture(blurTex or "")
+	glDeleteTexture (screenTex or "")
+	blurTex, screenTex = nil, nil
+	
+	screenTex = glCreateTexture(vsx, vsy, {
+		fbo = true, min_filter = GL.LINEAR, mag_filter = GL.LINEAR,
+		wrap_s = GL.CLAMP, wrap_t = GL.CLAMP,
+	})
+	
+	blurTex = glCreateTexture(vsx/2, vsy/2, {
+		fbo = true, min_filter = GL.LINEAR, mag_filter = GL.LINEAR,
+		wrap_s = GL.CLAMP, wrap_t = GL.CLAMP,
+	})
+	
+	if not blurTex or not screenTex then
+		Spring.Echo("Depth of Field: Failed to create textures!")
+		widgetHandler:RemoveWidget()
+		return
+	end
+end
+
+function widget:Initialize()
+	if (glCreateShader == nil) then
+		Spring.Echo("[Depth of Field::Initialize] removing widget, no shader support")
+		widgetHandler:RemoveWidget()
+		return
+	end
+	
+	if not options.useDoF.value then
+		return
+	end
+	
+	dofShader = dofShader or glCreateShader({
+		fragment = VFS.LoadFile("LuaUI\\Widgets\\Shaders\\dof.fs", VFS.ZIP),
+		
+		uniformInt = {origTex = 0, blurTex = 1, mapdepths = 2},
+	})
+	
+	if not dofShader then
+		Spring.Echo("Depth of Field: Failed to create shader!")
+		Spring.Echo(gl.GetShaderLog())
+		widgetHandler:RemoveWidget()
+		return
+	end
+	
+	eyePosLoc = gl.GetUniformLocation(dofShader, "eyePos")
+	viewProjectionInvLoc = gl.GetUniformLocation(dofShader, "viewProjectionInv")
+	
+	widget:ViewResize()
+end
+
+function widget:Shutdown()
+	if (glDeleteShader and dofShader) then
+		glDeleteShader(dofShader)
+	end
+	
+	if glDeleteTexture then
+		glDeleteTexture(blurTex or "")
+		glDeleteTexture(screenTex or "")
+	end
+	dofShader, blurTex, screenTex = nil, nil, nil
+end
+
+function widget:DrawScreenEffects()
+	if not options.useDoF.value then
+		return -- if the option is disabled don't draw anything.
+	end
+
+	gl.Blending(false)
+	glCopyToTexture(screenTex, 0, 0, 0, 0, vsx, vsy) -- the original screen image
+	
+	glTexture(screenTex)
+	glRenderToTexture(blurTex, glTexRect, -1, 1, 1, -1)
+	glTexture(false)
+	
+	local cpx, cpy, cpz = spGetCameraPosition()
+	local gmin, gmax = Spring.GetGroundExtremes()
+	local effectiveHeight = cpy - math.max(0, gmin)
+	cpy = 3.5 * math.sqrt(effectiveHeight) * math.log(effectiveHeight)
+	glUseShader(dofShader)
+		glUniform(eyePosLoc, cpx, cpy, cpz)
+		glUniformMatrix(viewProjectionInvLoc, "viewprojectioninverse")
+		glTexture(0, screenTex)
+		glTexture(1, blurTex)
+		glTexture(2, "$map_gbuffer_zvaltex")
+		
+		glTexRect(0, 0, vsx, vsy, false, true)
+		
+		glTexture(0, false)
+		glTexture(1, false)
+		glTexture(2, false)
+	glUseShader(0)
+end


### PR DESCRIPTION
Reinhard tonemapping was implemented incorrectly, and used color correction that it did not need. I added some notes so that nobody should get confused in the future.

Now there should be zero difference in color between HDR and LDR.