### PR TITLE
Unit AI: Fix tactical AI for arty

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -910,19 +910,21 @@ local behaviourConfig = {
 	},
 	
 	["armmerl"] = {
-		skirms = allGround,
+		skirms = artyRangeSkirmieeArray,
 		skirmRadar = true, 
 		swarms = {}, 
 		flees = {},
-		skirmLeeway = 400, 
+		skirmLeeway = 400,
+		skirmOnlyNearEnemyRange = 350,
 	},
 	
 	["cormart"] = {
-		skirms = allGround,
+		skirms = artyRangeSkirmieeArray,
 		skirmRadar = true,
 		swarms = {}, 
 		flees = {},
-		skirmLeeway = 50, 
+		skirmLeeway = 50,
+		skirmOnlyNearEnemyRange = 250,
 	},
 	
 	["armraven"] = {
@@ -979,11 +981,12 @@ local behaviourConfig = {
 		skirmLeeway = 150, 
 	},	
 	["armmanni"] = {
-		skirms = allGround, 
+		skirms = artyRangeSkirmieeArray, 
 		swarms = {}, 
 		flees = {},
 		skirmRadar = true,
-		skirmLeeway = 200, 
+		skirmLeeway = 200,
+		skirmOnlyNearEnemyRange = 250,
 	},	
 	["armbanth"] = {
 		skirms = allGround, 


### PR DESCRIPTION
Using skirmish AI for arty was something of an experiment, and one which did not work out particularly well. I decided to switch arty to use slasher-style flee-skirm instead of regular skirm and it seems to work much better, particularly for pillagers and penetrators which can't turn their turrets fast enough to aim while moving.