### PR TITLE
Death explosion avoidance

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -132,7 +132,6 @@ local veryShortRangeSkirmieeArray = NameToDefID({
 	"chicken_tiamat",
 	"chicken_dragon",
 	"hoverdepthcharge",
-	"armwin",
 	
 	"corgator",
 	"armflea",
@@ -219,13 +218,6 @@ local medRangeSkirmieeArray = NameToDefID({
 	"corgol",
 	"tawf114", -- banisher
 	"scorpion",
-	
-	"armfus", -- don't suicide vs fusions if possible.
-	"geo",
-	"amgeo",
-	"armestor",
-	"cafus", -- same with singu, at least to make an effort for survival.
-	"armbanth", -- banthas also have a fairly heavy but dodgeable explosion.
 	
 	"shipscout",
 	"shipassault",

--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -132,6 +132,7 @@ local veryShortRangeSkirmieeArray = NameToDefID({
 	"chicken_tiamat",
 	"chicken_dragon",
 	"hoverdepthcharge",
+	"armwin",
 	
 	"corgator",
 	"armflea",
@@ -220,6 +221,9 @@ local medRangeSkirmieeArray = NameToDefID({
 	"scorpion",
 	
 	"armfus", -- don't suicide vs fusions if possible.
+	"geo",
+	"amgeo",
+	"armestor",
 	"cafus", -- same with singu, at least to make an effort for survival.
 	"armbanth", -- banthas also have a fairly heavy but dodgeable explosion.
 	


### PR DESCRIPTION
 * very low range units (Glaive and Dart) skirm windgen (chainsplosions tend to be lethal if adjacent)
 * medium range units skirm [Adv.] Geo and Pylon (to avoid death explosion: they already skirm Fusion and Singu for that reason)