### PR TITLE
Pylon quadfield tweak

### DIFF
--- a/LuaRules/Gadgets/unit_mex_overdrive.lua
+++ b/LuaRules/Gadgets/unit_mex_overdrive.lua
@@ -58,7 +58,7 @@ local enableMexPayback = ((odSharingModOptions == "investmentreturn") or (odShar
 
 include("LuaRules/Configs/constants.lua")
 
-local QUADFIELD_SQUARE_SIZE = 0 -- set to be twice the largest pylon range (so a pylon can be in 4 quads at most)
+local QUADFIELD_SQUARE_SIZE = 0
 
 for i = 1, #UnitDefs do
 	local udef = UnitDefs[i]
@@ -84,6 +84,7 @@ for i = 1, #UnitDefs do
 		}
 	end
 end
+QUADFIELD_SQUARE_SIZE = QUADFIELD_SQUARE_SIZE * 2 -- set to be twice the largest pylon range (so a pylon can be in 4 quads at most)
 
 local alliedTrueTable = {allied = true}
 local inlosTrueTable = {inlos = true}


### PR DESCRIPTION
It would be good if @ashdnazg could look since he made the original code.
The comment implies the value should be 2x what it currently is.

However the max value is only used by the actual Pylon (at 500 elmo radius). All other structures have no more than 150 (so the "always <= 4 quads" already holds for them). They are much more common than Pylons (Solars and Winds especially) so perhaps doubling the current value would overall only do harm since it only benefits the rare Pylons. Maybe it would make more sense to set it to 2x the common max and let Pylon to be in >4 quads.

For comparison, the relevant size values:
 * 2x max except Pylon: 300
 * current value: 500
 * 2x max: 1000