### PR TITLE
Unit AI: Fix scorcher dive

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -272,6 +272,10 @@ local shortRangeExplodables = NameToDefID({
 	"armestor",
 })
 
+local scorcherExplodables = NameToDefID({
+	"armestor",
+})
+
 local medRangeExplodables = NameToDefID({
 	"armfus", -- don't suicide vs fusions if possible.
 	"geo",
@@ -290,6 +294,7 @@ end
 -- Notably, this occurs after the skirm nested union
 veryShortRangeSkirmieeArray = Union(veryShortRangeSkirmieeArray, veryShortRangeExplodables)
 
+local scorcherSkirmieeArray = Union(shortRangeSkirmieeArray, scorcherExplodables)
 shortRangeSkirmieeArray     = Union(shortRangeSkirmieeArray, shortRangeExplodables)
 riotRangeSkirmieeArray      = Union(riotRangeSkirmieeArray, shortRangeExplodables)
 
@@ -350,7 +355,7 @@ local subfleeables = NameToDefID({
 })
 
 -- Some short ranged units dive everything that they don't skirm or swarm.
-local shortRangeDiveArray = SetMinus(SetMinus(allGround, shortRangeSkirmieeArray), lowRangeSwarmieeArray)
+local shortRangeDiveArray = SetMinus(SetMinus(allGround, scorcherSkirmieeArray), lowRangeSwarmieeArray)
 
 -- waterline(defaults to 0): Water level at which the unit switches between land and sea behaviour
 -- sea: table of behaviour for sea. Note that these tables are optional.
@@ -542,7 +547,7 @@ local behaviourConfig = {
 	},
 	
 	["corgator"] = {
-		skirms = shortRangeSkirmieeArray,
+		skirms = scorcherSkirmieeArray,
 		swarms = lowRangeSwarmieeArray,
 		flees = {},
 		hugs = shortRangeDiveArray,

--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -272,7 +272,7 @@ local shortRangeExplodables = NameToDefID({
 	"armestor",
 })
 
-local scorcherExplodables = NameToDefID({
+local diverExplodables = NameToDefID({
 	"armestor",
 })
 
@@ -294,7 +294,7 @@ end
 -- Notably, this occurs after the skirm nested union
 veryShortRangeSkirmieeArray = Union(veryShortRangeSkirmieeArray, veryShortRangeExplodables)
 
-local scorcherSkirmieeArray = Union(shortRangeSkirmieeArray, scorcherExplodables)
+local diverSkirmieeArray = Union(shortRangeSkirmieeArray, diverExplodables)
 shortRangeSkirmieeArray     = Union(shortRangeSkirmieeArray, shortRangeExplodables)
 riotRangeSkirmieeArray      = Union(riotRangeSkirmieeArray, shortRangeExplodables)
 
@@ -355,7 +355,7 @@ local subfleeables = NameToDefID({
 })
 
 -- Some short ranged units dive everything that they don't skirm or swarm.
-local shortRangeDiveArray = SetMinus(SetMinus(allGround, scorcherSkirmieeArray), lowRangeSwarmieeArray)
+local shortRangeDiveArray = SetMinus(SetMinus(allGround, diverSkirmieeArray), lowRangeSwarmieeArray)
 
 -- waterline(defaults to 0): Water level at which the unit switches between land and sea behaviour
 -- sea: table of behaviour for sea. Note that these tables are optional.
@@ -547,7 +547,7 @@ local behaviourConfig = {
 	},
 	
 	["corgator"] = {
-		skirms = scorcherSkirmieeArray,
+		skirms = diverSkirmieeArray,
 		swarms = lowRangeSwarmieeArray,
 		flees = {},
 		hugs = shortRangeDiveArray,
@@ -655,7 +655,7 @@ local behaviourConfig = {
 	
 	-- could flee subs but isn't fast enough for it to be useful
 	["shipriot"] = {
-		skirms = shortRangeSkirmieeArray,
+		skirms = diverSkirmieeArray,
 		swarms = lowRangeSwarmieeArray,
 		flees = {},
 		hugs = shortRangeDiveArray,


### PR DESCRIPTION
Scorchers were not diving vs mexes and windgens due to short range explodables, so I created separate explodables/skirm arrays for units that dive. This also affects the shotgun ship, but since neither it nor scorchers are sensitive to minor explosions like mex/windgen it's generally better for both.