### PR TITLE
Fix for economy warnings with no storage (#1838)

### DIFF
--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -612,11 +612,6 @@ function widget:GameFrame(n)
 		bar_energy:SetColor( col_energy )
 		bar_overlay_energy:SetColor({0,0,0,0})
 	end
-	
-	local metalWarning = mCurr > mStor * options.metalWarning.value
-	local energyWarning = eCurr < eStor * options.energyWarning.value
-	metalWarningPanel.ShowWarning(metalWarning and not energyWarning)
-	energyWarningPanel.ShowWarning(energyWarning)
 
 	--// Storage, income and pull numbers
 	local realEnergyPull = ePull
@@ -781,6 +776,11 @@ function widget:GameFrame(n)
 	else
 		bar_overlay_energy:SetCaption(positiveColourStr..">>>>>>")
 	end
+	
+	local metalWarning = (mStor > 1 and mCurr > mStor * options.metalWarning.value) or (mStor <= 1 and netMetal > 0)
+	local energyWarning = (eStor > 1 and eCurr < eStor * options.energyWarning.value) or (eStor <= 1 and eInco < mInco + mReci)
+	metalWarningPanel.ShowWarning(metalWarning and not energyWarning)
+	energyWarningPanel.ShowWarning(energyWarning)
 end
 
 --------------------------------------------------------------------------------

--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -630,8 +630,7 @@ function widget:GameFrame(n)
 	else
 		mPercent = 0
 		mCurr = 0
-		local excess = math.min(0, mReci - mSent) - teamMetalWaste
-		metalNoStorage.SetFlash(metalWarning)--excess > 0.01)
+		metalNoStorage.SetFlash(metalWarning)
 	end
 	
 	if eStor > 1 then
@@ -639,7 +638,7 @@ function widget:GameFrame(n)
 	else
 		ePercent = 0
 		eCurr = 0
-		energyNoStorage.SetFlash(energyWarning)--cp.team_energyWaste > 0)
+		energyNoStorage.SetFlash(energyWarning)
 	end
 	
 	metalNoStorage.Show(mStor <= 1)

--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -620,7 +620,7 @@ function widget:GameFrame(n)
 	local netEnergy = eInco - realEnergyPull
 	
 	local metalWarning = (mStor > 1 and mCurr > mStor * options.metalWarning.value) or (mStor <= 1 and netMetal > 0)
-	local energyWarning = (eStor > 1 and eCurr < eStor * options.energyWarning.value) or (eStor <= 1 and eInco < mInco + mReci)
+	local energyWarning = eStor > 1 and eCurr < eStor * options.energyWarning.value
 	metalWarningPanel.ShowWarning(metalWarning and not energyWarning)
 	energyWarningPanel.ShowWarning(energyWarning)
 	
@@ -638,7 +638,7 @@ function widget:GameFrame(n)
 	else
 		ePercent = 0
 		eCurr = 0
-		energyNoStorage.SetFlash(energyWarning)
+		energyNoStorage.SetFlash(cp.team_energyWaste > 0)
 	end
 	
 	metalNoStorage.Show(mStor <= 1)

--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -615,6 +615,14 @@ function widget:GameFrame(n)
 
 	--// Storage, income and pull numbers
 	local realEnergyPull = ePull
+
+	local netMetal = mInco - mPull + mReci
+	local netEnergy = eInco - realEnergyPull
+	
+	local metalWarning = (mStor > 1 and mCurr > mStor * options.metalWarning.value) or (mStor <= 1 and netMetal > 0)
+	local energyWarning = (eStor > 1 and eCurr < eStor * options.energyWarning.value) or (eStor <= 1 and eInco < mInco + mReci)
+	metalWarningPanel.ShowWarning(metalWarning and not energyWarning)
+	energyWarningPanel.ShowWarning(energyWarning)
 	
 	local mPercent, ePercent 
 	if mStor > 1 then
@@ -623,7 +631,7 @@ function widget:GameFrame(n)
 		mPercent = 0
 		mCurr = 0
 		local excess = math.min(0, mReci - mSent) - teamMetalWaste
-		metalNoStorage.SetFlash(excess > 0.01)
+		metalNoStorage.SetFlash(metalWarning)--excess > 0.01)
 	end
 	
 	if eStor > 1 then
@@ -631,7 +639,7 @@ function widget:GameFrame(n)
 	else
 		ePercent = 0
 		eCurr = 0
-		energyNoStorage.SetFlash(cp.team_energyWaste > 0)
+		energyNoStorage.SetFlash(energyWarning)--cp.team_energyWaste > 0)
 	end
 	
 	metalNoStorage.Show(mStor <= 1)
@@ -719,7 +727,6 @@ function widget:GameFrame(n)
 	lbl_storage_metal:SetCaption(("%.0f"):format(mCurr))
 
 	--// Net income indicator on resource bars.
-	local netMetal = mInco - mPull + mReci
 	if netMetal < -27.5 then
 		bar_metal:SetCaption(negativeColourStr.."<<<<<<")
 	elseif netMetal < -22.5 then
@@ -748,7 +755,6 @@ function widget:GameFrame(n)
 		bar_metal:SetCaption(positiveColourStr..">>>>>>")
 	end
 	
-	local netEnergy = eInco - realEnergyPull
 	if netEnergy < -27.5 then
 		bar_overlay_energy:SetCaption(negativeColourStr.."<<<<<<")
 	elseif netEnergy < -22.5 then
@@ -776,11 +782,6 @@ function widget:GameFrame(n)
 	else
 		bar_overlay_energy:SetCaption(positiveColourStr..">>>>>>")
 	end
-	
-	local metalWarning = (mStor > 1 and mCurr > mStor * options.metalWarning.value) or (mStor <= 1 and netMetal > 0)
-	local energyWarning = (eStor > 1 and eCurr < eStor * options.energyWarning.value) or (eStor <= 1 and eInco < mInco + mReci)
-	metalWarningPanel.ShowWarning(metalWarning and not energyWarning)
-	energyWarningPanel.ShowWarning(energyWarning)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
* Metal warning when there's no storage triggered when net metal is positive
* Energy warning when there's no storage triggered when there's more metal income than energy income (i.e. energy is the bottleneck)