### PR TITLE
Improve sharemenu title spacing

### DIFF
--- a/LuaUI/Widgets/gui_chili_share.lua
+++ b/LuaUI/Widgets/gui_chili_share.lua
@@ -806,14 +806,14 @@ local function Buildme()
 		width = '80%',
 		height = '20%',
 		x='43%',
-		y='1%',
+		y=5,
 		text="P L A Y E R S",
 		fontsize=17,
 		textColor={1.0,1.0,1.0,1.0}
 	}
 	chili.ScrollPanel:New{
 		parent=window,
-		y='5%',
+		y=30,
 		verticalScrollbar=true,
 		horizontalScrollbar=false,
 		width='100%',


### PR DESCRIPTION
Leave a little more vertical space for the title and fill out the rest of the panel.