### PR TITLE
Hacksaw: missile flight time 3 → 10 s

### DIFF
--- a/units/missiletower.lua
+++ b/units/missiletower.lua
@@ -88,7 +88,7 @@ unitDef = {
 
       explosionGenerator      = [[custom:FLASH2]],
       fireStarter             = 70,
-      flightTime              = 3,
+      flightTime              = 10,
       impactOnly              = true,
       impulseBoost            = 0,
       impulseFactor           = 0.4,


### PR DESCRIPTION
Makes the missile much more reliable; baiting now hard-requires to sacrifice the Swift (still makes cost; previously it could be saved with a timely boost).