### PR TITLE
Djinn: SPECIAL → UTILITY

### DIFF
--- a/LuaUI/Configs/integral_menu_commands.lua
+++ b/LuaUI/Configs/integral_menu_commands.lua
@@ -148,7 +148,7 @@ local units = {
 		-- No Amph Artillery
 		amphaa = ANTI_AIR,
 		amphassault = HEAVY_SOMETHING,
-		amphtele = SPECIAL,
+		amphtele = UTILITY,
 	},
 	factoryship = {
 		shipcon = CONSTRUCTOR,


### PR DESCRIPTION
Same as Aspis and Eraser. The main worry here would be that it makes the icon disjoint from the others.

A similar thing to consider would be Hawk: WEIRD RAIDER → ANTI AIR. All other planes fit decently into the slot roles but again this would disrupt the little Fighter vs Bomber grouping.