### PR TITLE
Fix #424 and #637 - show vertical lines for UW units

### DIFF
--- a/LuaUI/Widgets/gui_vertLineAid.lua
+++ b/LuaUI/Widgets/gui_vertLineAid.lua
@@ -41,7 +41,7 @@ options = {
 		name = 'Show for enemy underwater',
 		desc = 'Draw a line perpendicular to the surface for enemy submerged units',
 		type = 'radioButton',
-		value = 'never',
+		value = 'always',
 		items = {
 			{key ='always', name='Always'},
 			{key ='radar',  name='In radar, not in sight'},
@@ -53,7 +53,7 @@ options = {
 		name = 'Show for allied units',
 		desc = 'Draw the lines for allied units',
 		type = 'radioButton',
-		value = 'never',
+		value = 'water',
 		items = {
 			{key ='always', name='Aircraft and Underwater'},
 			{key ='air',    name='Aircraft'},


### PR DESCRIPTION
Fixes #424, the lines point to the surface.

Also fixes #637, the lines are team colored. Not the best visuals but we get it for free when fixing 424.