### PR TITLE
Aum mapsettings override

### DIFF
--- a/LuaUI/Configs/MapSettingsOverride/Aum_1.1.lua
+++ b/LuaUI/Configs/MapSettingsOverride/Aum_1.1.lua
@@ -1,0 +1,12 @@
+return {	
+	["water"] = {
+		["surfaceAlpha"]  = 0.01,
+		["fresnelPower"]  = 2.0,
+		["fresnelMin"]  = 0.0,
+		["fresnelMax"]  = 1.8,
+		["perlinLacunarity"]  = 1.7,
+		["perlinAmplitude"]  = 1.1,
+		["specularFactor"]  = 1.0,
+		["ambientFactor"]  = 1.0,
+	}
+}


### PR DESCRIPTION
Superior water config for Aum. Bumpwater no longer blindingly bright.