### PR TITLE
Minimal fix to https://github.com/ZeroK-RTS/Zero-K/issues/2926

### DIFF
--- a/LuaRules/Gadgets/unit_carrier_drones.lua
+++ b/LuaRules/Gadgets/unit_carrier_drones.lua
@@ -853,7 +853,7 @@ end
 -- Save/Load
 
 local function LoadDrone(unitID, parentID)
-	Spring.DestroyUnit(unitID)
+	Spring.DestroyUnit(unitID, false, true)
 end
 
 function gadget:Load(zip)

--- a/LuaRules/Gadgets/unit_regeneration.lua
+++ b/LuaRules/Gadgets/unit_regeneration.lua
@@ -27,9 +27,6 @@ for id, def in pairs(UnitDefs) do
 end
 
 local currentFrame
-function gadget:Initialize()
-	currentFrame = Spring.GetGameFrame()
-end
 
 function gadget:GameFrame (frame)
 	currentFrame = frame
@@ -99,6 +96,7 @@ function gadget:UnitDestroyed(unitID)
 end
 
 function gadget:Initialize()
+	currentFrame = Spring.GetGameFrame()
 	GG.SetUnitIdleRegen = SetUnitIdleRegen
 
 	for _, unitID in ipairs(Spring.GetAllUnits()) do


### PR DESCRIPTION
(Starlight save/load causes LuaRules errors)

There are other issues with Starlight though:
1) Save/load is in conflict with initial unit states widget. The widget overrides what's been restored from the save file
2) Changing "activate" state to false same frame Starlight is created (on load) does not cause laser to turn off (activate button turns off though)