### PR TITLE
This is a performance light way to fix https://github.com/ZeroK-RTS/Zero-K/issues/3011

### DIFF
--- a/LuaRules/Gadgets/unit_target_priority.lua
+++ b/LuaRules/Gadgets/unit_target_priority.lua
@@ -278,10 +278,14 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Priority callin
+local DEF_TARGET_TOO_FAR_PRIORITY = 100000 --usually numbers are around several millions, if target is out of range
 
 function gadget:AllowWeaponTarget(unitID, targetID, attackerWeaponNum, attackerWeaponDefID, defPriority)
 
 	--Spring.Echo("TARGET CHECK")
+	if defPriority > DEF_TARGET_TOO_FAR_PRIORITY then
+		return defPriority --hope engine is not that wrong about the best target outside of the range
+	end
 	
 	if (not targetID) or (not unitID) or (not attackerWeaponDefID) then
 		return true, 25


### PR DESCRIPTION
The reason behind this particular implementation is that even with new engine, it's hard to tell what defPriority will be if target is out of range.
This implementation will work with the current engine and future engines equally well.

Alternative implementation would be to guess if defPriority is high enough and then deprioritize target.
The issues are following: 1) Needs recent enough engine 2) Needs a good guestimate on defPriority value (so engine wants to tell us the target is out of reach).

P.S. One downside is that attacker will oscilate between similar out of reach targets, because, as we all are aware, defPriority has random() inside. To fix this it is required to run priority calculation the way ZK does that and only then apply out-of-reach multiplier.
Seeking guidance if this is something we want to do.