### PR TITLE
Quickfix #3071

### DIFF
--- a/LuaRules/Gadgets/unit_regeneration.lua
+++ b/LuaRules/Gadgets/unit_regeneration.lua
@@ -31,14 +31,13 @@ function gadget:GameFrame (frame)
 	currentFrame = frame
 	if ((frame % 15) == 7) then
 		local setParam = ((frame % 30) == 7)
-		local unitID, data, slowMult, amount, health
 		for i = 1, unitCount do
-			unitID = unitList[i]
-			data = units[unitID]
+			local unitID = unitList[i]
+			local data = units[unitID]
 			if (data.idleFrame < frame) and (not spGetUnitIsStunned(unitID)) and (spGetUnitRulesParam(unitID, "disarmed") ~= 1) then
-				regenRate = spGetUnitRulesParam(unitID,"totalBuildPowerChange") or 1
-				amount = data.rate * regenRate
-				health = spGetUnitHealth(unitID)
+				local regenRate = 1- (spGetUnitRulesParam(unitID, "slowState") or 0)
+				local amount = data.rate * regenRate
+				local health = spGetUnitHealth(unitID)
 				if health then
 					spSetUnitHealth(unitID, health + amount)
 				end


### PR DESCRIPTION
Not very elegant using `slowState` directly but using `totalBuildPowerChange` is incorrect (due to commanders) and nothing else makes much sense.