### PR TITLE
A few improvements to the current fancy shields code:

### DIFF
--- a/lups/ParticleClasses/ShieldSphereColorHQ.lua
+++ b/lups/ParticleClasses/ShieldSphereColorHQ.lua
@@ -73,7 +73,7 @@ function ShieldSphereColorHQParticle:Visible()
 	return self.visibleToMyAllyTeam
 end
 
-local PACE = 1200
+local PACE = 400
 
 local lastTexture = ""
 
@@ -82,8 +82,8 @@ function ShieldSphereColorHQParticle:BeginDraw()
 	gl.DepthMask(false)
 	gl.UseShader(shieldShader)
 
-	local low, high = Spring.GetDrawFrame()
-	gl.Uniform(timerUniform,	(high * 65535 + low) / PACE)
+	local gf = Spring.GetGameFrame()
+	gl.Uniform(timerUniform,	gf / PACE)
 	gl.UniformMatrix(viewInvUniform, "viewinverse")
 end
 
@@ -168,178 +168,206 @@ end
 -----------------------------------------------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------------------
 
-function ShieldSphereColorHQParticle:Initialize()
-	shieldShader = gl.CreateShader({
-		vertex = [[
-		uniform vec4 pos;
-		uniform float margin;
-		uniform float size;
+local vsCode = [[
+____VS_CODE_DEFS_____
+	uniform vec4 pos;
+	uniform float margin;
+	uniform float size;
 
-		uniform float uvMul;
+	uniform float uvMul;
 
-		uniform float timer;
+	uniform float timer;
 
-		uniform float sizeDrift;
+	uniform float sizeDrift;
 
-		varying float opac;
+	varying float opac;
 
-		varying vec3 normal;
+	varying vec3 normal;
 
-		#define DRIFT_FREQ 25.0
+	#define DRIFT_FREQ 25.0
 
-		#define PI 3.141592653589793
+	#define PI 3.141592653589793
 
-		#define nsin(x) (0.5 * sin(x) + 0.5)
+	#define nsin(x) (0.5 * sin(x) + 0.5)
 
-		void main()
-		{
-			gl_TexCoord[0] = gl_MultiTexCoord0;
+	void main()
+	{
+		gl_TexCoord[0] = gl_MultiTexCoord0;
 
-			float r = length(gl_Vertex.xyz);
-			float theta = acos(gl_Vertex.z / r);
-			float phi = atan(gl_Vertex.y, gl_Vertex.x);
+		float r = length(gl_Vertex.xyz);
+		float theta = acos(gl_Vertex.z / r);
+		float phi = atan(gl_Vertex.y, gl_Vertex.x);
 
-			r += sizeDrift * r * nsin(theta + phi + timer * DRIFT_FREQ);
+		r += sizeDrift * r * nsin(theta + phi + timer * DRIFT_FREQ);
 
-			vec4 myVertex;
-			myVertex = vec4(r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta), 1.0f);
+		vec4 myVertex;
+		myVertex = vec4(r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta), 1.0f);
 
-			vec4 size4 = vec4(size, size, size, 1.0f);
-			gl_Position = gl_ModelViewProjectionMatrix * (myVertex * size4 + pos);
+		vec4 size4 = vec4(size, size, size, 1.0f);
+		gl_Position = gl_ModelViewProjectionMatrix * (myVertex * size4 + pos);
 
-			normal = normalize(gl_NormalMatrix * gl_Normal);
+		normal = normalize(gl_NormalMatrix * gl_Normal);
 
-			vec3 vertex = vec3(gl_ModelViewMatrix * gl_Vertex);
-			float angle = dot(normal, vertex) * inversesqrt( dot(normal, normal) * dot(vertex, vertex) ); //dot(norm(n), norm(v))
-			opac = pow( abs( angle ) , margin);
-		}
-		]],
-		fragment = [[
-		varying float opac;
-		varying vec3 normal;
+		vec3 vertex = vec3(gl_ModelViewMatrix * myVertex);
+		float angle = dot(normal, vertex) * inversesqrt( dot(normal, normal) * dot(vertex, vertex) ); //dot(norm(n), norm(v))
+		opac = pow( abs( angle ) , margin);
+	}
+]]
 
-		uniform float timer;
+local fsCode = [[
+____FS_CODE_DEFS_____
+	varying float opac;
+	varying vec3 normal;
 
-		uniform mat4 viewMatrixI;
+	uniform float timer;
 
-		uniform vec4 color1;
-		uniform vec4 color2;
-		uniform vec4 colorMult;
-		uniform vec4 colorMix;
+	uniform mat4 viewMatrixI;
 
-		uniform float uvMul;
+	uniform vec4 color1;
+	uniform vec4 color2;
+	uniform vec4 colorMult;
+	uniform vec4 colorMix;
 
-		uniform float sizeDrift;
+	uniform float uvMul;
 
-		uniform int hitPointCount;
-		uniform float hitPoints[5 * MAX_POINTS];
+	uniform float sizeDrift;
 
-		uniform sampler2D tex0;
+	uniform int hitPointCount;
+	uniform float hitPoints[5 * MAX_POINTS];
 
-		uniform int method;
+	uniform sampler2D tex0;
 
-		#define PI 3.141592653589793
+	uniform int method;
 
-		#define HEXSCALE 90.0
+	#define PI 3.141592653589793
 
-		#define SZDRIFTTOUV 7.0
+	#define HEXSCALE 90.0
 
-		#define nsin(x) (0.5 * sin(x) + 0.5)
+	#define SZDRIFTTOUV 7.0
 
-		float hex(vec2 p, float width, float coreSize)
-		{
-			p.x *= 0.57735 * 2.0;
-			p.y += mod(floor(p.x), 2.0)*0.5;
-			p = abs((mod(p, 1.0) - 0.5));
-			float val = abs(max(p.x*1.5 + p.y, p.y*2.0) - 1.0);
-			return smoothstep(coreSize, width, val);
-		}
+	#define nsin(x) (0.5 * sin(x) + 0.5)
 
-		vec2 GetRippleLinearFallOffCoord(vec2 uv, vec2 point, float mag, float waveFreq, float waveSpeed, float waveDist, float time)
-		{
-			vec2 dir = uv - point;
-			float dist = distance(uv, point);
-			float magMult = (1.0 - smoothstep(0.0, waveDist, dist));
-			vec2 offset = dir * (nsin(dist * waveFreq - time * waveSpeed)) * mag * magMult;
-			return offset;
-		}
+	float hex(vec2 p, float width, float coreSize)
+	{
+		p.x *= 0.57735 * 2.0;
+		p.y += mod(floor(p.x), 2.0)*0.5;
+		p = abs((mod(p, 1.0) - 0.5));
+		float val = abs(max(p.x*1.5 + p.y, p.y*2.0) - 1.0);
+		return smoothstep(coreSize, width, val);
+	}
 
-		vec2 GetRippleCoord(vec2 uv, vec2 point, float mag, float waveFreq, float waveSpeed, float time)
-		{
-			vec2 dir = uv - point;
-			float dist = distance(uv, point);
-			vec2 offset = dir * (nsin(dist * waveFreq - time * waveSpeed)) * mag;
-			return offset;
-		}
+	vec2 GetRippleLinearFallOffCoord(vec2 uv, vec2 point, float mag, float waveFreq, float waveSpeed, float waveDist, float time)
+	{
+		vec2 dir = uv - point;
+		float dist = distance(uv, point);
+		float magMult = (1.0 - smoothstep(0.0, waveDist, dist));
+		vec2 offset = dir * (nsin(dist * waveFreq - time * waveSpeed)) * mag * magMult;
+		return offset;
+	}
+
+	vec2 GetRippleCoord(vec2 uv, vec2 point, float mag, float waveFreq, float waveSpeed, float time)
+	{
+		vec2 dir = uv - point;
+		float dist = distance(uv, point);
+		vec2 offset = dir * (nsin(dist * waveFreq - time * waveSpeed)) * mag;
+		return offset;
+	}
 
 
-		vec2 RadialCoords(vec3 a_coords)
-		{
-			vec3 a_coords_n = normalize(a_coords);
-			float lon = atan(a_coords_n.z, a_coords_n.x);
-			float lat = acos(a_coords_n.y);
-			vec2 sphereCoords = vec2(lon, lat) / PI;
-			return vec2(sphereCoords.x * 0.5 + 0.5, 1.0 - sphereCoords.y);
-		}
+	vec2 RadialCoords(vec3 a_coords)
+	{
+		vec3 a_coords_n = normalize(a_coords);
+		float lon = atan(a_coords_n.z, a_coords_n.x);
+		float lat = acos(a_coords_n.y);
+		vec2 sphereCoords = vec2(lon, lat) / PI;
+		return vec2(sphereCoords.x * 0.5 + 0.5, 1.0 - sphereCoords.y);
+	}
 
-		void main(void)
-		{
-			vec2 uvMulS = vec2(1.0, 0.5) * uvMul;
-			vec2 uv = RadialCoords(normal) * uvMulS;
+	void main(void)
+	{
+		vec2 uvMulS = vec2(1.0, 0.5) * uvMul;
+		vec2 uv = RadialCoords(normal) * uvMulS;
 
-			vec2 offset = vec2(0.0);
+		vec2 offset = vec2(0.0);
 
-			offset += GetRippleCoord(uv, vec2(0.75, 0.5) * uvMulS, sizeDrift * SZDRIFTTOUV, 80.0, 15.0, timer);
-			//offset += GetRippleCoord(uv, vec2(0.5, 0.5) * uvMulS, 0.01, 80.0, 15.0, timer);
-			//offset += GetRippleCoord(uv, vec2(1.0, 0.5) * uvMulS, 0.01, 80.0, 15.0, timer);
+		//offset += GetRippleCoord(uv, vec2(0.75, 0.5) * uvMulS, sizeDrift * SZDRIFTTOUV, 80.0, 15.0, timer);
+		offset += GetRippleCoord(uv, vec2(0.25 + 0.5 * float(!gl_FrontFacing), 0.5) * uvMulS, sizeDrift * SZDRIFTTOUV, 80.0, 15.0, timer);
 
-			vec2 offset2 = vec2(0.0);
+		vec2 offset2 = vec2(0.0);
 
-			for (int hitPointIdx = 0; hitPointIdx < MAX_POINTS; ++hitPointIdx) {
-				if (hitPointIdx < hitPointCount) {
-					vec3 impactPoint = vec3(hitPoints[5 * hitPointIdx + 0], hitPoints[5 * hitPointIdx + 1], hitPoints[5 * hitPointIdx + 2]);
-					vec3 impactPointAdj = (vec4(impactPoint, 1.0) * viewMatrixI).xyz;
-					vec2 impactPointUV = RadialCoords(impactPointAdj) * uvMulS;
-					float mag = hitPoints[5 * hitPointIdx + 3];
-					float aoe = hitPoints[5 * hitPointIdx + 4];
-					offset2 += GetRippleLinearFallOffCoord(uv, impactPointUV, mag, 100.0, -120.0, aoe, timer);
-				}
+		for (int hitPointIdx = 0; hitPointIdx < MAX_POINTS; ++hitPointIdx) {
+			if (hitPointIdx < hitPointCount) {
+				vec3 impactPoint = vec3(hitPoints[5 * hitPointIdx + 0], hitPoints[5 * hitPointIdx + 1], hitPoints[5 * hitPointIdx + 2]);
+				vec3 impactPointAdj = (vec4(impactPoint, 1.0) * viewMatrixI).xyz;
+				vec2 impactPointUV = RadialCoords(impactPointAdj) * uvMulS;
+				float mag = hitPoints[5 * hitPointIdx + 3];
+				float aoe = hitPoints[5 * hitPointIdx + 4];
+				offset2 += GetRippleLinearFallOffCoord(uv, impactPointUV, mag, 100.0, -120.0, aoe, timer);
 			}
-
-			vec2 uvo = uv + offset + offset2; //this is to trick GLSL compiler, otherwise shot-induced ripple is not drawn. Silly....
-
-			vec4 texel;
-			if (method == 0)
-				texel = vec4(1.0 - hex(uvo * HEXSCALE, 0.2, 0.01));
-			else if (method == 1)
-				texel = texture2D(tex0, uvo);
-			else
-				texel = vec4(0.0);
-
-			vec4 colorMultAdj = colorMult * (1.0 + length(offset2) * 50.0);
-			//float colorMultAdj = colorMult;
-			//vec4 color1M = color1 * colorMultAdj;
-			vec4 color2M = color2 * colorMultAdj;
-
-			vec4 color1Tex = mix(color1, texel, colorMix);
-			vec4 color1TexM = color1Tex * colorMultAdj;
-
-			gl_FragColor = mix(color1TexM, color2M, opac);
-			//gl_FragColor = mix(color1Tex, color2M, opac);
-			//gl_FragColor = texel;
 		}
-	]],
+
+		vec2 uvo = uv + offset + offset2; //this is to trick GLSL compiler, otherwise shot-induced ripple is not drawn. Silly....
+
+		vec4 texel;
+		if (method == 0)
+			texel = vec4(1.0 - hex(uvo * HEXSCALE, 0.2, 0.01));
+		else if (method == 1)
+			texel = texture2D(tex0, uvo);
+		else
+			texel = vec4(0.0);
+
+		vec4 colorMultAdj = colorMult * (1.0 + length(offset2) * 50.0);
+		//float colorMultAdj = colorMult;
+		//vec4 color1M = color1 * colorMultAdj;
+		vec4 color2M = color2 * colorMultAdj;
+
+		vec4 color1Tex = mix(color1, texel, colorMix);
+		vec4 color1TexM = color1Tex * colorMultAdj;
+
+		gl_FragColor = mix(color1TexM, color2M, opac);
+		//gl_FragColor = mix(color1Tex, color2M, opac);
+		//gl_FragColor = texel;
+	}
+]]
+
+commonCodeDefs = {
+	"#version 120",
+}
+
+vsCodeDefs = {
+}
+
+fsCodeDefs = {
+	string.format("#define MAX_POINTS %d\n", MAX_POINTS),
+}
+
+local function ListToString(defs)
+	local result = ""
+	for _, line in ipairs(defs) do
+		result = result .. "\t" .. line .. "\n"
+	end
+	return result
+end
+
+function ShieldSphereColorHQParticle:Initialize()
+	local vsCodeEff = string.gsub(vsCode, "____VS_CODE_DEFS_____", ListToString(commonCodeDefs) .. ListToString(vsCodeDefs))
+	local fsCodeEff = string.gsub(fsCode, "____FS_CODE_DEFS_____", ListToString(commonCodeDefs) .. ListToString(fsCodeDefs))
+	shieldShader = gl.CreateShader({
+		vertex = vsCodeEff,
+		fragment = fsCodeEff,
 		uniformInt = {
 			tex0 = 0,
-		},
-		definitions = {
-			string.gsub("#define MAX_POINTS _PTS_NUM_ \n", "_PTS_NUM_", tostring(MAX_POINTS)),
 		},
 	})
 
 	local shLog = gl.GetShaderLog()
-	if (shieldShader == nil or string.len(shLog or "") > 0) then
-		print(PRIO_MAJOR, "LUPS->Shield: shader warnings & errors: "..shLog)
+
+	if (string.len(shLog or "") > 0) then
+		print(PRIO_MAJOR, "LUPS->Shield: shader warnings & errors:\n"..shLog)
+		print(PRIO_MAJOR, "LUPS->Shield: Vertex Shader Code:\n"..vsCodeEff)
+		print(PRIO_MAJOR, "LUPS->Shield: Fragment Shader Code:\n"..fsCodeEff)
+	end
+	if (shieldShader == nil) then
 		return false
 	end
 
@@ -369,7 +397,9 @@ function ShieldSphereColorHQParticle:Initialize()
 end
 
 function ShieldSphereColorHQParticle:Finalize()
-	gl.DeleteShader(shieldShader)
+	if shieldShader then
+		gl.DeleteShader(shieldShader)
+	end
 	for _, list in pairs(sphereList) do
 		gl.DeleteList(list)
 	end


### PR DESCRIPTION
1) Warnings no longer cause Lups class failure. See https://github.com/ZeroK-RTS/Zero-K/issues/3078
2) Should a GLSL compiler produce errors or warnings, whole code of the shader is dumped along with the error/warning. This allows for easier matching between the error line reference and the actual code
3) I think I found what was causing "WARNING: 1:88: 'assing' : implict conversion between types allowed from GLSL 1.20" error. Probably it was MAX_POINTS variable, that got presented as float to the GLSL compiler
4) Put "#version 120" in case I found the cause above wrong
5) Fixed terribly looking distortion on the back side of the sphere. This was caused by wrong 2D coordinate of ripple center for the back side.
6) Pace of shield animation no longer depends on the drawframe, but on the current gameframe. As a result, shields no longer animate on pause and the animation pace has become independent from FPS.