### PR TITLE
Fixes solar opening too early when attacked by flea

### DIFF
--- a/scripts/energysolar.lua
+++ b/scripts/energysolar.lua
@@ -117,7 +117,7 @@ end
 
 -- this happens before PreDamaged but only in 97.0+
 function script.HitByWeapon(x, z, weaponDefID, damage)
-	if damage > 1 and not (weaponDefID and noFFWeaponDefs[weaponDefID]) then
+	if damage > 0 and not (weaponDefID and noFFWeaponDefs[weaponDefID]) then
 		StartThread(DefensiveManeuver)
 	end
 end


### PR DESCRIPTION
Closes #3304.

When the solar is in armored form, the flea attacks it for 0.88083333 damage, which isn't enough to trigger the defensive maneuver thread, which starts a cycle of the solar eventually going into unarmed form, taking a hit, triggering it, and going back into armored form.