### PR TITLE
fix #3477 (nuke explosion not spawning for shield and unit hits)

### DIFF
--- a/LuaRules/Gadgets/exp_nuke_effect_chooser.lua
+++ b/LuaRules/Gadgets/exp_nuke_effect_chooser.lua
@@ -1,10 +1,8 @@
--- $Id: exp_no_air_nuke.lua 3171 2008-11-06 09:06:29Z det $
-
 function gadget:GetInfo()
   return {
-    name      = "NoAirNuke",
-    desc      = "Disables the custom nuke effect, if the nuke is shoot in the air.",
-    author    = "jK",
+    name      = "Nuke Explosion Chooser",
+    desc      = "Chooses which nuke explosion to spawn based on altitude.",
+    author    = "jK, Anarchid",
     date      = "Dec, 2007",
     license   = "GNU GPL, v2 or later",
     layer     = 0,
@@ -15,6 +13,8 @@ end
 local GetGroundHeight = Spring.GetGroundHeight
 
 local nux = {}
+local defaultSuccessExplosion = [[LONDON_FLAT]]
+local defaultInterceptExplosion = [[ANTINUKE]]
 
 if (not gadgetHandler:IsSyncedCode()) then
   return false
@@ -27,7 +27,7 @@ for i=1,#WeaponDefs do
 	local wd = WeaponDefs[i]
 	--note that area of effect is radius, not diameter here!
 	if (wd.damageAreaOfEffect >= 800 and wd.targetable) then
-		nux[wd.id] = true
+		nux[wd.id] = wd.damageAreaOfEffect
 		wantedList[#wantedList + 1] = wd.id
 		if Script.SetWatchExplosion then
 			Script.SetWatchExplosion(wd.id, true)
@@ -42,8 +42,10 @@ function gadget:Explosion_GetWantedWeaponDef()
 end
 
 function gadget:Explosion(weaponID, px, py, pz, ownerID)
-	if (nux[weaponID] and py-GetGroundHeight(px,pz)>100) then
-		return true
+	if (nux[weaponID] and py-GetGroundHeight(px,pz)>200) then
+		Spring.SpawnCEG(defaultInterceptExplosion, px, py, pz, 0, 0, 0, nux[weaponID])
+	else
+		Spring.SpawnCEG(defaultSuccessExplosion, px, py, pz, 0, 0, 0, nux[weaponID])
 	end
-	return false
+	return true -- always suppress engine/weapon default effects
 end

--- a/LuaRules/Gadgets/exp_nuke_effect_chooser.lua
+++ b/LuaRules/Gadgets/exp_nuke_effect_chooser.lua
@@ -42,7 +42,7 @@ function gadget:Explosion_GetWantedWeaponDef()
 end
 
 function gadget:Explosion(weaponID, px, py, pz, ownerID)
-	if (nux[weaponID] and py-GetGroundHeight(px,pz)>200) then
+	if (nux[weaponID] and py-math.max(0, GetGroundHeight(px,pz))>200) then
 		Spring.SpawnCEG(defaultInterceptExplosion, px, py, pz, 0, 0, 0, nux[weaponID])
 	else
 		return false

--- a/LuaRules/Gadgets/exp_nuke_effect_chooser.lua
+++ b/LuaRules/Gadgets/exp_nuke_effect_chooser.lua
@@ -45,7 +45,7 @@ function gadget:Explosion(weaponID, px, py, pz, ownerID)
 	if (nux[weaponID] and py-GetGroundHeight(px,pz)>200) then
 		Spring.SpawnCEG(defaultInterceptExplosion, px, py, pz, 0, 0, 0, nux[weaponID])
 	else
-		Spring.SpawnCEG(defaultSuccessExplosion, px, py, pz, 0, 0, 0, nux[weaponID])
+		return false
 	end
 	return true -- always suppress engine/weapon default effects
 end

--- a/units/staticantinuke.lua
+++ b/units/staticantinuke.lua
@@ -87,7 +87,8 @@ unitDef = {
         subs    = 75,
       },
 
-      explosionGenerator      = [[custom:ANTINUKE]],
+      --spawning the intercept explosion is handled by exp_nuke_effect_chooser.lua
+      --explosionGenerator      = [[custom:ANTINUKE]],
       fireStarter             = 100,
       flightTime              = 20,
       impulseBoost            = 0,

--- a/units/staticantinuke.lua
+++ b/units/staticantinuke.lua
@@ -88,7 +88,7 @@ unitDef = {
       },
 
       --spawning the intercept explosion is handled by exp_nuke_effect_chooser.lua
-      --explosionGenerator      = [[custom:ANTINUKE]],
+      explosionGenerator      = [[custom:lrpc_expl]],
       fireStarter             = 100,
       flightTime              = 20,
       impulseBoost            = 0,

--- a/units/staticnuke.lua
+++ b/units/staticnuke.lua
@@ -76,7 +76,7 @@ unitDef = {
       },
 
       edgeEffectiveness       = 0.3,
-      explosionGenerator      = [[custom:LONDON_FLAT]],
+      explosionGenerator      = [[custom:LONDON_FLAT]],      -- note, spawning of the explosion is handled by exp_nuke_effect_chooser.lua 
       fireStarter             = 0,
       flightTime              = 180,
       impulseBoost            = 0.5,


### PR DESCRIPTION
Gadget solution. Automatically also handles Funnelweb shields (which were also bork, like any other non-anti intercept above altitude 100).

Increased altitude valid for a "ground" hit because imo nuking a Nimbus should still trigger a ground version of the explosion.