### PR TITLE
Attrition counter now handles capture and suicide units

### DIFF
--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -454,7 +454,7 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, at
 	
 	-- prevents factory-cancel from counting as kill
 	local buildProgress = select(5, GetUnitHealth(unitID))
-	if GetUnitHealth(unitID) > 0 && buildProgress < 1 then return end
+	if GetUnitHealth(unitID) > 0 and buildProgress < 1 then return end
 	
 	-- don't count morphed units
 	local wasMorphed = Spring.GetUnitRulesParam(unitID, wasMorphedTo);

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -376,8 +376,6 @@ function widget:UnitTaken(unitID, unitDefID, unitTeamID, newTeamID) --//will be 
 			doUpdate = true
 		end
 	else
-		-- this is most likely dead code because of the weird relationship between UnitGiven and UnitTaken
-		-- however there's no documentation i could find that explains it, so i feel unsafe otherwise.
 		if capturedUnits[unitID] and capturedUnits[unitID] == unitDefID then
 			Echo("<AttritionCounter>: unitTaken: captured by a new team while already captured, how peculiar")
 			-- unit has been captured before and is now captured by another owner. 

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -384,7 +384,6 @@ function widget:UnitTaken(unitID, unitDefID, unitTeamID, newTeamID) --//will be 
 			-- do nothing; shouldn't happen unless FFA, and this widget shuts down in FFA.
 		else
 			-- unit has now become mind-controlled for the first time; unitTeamID lost it
-			Echo("<AttritionCounter>: unitTaken: captured for the first time, file as casualty")
 			capturedUnits[unitID] = unitDefID; -- verify unitdef in case of ID recycling 
 			local buildProgress = select(5, GetUnitHealth(unitID))
 			local worth = Spring.Utilities.GetUnitCost(unitID, unitDefID) * buildProgress

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -449,6 +449,9 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, at
 	-- if its also the same kind of unit, its safe to assume that it is the very same unit
 	-- else it is most likely not the same unit but an old table entry and a re-used unitID. we just keep the entry
 	-- small margin of error remains
+	
+	-- prevents morph and factory-cancel from counting as kill
+	if GetUnitHealth(unitID) > 0 then return end
 
 	if teamID == gaiaTeam then return end
 	

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -457,7 +457,7 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, at
 	if GetUnitHealth(unitID) > 0 and buildProgress < 1 then return end
 	
 	-- don't count morphed units
-	local wasMorphed = Spring.GetUnitRulesParam(unitID, wasMorphedTo);
+	local wasMorphed = Spring.GetUnitRulesParam(unitID, "wasMorphedTo");
 	if wasMorphed then return end
 
 	if teamID == gaiaTeam then return end

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -450,8 +450,15 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, at
 	-- else it is most likely not the same unit but an old table entry and a re-used unitID. we just keep the entry
 	-- small margin of error remains
 	
-	-- prevents morph and factory-cancel from counting as kill
-	if GetUnitHealth(unitID) > 0 then return end
+	
+	
+	-- prevents factory-cancel from counting as kill
+	local buildProgress = select(5, GetUnitHealth(unitID))
+	if GetUnitHealth(unitID) > 0 && buildProgress < 1 then return end
+	
+	-- don't count morphed units
+	local wasMorphed = Spring.GetUnitRulesParam(unitID, wasMorphedTo);
+	if wasMorphed then return end
 
 	if teamID == gaiaTeam then return end
 	
@@ -476,7 +483,6 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, at
 	Echo("<Attrition Counter>: UnitDestroyed: While owned by controller: "..tostring(captureController));
 	if captureController and captureController ~= -1 then return end
 		
-	local buildProgress = select(5, GetUnitHealth(unitID))
 	local worth = Spring.Utilities.GetUnitCost(unitID, unitDefID) * buildProgress
 	
 	-- if teamID and unitID and unitDefID and teamID ~= gaiaTeam then 	

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -450,7 +450,8 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, at
 	
 	
 	
-	-- prevents factory-cancel from counting as kill
+	-- prevents factory-cancel from counting as kill.
+	-- TODO: only count mobile units because statics are never factory-made
 	local buildProgress = select(5, GetUnitHealth(unitID))
 	if GetUnitHealth(unitID) > 0 and buildProgress < 1 then return end
 	
@@ -478,7 +479,6 @@ function widget:UnitDestroyed(unitID, unitDefID, teamID, attUnitID, attDefID, at
 	
 	-- ignore deaths of presently mind-controlled units 
 	local captureController = Spring.GetUnitRulesParam(unitID,"capture_controller");
-	Echo("<Attrition Counter>: UnitDestroyed: While owned by controller: "..tostring(captureController));
 	if captureController and captureController ~= -1 then return end
 		
 	local worth = Spring.Utilities.GetUnitCost(unitID, unitDefID) * buildProgress


### PR DESCRIPTION
Capture:
- Captured units are considered as losses for the original owner on capture event
- Deaths of units that are currently slaves are not counted anywhere because they were already worse than dead
- Units returned to original owner due to Domi death are considered as reverse losses for the original owner.

Suicides:
- Health check on unit death - used to handle factory cancel, morph, and accidentally also suicide - now only prevents *incomplete* units from being counted. 
- Morph is detected via `wasMorphedTo` UnitRulesParam instead
- Self-destructing and suicide units are counted as casualties.