### PR TITLE
Reset button for Chili Profiler

### DIFF
--- a/LuaUI/Widgets/dbg_chili_profiler.lua
+++ b/LuaUI/Widgets/dbg_chili_profiler.lua
@@ -110,6 +110,15 @@ local function AddSedateProfiler()
 	debug.sethook(trace, "l", 16000000)
 end
 
+local function ResetProfiler()
+	if profiling then return end
+	tree0.root:ClearChildren()
+	sample_tree = {}
+	samples = 0
+	label0:SetCaption("Samples: " .. samples)
+	profiling = false
+end
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
@@ -152,19 +161,25 @@ function widget:Initialize()
 				},
 			},
 			Chili.Button:New{
-				x=0, right="66%",
+				x=0, right="75%",
 				y=-20, bottom=0,
 				caption="start",
 				OnClick = {AddProfiler},
 			},
 			Chili.Button:New{
-				x="34%", right="34%",
+				x="25%", right="50%",
 				y=-20, bottom=0,
 				caption="sedate",
 				OnClick = {AddSedateProfiler},
 			},
 			Chili.Button:New{
-				x="66%", right=0,
+				x="50%", right="25%",
+				y=-20, bottom=0,
+				caption="reset",
+				OnClick = {ResetProfiler},
+			},
+			Chili.Button:New{
+				x="75%", right=0,
 				y=-20, bottom=0,
 				caption = "stop",
 				OnClick = {function() debug.sethook( nil ); profiling = false; rendertree() end},

--- a/LuaUI/Widgets/dbg_chili_profiler.lua
+++ b/LuaUI/Widgets/dbg_chili_profiler.lua
@@ -116,7 +116,6 @@ local function ResetProfiler()
 	sample_tree = {}
 	samples = 0
 	label0:SetCaption("Samples: " .. samples)
-	profiling = false
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
QoL update - adds a button to reset the profiler, instead of needing to unload and reload the Chili Profiler widget to profile again