### PR TITLE
Healthbar Widget - Maximum Height Limit

### DIFF
--- a/LuaUI/Widgets/unit_healthbars.lua
+++ b/LuaUI/Widgets/unit_healthbars.lua
@@ -197,6 +197,25 @@ end
 
 local paralyzeOnMaxHealth = ((lowerkeys(VFS.Include"gamedata/modrules.lua") or {}).paralyze or {}).paralyzeonmaxhealth
 
+local function IsCameraBelowMaxHeight() 
+	
+	local cs = Spring.GetCameraState()
+	local gy = Spring.GetGroundHeight(cs.px, cs.pz)
+	local tolerance = 25 --// as defined in iconheight
+
+	if cs.name == "ov" then
+		testHeight = options.drawMaxHeight.value * 2
+	elseif cs.name == "ta" then
+		testHeight = cs.height - gy
+	end
+
+	if testHeight >= options.drawMaxHeight.value - tolerance then
+		return false
+	end
+	return true
+end
+
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
@@ -249,7 +268,6 @@ local gameFrame = 0;
 local empDecline = 1/40;
 
 local cx, cy, cz = 0,0,0;  --// camera pos
-local tolerance = 25 --// via iconheight
 
 local paraUnits   = {};
 local disarmUnits = {};
@@ -1099,18 +1117,9 @@ do
 				return
 			end
 
-			-- Test for Camera Height before processing
-			local cs = Spring.GetCameraState() 
-			local gy = Spring.GetGroundHeight(cs.px, cs.pz)
-
-			if cs.name == "ov" then
-				testHeight = options.drawMaxHeight.value * 2
-			elseif cs.name == "ta" then
-				testHeight = cs.height - gy
-			end
-		
-			if testHeight >= options.drawMaxHeight.value - tolerance then
-				return
+			-- Test camera height before processing
+			if not IsCameraBelowMaxHeight() then
+				return false
 			end
 
 			-- Processing
@@ -1206,17 +1215,8 @@ do
 	function widget:Update(dt)
 
 		-- Test camera height before processing
-		local cs = Spring.GetCameraState()
-		local gy = Spring.GetGroundHeight(cs.px, cs.pz)
-
-		if cs.name == "ov" then
-			testHeight = options.drawMaxHeight.value * 2
-		elseif cs.name == "ta" then
-			testHeight = cs.height - gy
-		end
-	
-		if testHeight >= options.drawMaxHeight.value - tolerance then
-			return
+		if not IsCameraBelowMaxHeight() then
+			return false
 		end
 
 		-- Processing

--- a/LuaUI/Widgets/unit_healthbars.lua
+++ b/LuaUI/Widgets/unit_healthbars.lua
@@ -45,8 +45,6 @@ local featureHpThreshold = 0.85
 
 local barScale = 1
 
-local infoDistance = 700000
-
 local drawStunnedOverlay = true
 local drawUnitsOnFire    = Spring.GetGameRulesParam("unitsOnFire")
 
@@ -114,7 +112,7 @@ local function OptionsChanged()
 end
 
 options_path = 'Settings/Interface/Healthbars'
-options_order = { 'showhealthbars', 'drawFeatureHealth', 'drawBarPercentages', 'barScale', 'debugMode', 'minReloadTime', 'drawMaxHeight'}
+options_order = { 'showhealthbars', 'drawFeatureHealth', 'drawBarPercentages', 'barScale', 'debugMode', 'minReloadTime', 'drawMaxHeight', 'simpleHealthPercent'}
 options = {
 	showhealthbars = {
 		name = 'Show Healthbars',
@@ -143,7 +141,7 @@ options = {
 		type = 'number',
 		value = 1,
 		min = 0.5,
-		max = 3,
+		max = 6,
 		step = 0.25,
 		OnChange = OptionsChanged,
 	},
@@ -168,10 +166,18 @@ options = {
 	},	
 	drawMaxHeight = { -- Code for this is all from icon height widget
 		name = 'Health Bar Fade Height',
-		desc = 'If the camera is above this height, health bars will not be drawn.',
+		desc = 'If the camera is above this height, health bars will not be drawn. Setting this above 3000 may affect performance.',
 		type = 'number',
-		min = 0, max = 20000, step = 200,
+		min = 0, max = 9000, step = 200,
 		value = 3000,
+	},
+
+	simpleHealthPercent = { -- Code for this is all from icon height widget
+		name = 'Simple Health Bar Distance',
+		desc = 'Percentage of Health Bar Fade Height after which simple health bars are shown. Setting this above 50 may affect performance.',
+		type = 'number',
+		min = 10, max = 100, step = 5,
+		value = 25,
 	},
 }
 
@@ -620,8 +626,11 @@ do
 		end
 		local dx, dy, dz = ux-cx, uy-cy, uz-cz
 		local dist = dx*dx + dy*dy + dz*dz
-		if (dist > infoDistance) then
-			if (dist > 9000000) then
+		local maxDist = math.pow(options.drawMaxHeight.value, 2)
+		local simpleDist = maxDist * (options.simpleHealthPercent.value/100)
+
+		if (dist > simpleDist) then
+			if (dist > maxDist) then
 				if debugMode then
 					local x,y,z = Spring.GetUnitPosition(unitID)
 					Spring.MarkerAddPoint(x,y,z,"High Distance")
@@ -1159,6 +1168,8 @@ do
 			--// draw bars for features
 			local wx, wy, wz, dx, dy, dz, dist, featureID, valid
 			local featureInfo
+			local maxFeatureDist = math.pow(options.drawMaxHeight.value, 2) * (2/3)
+			local simpleFeatureDist = maxFeatureDist*(options.simpleHealthPercent.value/100)
 			for i=1,#visibleFeatures do
 				featureInfo = visibleFeatures[i]
 				featureID = featureInfo[4]
@@ -1167,8 +1178,8 @@ do
 					wx, wy, wz = featureInfo[1],featureInfo[2],featureInfo[3]
 					dx, dy, dz = wx-cx, wy-cy, wz-cz
 					dist = dx*dx + dy*dy + dz*dz
-					if (dist < 6000000) then
-						if (dist < infoDistance) then
+					if (dist < maxFeatureDist) then
+						if (dist < simpleFeatureDist) then
 							DrawFeatureInfos(featureInfo[4], featureInfo[5], true, wx,wy,wz)
 						else
 							DrawFeatureInfos(featureInfo[4], featureInfo[5], false, wx,wy,wz)


### PR DESCRIPTION
When fully zoomed out in a large game, health bar widget can have high CPU and upwards of 1+ MB/s memory by processing all units and features on the map. 

The existing widget already stops rendering bars at a distance of around 3000 units. This adds a slider to place an height limit over which health bars will not be processed or drawn. Entirely based on 'Icon Height' widget. When set to 3000 units, testing shows memory peaking at 300KB/s and zero when viewed from higher.

It would need to be checked for side effects with other camera modes.