### PR TITLE
Improve Knight unit AI when attacking

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -882,14 +882,14 @@ local behaviourConfig = {
 	
 	--assaults
 	["cloakassault"] = {
-		skirms = lowMedRangeSkirmieeArray, 
+		skirms = allGround, 
 		swarms = medRangeSwarmieeArray, 
 		flees = {},
 		fightOnlyUnits = medRangeExplodables,
 		maxSwarmLeeway = 30, 
 		minSwarmLeeway = 90, 
-		skirmLeeway = 30, 
-		skirmBlockedApproachFrames = 20,
+		skirmLeeway = 40,
+		skirmBlockedApproachFrames = 10,
 	},
 	["shieldassault"] = {
 		skirms = riotRangeSkirmieeArray, 


### PR DESCRIPTION
This is a QoL improvement for the Knight.  The Knight has issues with LoS because its weapon can't fire through other Knights.  When giving a group of Knights an attack command against a single unit, they would tend to bunch up and push each other forward, making the problem worse.  Even when microing Knight movement with line moves it can be difficult to optimize their damage.

This change causes Knights to always use skirmish AI against ground targets.  The effect is that when Knights in the back start pushing forward, the Knights in the front move to the side.

`skirmLeeway` and `skirmBlockedApproachFrames` were also tweaked to make the Knight's positioning more aggressive, it is an assault unit after all.

[Here is a video](https://youtu.be/-HD97udi0PU) demonstrating before and after, comparing a blob of Knights to a blob of Ravagers which have equivalent DPS but less problems shooting through each other.