### PR TITLE
Fixed team name side for spectator widgets

### DIFF
--- a/LuaUI/Headers/allyteam_selection_utilities.lua
+++ b/LuaUI/Headers/allyteam_selection_utilities.lua
@@ -1,35 +1,39 @@
 local function GetLeftRightAllyTeamIDs()
-    if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
-        -- not 2 teams: unhandled by spec panels
-        return {}
-    end
+	if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
+		-- not 2 teams: unhandled by spec panels
+		return {}
+	end
 
+	local myAllyTeamID = 0 -- FIXME Spring.GetLocalAllyTeamID()
+	local enemyAllyTeamID = 1 -- FIXME assumes teams are 0 and 1
+	local myTeamID = Spring.GetTeamList(myAllyTeamID)[1] -- FIXME Spring.GetLocalTeamID()
 
-    local myAllyTeamID = 0--Spring.GetLocalAllyTeamID()
-    local enemyAllyTeamID = 1 -- FIXME assumes teams are 0 and 1
-    local myTeamID = Spring.GetTeamList(myAllyTeamID)[1]--Spring.GetLocalTeamID()
+	local myBoxID = Spring.GetTeamRulesParam(myTeamID, "start_box_id")
+	if not myBoxID then -- can start anywhere
+		--[[ FIXME: since allyteam is hardcoded to 0 this can also mean we're in in allyteam 1+
+		     and just can't read allyteam 0's box, but since currently this func's result is
+		     only really used by specs so it's not apparent ]]
+		return {0, 1}
+	end
 
-    local myBoxID = Spring.GetTeamRulesParam(myTeamID, "start_box_id")
-    if not myBoxID then -- can start anywhere
-        return {0, 1} -- players see themselves on the left, maybe should `return 0, 1` (see fixme above) so everybody sees everything the same?
-    end
+	local myBoxRepresentativeSpotX = Spring.GetGameRulesParam("startpos_x_" .. myBoxID .. "_1")
 
-    local myBoxRepresentativeSpotX = Spring.GetGameRulesParam("startpos_x_" .. myBoxID .. "_1")
+	local comparisonX
+	if Spring.GetGameRulesParam("shuffleMode") == "allshuffle" and Spring.GetGameRulesParam("startbox_max_n") > 1 then
+		-- there are multiple boxes the enemy can be in so just look where we are on the map
+		-- FIXME 1: if fullview spec, should just compare to enemy box directly
+		-- FIXME 2: else it should compare to the remaining boxes, not the map center
+		comparisonX = Game.mapSizeX / 2
+	else
+		local enemyBoxID = 1 - myBoxID -- FIXME: assumes boxIDs are 0 and 1 and that there are at least 2 boxes
+		comparisonX = Spring.GetGameRulesParam("startpos_x_" .. enemyBoxID .. "_1")
+	end
 
-    local comparisonX
-    if Spring.GetGameRulesParam("shuffleMode") == "allshuffle" and Spring.GetGameRulesParam("startbox_max_n") > 1 then
-        -- there are multiple boxes the enemy can be in so just look where we are on the map
-        comparisonX = Game.mapSizeX / 2
-    else
-        local enemyBoxID = 1 - myBoxID
-        comparisonX = Spring.GetGameRulesParam("startpos_x_" .. enemyBoxID .. "_1")
-    end
-
-    if myBoxRepresentativeSpotX <= comparisonX then
-        return {myAllyTeamID, enemyAllyTeamID}
-    else
-        return {enemyAllyTeamID, myAllyTeamID}
-    end
+	if myBoxRepresentativeSpotX <= comparisonX then
+		return {myAllyTeamID, enemyAllyTeamID}
+	else
+		return {enemyAllyTeamID, myAllyTeamID}
+	end
 end
 
 return GetLeftRightAllyTeamIDs

--- a/LuaUI/Headers/allyteam_selection_utilities.lua
+++ b/LuaUI/Headers/allyteam_selection_utilities.lua
@@ -1,0 +1,35 @@
+local function GetLeftRightAllyTeamIDs()
+    if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
+        -- not 2 teams: unhandled by spec panels
+        return {}
+    end
+
+
+    local myAllyTeamID = 0--Spring.GetLocalAllyTeamID()
+    local enemyAllyTeamID = 1 -- FIXME assumes teams are 0 and 1
+    local myTeamID = Spring.GetTeamList(myAllyTeamID)[1]--Spring.GetLocalTeamID()
+
+    local myBoxID = Spring.GetTeamRulesParam(myTeamID, "start_box_id")
+    if not myBoxID then -- can start anywhere
+        return {0, 1} -- players see themselves on the left, maybe should `return 0, 1` (see fixme above) so everybody sees everything the same?
+    end
+
+    local myBoxRepresentativeSpotX = Spring.GetGameRulesParam("startpos_x_" .. myBoxID .. "_1")
+
+    local comparisonX
+    if Spring.GetGameRulesParam("shuffleMode") == "allshuffle" and Spring.GetGameRulesParam("startbox_max_n") > 1 then
+        -- there are multiple boxes the enemy can be in so just look where we are on the map
+        comparisonX = Game.mapSizeX / 2
+    else
+        local enemyBoxID = 1 - myBoxID
+        comparisonX = Spring.GetGameRulesParam("startpos_x_" .. enemyBoxID .. "_1")
+    end
+
+    if myBoxRepresentativeSpotX <= comparisonX then
+        return {myAllyTeamID, enemyAllyTeamID}
+    else
+        return {enemyAllyTeamID, myAllyTeamID}
+    end
+end
+
+return GetLeftRightAllyTeamIDs

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -142,10 +142,7 @@ end
 local function GetOpposingAllyTeams()
 	local gaiaAllyTeamID = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID(), false))
 	local returnData = {}
-	local allyTeamList = {}
-  if spectating then allyTeamList = GetLeftRightAllyTeamIDs() 
-  else allyTeamList = Spring.GetAllyTeamList()
-  end
+	local allyTeamList = GetLeftRightAllyTeamIDs()
 	for i = 1, #allyTeamList do
 		local allyTeamID = allyTeamList[i]
 
@@ -273,6 +270,8 @@ function widget:Initialize()
 	
 	font = Chili.Font:New{} -- need this to call GetTextWidth without looking up an instance
 	
+	--[[ in the original design, "own" team was supposed to be on the left,
+	     but when speccing it's better to put the geographical left there ]]
 	if spectating then
 		myAllyTeam = GetLeftRightAllyTeamIDs()[1]
 	else

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -14,7 +14,7 @@ end
 include("colors.h.lua")
 VFS.Include("LuaRules/Configs/constants.lua")
 
--- local GetLeftRightAllyTeamIDs = VFS.Include("LuaUI/Headers/allyteam_selection_utilities.lua")
+local GetLeftRightAllyTeamIDs = VFS.Include("LuaUI/Headers/allyteam_selection_utilities.lua")
 
 options_path = 'Settings/HUD Panels/Attrition Counter'
 options_order = {'updateFrequency'}
@@ -137,40 +137,6 @@ local function GetTeamName(teamID)
 		end
 		return name;
 	end
-end
-
-local function GetLeftRightAllyTeamIDs()
-    if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
-        -- not 2 teams: unhandled by spec panels
-        return {}
-    end
-
-
-    local myAllyTeamID = 0--Spring.GetLocalAllyTeamID()
-    local enemyAllyTeamID = 1 -- FIXME assumes teams are 0 and 1
-    local myTeamID = Spring.GetTeamList(myAllyTeamID)[1]--Spring.GetLocalTeamID()
-
-    local myBoxID = Spring.GetTeamRulesParam(myTeamID, "start_box_id")
-    if not myBoxID then -- can start anywhere
-        return {0, 1} -- players see themselves on the left, maybe should `return 0, 1` (see fixme above) so everybody sees everything the same?
-    end
-
-    local myBoxRepresentativeSpotX = Spring.GetGameRulesParam("startpos_x_" .. myBoxID .. "_1")
-
-    local comparisonX
-    if Spring.GetGameRulesParam("shuffleMode") == "allshuffle" and Spring.GetGameRulesParam("startbox_max_n") > 1 then
-        -- there are multiple boxes the enemy can be in so just look where we are on the map
-        comparisonX = Game.mapSizeX / 2
-    else
-        local enemyBoxID = 1 - myBoxID
-        comparisonX = Spring.GetGameRulesParam("startpos_x_" .. enemyBoxID .. "_1")
-    end
-
-    if myBoxRepresentativeSpotX <= comparisonX then
-        return {myAllyTeamID, enemyAllyTeamID}
-    else
-        return {enemyAllyTeamID, myAllyTeamID}
-    end
 end
 
 local function GetOpposingAllyTeams()

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -14,6 +14,8 @@ end
 include("colors.h.lua")
 VFS.Include("LuaRules/Configs/constants.lua")
 
+-- local GetLeftRightAllyTeamIDs = VFS.Include("LuaUI/Headers/allyteam_selection_utilities.lua")
+
 options_path = 'Settings/HUD Panels/Attrition Counter'
 options_order = {'updateFrequency'}
 options = {
@@ -138,7 +140,7 @@ local function GetTeamName(teamID)
 end
 
 local function GetLeftRightAllyTeamIDs()
- 		if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
+    if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
         -- not 2 teams: unhandled by spec panels
         return {}
     end
@@ -174,7 +176,10 @@ end
 local function GetOpposingAllyTeams()
 	local gaiaAllyTeamID = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID(), false))
 	local returnData = {}
-	local allyTeamList = GetLeftRightAllyTeamIDs() --Spring.GetAllyTeamList()
+	local allyTeamList = {}
+  if spectating then allyTeamList = GetLeftRightAllyTeamIDs() 
+  else allyTeamList = Spring.GetAllyTeamList()
+  end
 	for i = 1, #allyTeamList do
 		local allyTeamID = allyTeamList[i]
 
@@ -198,10 +203,6 @@ local function GetOpposingAllyTeams()
 	if #returnData ~= 2 then
 		return
 	end
-	
-	-- if returnData[1].allyTeamID > returnData[2].allyTeamID then
-	-- 	returnData[1], returnData[2] = returnData[2], returnData[1]
-	-- end
 	
 	return returnData
 end

--- a/LuaUI/Widgets/gui_chili_spectator_panels.lua
+++ b/LuaUI/Widgets/gui_chili_spectator_panels.lua
@@ -909,7 +909,7 @@ end
 local function GetOpposingAllyTeams()
 	local gaiaAllyTeamID = select(6, Spring.GetTeamInfo(Spring.GetGaiaTeamID(), false))
 	local returnData = {}
-	local allyTeamList = GetLeftRightAllyTeamIDs()--Spring.GetAllyTeamList()
+	local allyTeamList = GetLeftRightAllyTeamIDs()
 	for i = 1, #allyTeamList do
 		local allyTeamID = allyTeamList[i]
 
@@ -953,6 +953,7 @@ end
 
 
 function option_CheckEnable(self)
+
 	if not self.value then
 		if enabled then
 			RemovePlayerWindow()
@@ -980,12 +981,11 @@ function option_CheckEnable(self)
 	if not allyTeamData then
 		return false
 	end
-
 	
 	if options.enablePlayerPanel.value then
 		AddPlayerWindow()
 	end
-
+	
 	if options.enableEconomyPanels.value then
 		AddEconomyWindows()
 	end

--- a/LuaUI/Widgets/gui_chili_spectator_panels.lua
+++ b/LuaUI/Widgets/gui_chili_spectator_panels.lua
@@ -19,6 +19,7 @@ end
 include("colors.h.lua")
 VFS.Include("LuaRules/Configs/constants.lua")
 
+-- local GetLeftRightAllyTeamIDs = VFS.Include("LuaUI/Headers/allyteam_selection_utilities.lua")
 local GetFlowStr = VFS.Include("LuaUI/Headers/ecopanels.lua")
 
 --------------------------------------------------------------------------------
@@ -906,18 +907,19 @@ local function GetWinString(name)
 end
 
 local function GetLeftRightAllyTeamIDs()
- 		if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
+    if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
         -- not 2 teams: unhandled by spec panels
         return {}
     end
 
-    local myAllyTeamID = 0
-    local enemyAllyTeamID = 1 
-    local myTeamID = Spring.GetTeamList(myAllyTeamID)[1]
+
+    local myAllyTeamID = 0--Spring.GetLocalAllyTeamID()
+    local enemyAllyTeamID = 1 -- FIXME assumes teams are 0 and 1
+    local myTeamID = Spring.GetTeamList(myAllyTeamID)[1]--Spring.GetLocalTeamID()
 
     local myBoxID = Spring.GetTeamRulesParam(myTeamID, "start_box_id")
     if not myBoxID then -- can start anywhere
-        return {0, 1} 
+        return {0, 1} -- players see themselves on the left, maybe should `return 0, 1` (see fixme above) so everybody sees everything the same?
     end
 
     local myBoxRepresentativeSpotX = Spring.GetGameRulesParam("startpos_x_" .. myBoxID .. "_1")
@@ -931,7 +933,7 @@ local function GetLeftRightAllyTeamIDs()
         comparisonX = Spring.GetGameRulesParam("startpos_x_" .. enemyBoxID .. "_1")
     end
 
-    if (not myBoxRepresentativeSpotX or not comparisonX) or myBoxRepresentativeSpotX < comparisonX then
+    if myBoxRepresentativeSpotX <= comparisonX then
         return {myAllyTeamID, enemyAllyTeamID}
     else
         return {enemyAllyTeamID, myAllyTeamID}
@@ -980,16 +982,11 @@ local function GetOpposingAllyTeams()
 		return
 	end
 	
-	-- if returnData[1].allyTeamID > returnData[2].allyTeamID then
-	-- 	returnData[1], returnData[2] = returnData[2], returnData[1]
-	-- end
-	
 	return returnData
 end
 
 
 function option_CheckEnable(self)
-
 	if not self.value then
 		if enabled then
 			RemovePlayerWindow()
@@ -1022,7 +1019,7 @@ function option_CheckEnable(self)
 	if options.enablePlayerPanel.value then
 		AddPlayerWindow()
 	end
-	
+
 	if options.enableEconomyPanels.value then
 		AddEconomyWindows()
 	end

--- a/LuaUI/Widgets/gui_chili_spectator_panels.lua
+++ b/LuaUI/Widgets/gui_chili_spectator_panels.lua
@@ -19,7 +19,7 @@ end
 include("colors.h.lua")
 VFS.Include("LuaRules/Configs/constants.lua")
 
--- local GetLeftRightAllyTeamIDs = VFS.Include("LuaUI/Headers/allyteam_selection_utilities.lua")
+local GetLeftRightAllyTeamIDs = VFS.Include("LuaUI/Headers/allyteam_selection_utilities.lua")
 local GetFlowStr = VFS.Include("LuaUI/Headers/ecopanels.lua")
 
 --------------------------------------------------------------------------------
@@ -904,40 +904,6 @@ local function GetWinString(name)
 		return (winTable[name].wonLastGame and "*" or "") .. winTable[name].wins
 	end
 	return ""
-end
-
-local function GetLeftRightAllyTeamIDs()
-    if Spring.Utilities.Gametype.isFFA() or Spring.Utilities.Gametype.isSandbox() then
-        -- not 2 teams: unhandled by spec panels
-        return {}
-    end
-
-
-    local myAllyTeamID = 0--Spring.GetLocalAllyTeamID()
-    local enemyAllyTeamID = 1 -- FIXME assumes teams are 0 and 1
-    local myTeamID = Spring.GetTeamList(myAllyTeamID)[1]--Spring.GetLocalTeamID()
-
-    local myBoxID = Spring.GetTeamRulesParam(myTeamID, "start_box_id")
-    if not myBoxID then -- can start anywhere
-        return {0, 1} -- players see themselves on the left, maybe should `return 0, 1` (see fixme above) so everybody sees everything the same?
-    end
-
-    local myBoxRepresentativeSpotX = Spring.GetGameRulesParam("startpos_x_" .. myBoxID .. "_1")
-
-    local comparisonX
-    if Spring.GetGameRulesParam("shuffleMode") == "allshuffle" and Spring.GetGameRulesParam("startbox_max_n") > 1 then
-        -- there are multiple boxes the enemy can be in so just look where we are on the map
-        comparisonX = Game.mapSizeX / 2
-    else
-        local enemyBoxID = 1 - myBoxID
-        comparisonX = Spring.GetGameRulesParam("startpos_x_" .. enemyBoxID .. "_1")
-    end
-
-    if myBoxRepresentativeSpotX <= comparisonX then
-        return {myAllyTeamID, enemyAllyTeamID}
-    else
-        return {enemyAllyTeamID, myAllyTeamID}
-    end
 end
 
 local function GetOpposingAllyTeams()


### PR DESCRIPTION
* Player/Team names now show on the side of the attrition and spectator panels corresponding to their start location on the map.
* Spectator Panel no longer messes with Economy Panel settings.