### PR TITLE
Updating Funnelweb turnrate

### DIFF
--- a/units/striderfunnelweb.lua
+++ b/units/striderfunnelweb.lua
@@ -71,7 +71,7 @@ unitDef = {
   trackStretch           = 1,
   trackType              = [[ChickenTrackPointy]],
   trackWidth             = 85,
-  turnRate               = 240,
+  turnRate               = 960,
   workerTime             = 40,
 
   weapons                = {


### PR DESCRIPTION
When I increased the Funnelweb's speed and reduced its size I forgot to update the turnrate.

Two possible turnrates worth considering:

1. Just bump to match visuals due to new speed and size: 240 -> 320
2. Consider role change and bump enough to reduce annoyance factor when using Funnel for construction and/or reclaim: 240 -> 960

I've gone with #2 for now as I can't think of a good gameplay reason for a slow turnrate on a constructor.

Anyone want to weigh in?