### PR TITLE
Context menu shield damage display improvements

### DIFF
--- a/LuaUI/Widgets/gui_contextmenu.lua
+++ b/LuaUI/Widgets/gui_contextmenu.lua
@@ -493,6 +493,23 @@ local function weapons2Table(cells, ws, unitID)
 		else
 			dam = val
 		end
+		
+		-- shield damage multiplier
+		local shieldDam = dam
+		if wd.customParams and wd.customParams.shield_damage_total then
+			-- Use the "real" damage value if possible
+			shieldDam = wd.customParams.shield_damage_total
+		else
+			-- Fallback on trying to calculate damage here
+			shieldDam = dam + damc + damd / 3 + dams / 3 + damc + damw / 3
+			local lowerName = name:lower()
+			if lowerName:find("flamethrower") or lowerName:find("flame thrower") then
+				shieldDam = shieldDam * 3
+			elseif lowerName:find("gauss") then
+				shieldDam = shieldDam * 1.5
+			end
+		end
+		local shieldDamPc = (100 * shieldDam) / (dam + damd + dams + damc + damw)
 
 		-- get reloadtime and calculate dps
 		local reloadtime = tonumber(cp.script_reload) or wd.reload
@@ -591,14 +608,11 @@ local function weapons2Table(cells, ws, unitID)
 			cells[#cells+1] = ' - DPS:'
 			cells[#cells+1] = dps_str
 		end
-		
-		local lowerName = name:lower()
-		if lowerName:find("flamethrower") or lowerName:find("flame thrower") then
-			cells[#cells+1] = ' - Shield damage:'
-			cells[#cells+1] = "300%"
-		elseif lowerName:find("gauss") then
-			cells[#cells+1] = ' - Shield damage:'
-			cells[#cells+1] = "150%"
+		if shieldDamPc ~= 100 then
+			if not cp.damage_vs_shield then -- Badger shield damage is handled above
+				cells[#cells+1] = ' - Shield damage:'
+				cells[#cells+1] = numformat(shieldDamPc, 2) .. "%"
+			end
 		end
 
 		if (wd.interceptedByShieldType == 0) then

--- a/gamedata/armordefs.lua
+++ b/gamedata/armordefs.lua
@@ -149,6 +149,7 @@ for name, wd in pairs(DEFS.weaponDefs) do
 		end
 	end
 	wd.customparams.shield_damage = wd.damage.shield/((wd.customparams.effective_beam_time or wd.beamtime or 1/30) * 30)
+	wd.customparams.shield_damage_total = wd.damage.shield
 	if wd.beamtime and wd.beamtime >= 0.1 then
 		-- Settings damage default to 0 removes cratering and impulse so is not universally applied.
 		-- It fixes long beams vs shield cases.

--- a/gamedata/armordefs.lua
+++ b/gamedata/armordefs.lua
@@ -149,7 +149,7 @@ for name, wd in pairs(DEFS.weaponDefs) do
 		end
 	end
 	wd.customparams.shield_damage = wd.damage.shield/((wd.customparams.effective_beam_time or wd.beamtime or 1/30) * 30)
-	wd.customparams.shield_damage_total = wd.damage.shield
+	wd.customparams.stats_shield_damage = wd.damage.shield
 	if wd.beamtime and wd.beamtime >= 0.1 then
 		-- Settings damage default to 0 removes cratering and impulse so is not universally applied.
 		-- It fixes long beams vs shield cases.


### PR DESCRIPTION
### Overview
This PR covers making the context menu state how much a weapon's on-paper damage is multiplied by when calculating shield damage.

Hopefully this will prevent disappointment when people fire a Shockley at a Funnelweb's shield and discover it only does 10K damage...

### Examples
* A Cyclop's slow beam will show " - Shield damage:   33%" because slow damage is 33% effective against shields.
* For multi-damage-type weapons (like a Scorpion's lightning gun) the damage is calculated for each damage type then summed. So a reader will see " - Shield damage:   50%" in the case of the Scorpion.
* Weapons with no special damage adjustment vs shields, such as a Dominatrix capture beam or a Ravager's cannon will continue to not state anything regarding shield damage.

Additionally, the shield damage percentages for gauss and flamethrowers will now come from the actual damage calculation, rather than being recalculated (and possibly getting out of sync).

### Regarding shield_damage_total 
I would like to rename `wd.customparams.shield_damage` to `wd.customparams.shield_damage_per_frame` in all the places it is used to better reflect its actual value and rename `shield_damage_total` to `shield_damage`.

However, I am unsure if this could potentially break some people's widgets.

Thoughts?