### PR TITLE
Experimental autonormal feature of the unit/feature shader

### DIFF
--- a/ModelMaterials/001_units_s3o_assimp.lua
+++ b/ModelMaterials/001_units_s3o_assimp.lua
@@ -21,6 +21,9 @@ local materials = {
 			[0] = "%TEX1",
 			[1] = "%TEX2",
 		},
+		shaderOptions = {
+			autonormal = true,
+		},
 		deferredOptions = {
 			materialIndex = 2,
 		},

--- a/ModelMaterials/126_units_3do.lua
+++ b/ModelMaterials/126_units_3do.lua
@@ -6,6 +6,9 @@ local materials = {
 			[0] = "$units1",
 			[1] = "$units2",
 		},
+		shaderOptions = {
+			autonormal = true,
+		},
 		deferredOptions = {
 			materialIndex = 126,
 		},

--- a/ModelMaterials/128_features_special.lua
+++ b/ModelMaterials/128_features_special.lua
@@ -108,7 +108,7 @@ local materials = {
 	featuresTreeMetalNoNormal = Spring.Utilities.MergeWithDefault(featureTreeTemplate, {
 		shaderOptions = {
 			autonormal = true,
-			autoNormalAmmount = 0.01,
+			autoNormalParams = {0.5, 0.01},
 			metal_highlight	= true,
 		},
 		deferredOptions = {
@@ -136,7 +136,7 @@ local materials = {
 	featuresTreeNoMetalNoNormal = Spring.Utilities.MergeWithDefault(featureTreeTemplate, {
 		shaderOptions = {
 			autonormal = true,
-			autoNormalAmmount = 0.01,
+			autoNormalParams = {0.5, 0.01},
 		},
 		deferredOptions = {
 			materialIndex = 131,
@@ -151,7 +151,7 @@ local materials = {
 		feature = true,
 		shaderOptions = {
 			autonormal = true,
-			autoNormalAmmount = 0.01,
+			autoNormalParams = {1.0, 0.005},
 			metal_highlight	= true,
 		},
 		deferredOptions = {

--- a/ModelMaterials/128_features_special.lua
+++ b/ModelMaterials/128_features_special.lua
@@ -107,6 +107,8 @@ local materials = {
 
 	featuresTreeMetalNoNormal = Spring.Utilities.MergeWithDefault(featureTreeTemplate, {
 		shaderOptions = {
+			autonormal = true,
+			autoNormalAmmount = 0.01,
 			metal_highlight	= true,
 		},
 		deferredOptions = {
@@ -132,6 +134,10 @@ local materials = {
 	}),
 
 	featuresTreeNoMetalNoNormal = Spring.Utilities.MergeWithDefault(featureTreeTemplate, {
+		shaderOptions = {
+			autonormal = true,
+			autoNormalAmmount = 0.01,
+		},
 		deferredOptions = {
 			materialIndex = 131,
 		},
@@ -144,6 +150,8 @@ local materials = {
 		},
 		feature = true,
 		shaderOptions = {
+			autonormal = true,
+			autoNormalAmmount = 0.01,
 			metal_highlight	= true,
 		},
 		deferredOptions = {

--- a/ModelMaterials/133_features_other.lua
+++ b/ModelMaterials/133_features_other.lua
@@ -9,7 +9,7 @@ local materials = {
 		feature = true,
 		shaderOptions = {
 			autonormal = true,
-			autoNormalAmmount = 0.01,
+			autoNormalParams = {0.5, 0.01},
 		},
 		deferredOptions = {
 			materialIndex = 133,

--- a/ModelMaterials/133_features_other.lua
+++ b/ModelMaterials/133_features_other.lua
@@ -7,6 +7,10 @@ local materials = {
 			[1] = "%%FEATUREDEFID:1",
 		},
 		feature = true,
+		shaderOptions = {
+			autonormal = true,
+			autoNormalAmmount = 0.01,
+		},
 		deferredOptions = {
 			materialIndex = 133,
 		},

--- a/ModelMaterials/254_features_3do.lua
+++ b/ModelMaterials/254_features_3do.lua
@@ -7,6 +7,10 @@ local materials = {
 			[1] = "$units2",
 		},
 		feature = true,
+		shaderOptions = {
+			autonormal = true,
+			autoNormalAmmount = 0.01,
+		},
 		deferredOptions = {
 			materialIndex = 254,
 		},

--- a/ModelMaterials/254_features_3do.lua
+++ b/ModelMaterials/254_features_3do.lua
@@ -9,7 +9,7 @@ local materials = {
 		feature = true,
 		shaderOptions = {
 			autonormal = true,
-			autoNormalAmmount = 0.01,
+			autoNormalParams = {0.5, 0.01},
 		},
 		deferredOptions = {
 			materialIndex = 254,

--- a/ModelMaterials/Templates/defaultMaterialTemplate.lua
+++ b/ModelMaterials/Templates/defaultMaterialTemplate.lua
@@ -726,7 +726,7 @@ local defaultMaterialTemplate = {
 		shadowsQuality	= 2,
 		materialIndex	= 0,
 
-		autoNormalParams = {1.5, 0.00125}, -- Sampling distance, autonormal value
+		autoNormalParams = {1.0, 0.00125}, -- Sampling distance, autonormal value
 		sunSpecularParams = {18.0, 4.0, 0.0}, -- Exponent, multiplier, bias
 		pomParams = {0.002, 1.0, 24.0, -2.0}, -- scale, minLayers, maxLayers, lodBias
 	},

--- a/ModelMaterials/Templates/defaultMaterialTemplate.lua
+++ b/ModelMaterials/Templates/defaultMaterialTemplate.lua
@@ -293,7 +293,7 @@ fragment = [[
 	uniform float shadowDensity;
 
 	uniform vec4 pomParams;
-	uniform float autoNormalAmmount;
+	uniform vec2 autoNormalParams;
 
 	uniform int shadowsQuality;
 	uniform int materialIndex;
@@ -345,6 +345,10 @@ fragment = [[
 		float selfIllumMod;
 		float fogFactor;
 	};
+
+	/***********************************************************************/
+	// Constants
+	const vec3 LUMA = vec3(0.2126, 0.7152, 0.0722);
 
 	/***********************************************************************/
 	// Shadow mapping functions
@@ -436,7 +440,8 @@ fragment = [[
 	}
 
 
-	#define GetDiffuseVal(tex, uv) length(texture(tex, uv).xyz)
+	#define GetDiffuseVal(tex, uv) length(texture(tex, uv).rgb)
+	//#define GetDiffuseVal(tex, uv) dot(LUMA, texture(tex, uv).rgb)
 	vec2 GetDiffuseGrad(vec2 uv, vec2 delta) {
 		vec3 d = vec3(delta, 0.0);
 		return vec2(
@@ -448,7 +453,7 @@ fragment = [[
 	vec3 GetNormalFromDiffuse(vec2 uv) {
 		vec2 texDim = vec2(textureSize(texture1, 0));
 		return normalize(
-			vec3(GetDiffuseGrad(uv, 0.5 / texDim), 1.0 / autoNormalAmmount)
+			vec3(GetDiffuseGrad(uv, autoNormalParams.x / texDim), 1.0 / autoNormalParams.y)
 		);
 	}
 
@@ -532,7 +537,7 @@ fragment = [[
 #if (RENDERING_MODE != 2) //non-shadow pass
 	// Fragment shader main()
 	void main(void){
-		#line 30534
+		#line 30540
 
 		vec2 myUV = modelUV;
 
@@ -721,7 +726,7 @@ local defaultMaterialTemplate = {
 		shadowsQuality	= 2,
 		materialIndex	= 0,
 
-		autoNormalAmmount = 0.00125,
+		autoNormalParams = {1.5, 0.00125}, -- Sampling distance, autonormal value
 		sunSpecularParams = {18.0, 4.0, 0.0}, -- Exponent, multiplier, bias
 		pomParams = {0.002, 1.0, 24.0, -2.0}, -- scale, minLayers, maxLayers, lodBias
 	},
@@ -805,7 +810,7 @@ local knownIntOptions = {
 
 }
 local knownFloatOptions = {
-	["autoNormalAmmount"] = 1,
+	["autoNormalParams"] = 2,
 	["pomParams"] = 4,
 	["sunSpecularParams"] = 3,
 }

--- a/ModelMaterials/Templates/defaultMaterialTemplate.lua
+++ b/ModelMaterials/Templates/defaultMaterialTemplate.lua
@@ -15,6 +15,7 @@ vertex = [[
 	#define OPTION_METAL_HIGHLIGHT 7
 	#define OPTION_TREEWIND 8
 	#define OPTION_POM 9
+	#define OPTION_AUTONORMAL 10
 
 	/***********************************************************************/
 	// Definitions
@@ -149,7 +150,7 @@ vertex = [[
 				shadowVertexPos.xy += vec2(0.5);  //no need for shadowParams anymore
 			}
 
-			if (BITMASK_FIELD(bitOptions, OPTION_NORMALMAPPING)) {
+			if (BITMASK_FIELD(bitOptions, OPTION_NORMALMAPPING) || BITMASK_FIELD(bitOptions, OPTION_AUTONORMAL)) {
 				//no need to do Gram-Schmidt re-orthogonalization, because engine does it for us anyway
 				vec3 T = gl_MultiTexCoord5.xyz;
 				vec3 B = gl_MultiTexCoord6.xyz;
@@ -247,6 +248,7 @@ fragment = [[
 	#define OPTION_METAL_HIGHLIGHT 7
 	#define OPTION_TREEWIND 8
 	#define OPTION_POM 9
+	#define OPTION_AUTONORMAL 10
 
 	/***********************************************************************/
 	// Definitions
@@ -265,7 +267,7 @@ fragment = [[
 		#define GBUFFER_COUNT 5
 	#endif
 
-	#line 20169
+	#line 20270
 
 
 	/***********************************************************************/
@@ -291,6 +293,7 @@ fragment = [[
 	uniform float shadowDensity;
 
 	uniform vec4 pomParams;
+	uniform float autoNormalAmmount;
 
 	uniform int shadowsQuality;
 	uniform int materialIndex;
@@ -433,6 +436,22 @@ fragment = [[
 	}
 
 
+	#define GetDiffuseVal(tex, uv) length(texture(tex, uv).xyz)
+	vec2 GetDiffuseGrad(vec2 uv, vec2 delta) {
+		vec3 d = vec3(delta, 0.0);
+		return vec2(
+			GetDiffuseVal(texture1, uv + d.xz) - GetDiffuseVal(texture1, uv - d.xz),
+			GetDiffuseVal(texture1, uv + d.zy) - GetDiffuseVal(texture1, uv - d.zy)
+		) / delta;
+	}
+
+	vec3 GetNormalFromDiffuse(vec2 uv) {
+		vec2 texDim = vec2(textureSize(texture1, 0));
+		return normalize(
+			vec3(GetDiffuseGrad(uv, 0.5 / texDim), 1.0 / autoNormalAmmount)
+		);
+	}
+
 	#define POM_SCALE pomParams.x
 	#define POM_MINLAYERS pomParams.y
 	#define POM_MAXLAYERS pomParams.z
@@ -513,7 +532,7 @@ fragment = [[
 #if (RENDERING_MODE != 2) //non-shadow pass
 	// Fragment shader main()
 	void main(void){
-		#line 30342
+		#line 30534
 
 		vec2 myUV = modelUV;
 
@@ -522,7 +541,10 @@ fragment = [[
 		}
 
 		mat3 worldTBN;
-		if (BITMASK_FIELD(bitOptions, OPTION_NORMALMAPPING) || BITMASK_FIELD(bitOptions, OPTION_POM)) {
+		if (BITMASK_FIELD(bitOptions, OPTION_NORMALMAPPING) ||
+			BITMASK_FIELD(bitOptions, OPTION_POM) ||
+			BITMASK_FIELD(bitOptions, OPTION_AUTONORMAL))
+		{
 			worldTBN = mat3(worldTangent, worldBitangent, worldNormal);
 		}
 
@@ -544,6 +566,9 @@ fragment = [[
 
 		if (BITMASK_FIELD(bitOptions, OPTION_NORMALMAPPING)) {
 			vec3 tbnNormal = NORM2SNORM(texture(normalTex, myUV).xyz);
+			N = worldTBN * tbnNormal;
+		} else if (BITMASK_FIELD(bitOptions, OPTION_AUTONORMAL)) {
+			vec3 tbnNormal = GetNormalFromDiffuse(myUV);
 			N = worldTBN * tbnNormal;
 		} else {
 			N = worldNormal;
@@ -625,7 +650,7 @@ fragment = [[
 		#undef wreckMetal
 
 		#if 0
-			finalColor = vec3(shadow);
+			finalColor = vec3( GetNormalFromDiffuse(myUV));
 		#endif
 
 		#if (RENDERING_MODE == 0)
@@ -691,10 +716,12 @@ local defaultMaterialTemplate = {
 		metal_highlight = false,
 		treewind 		= false,
 		pom 			= false,
+		autonormal 		= false,
 
 		shadowsQuality	= 2,
 		materialIndex	= 0,
 
+		autoNormalAmmount = 0.00125,
 		sunSpecularParams = {18.0, 4.0, 0.0}, -- Exponent, multiplier, bias
 		pomParams = {0.002, 1.0, 24.0, -2.0}, -- scale, minLayers, maxLayers, lodBias
 	},
@@ -710,6 +737,7 @@ local defaultMaterialTemplate = {
 		metal_highlight = false,
 		treewind 		= false,
 		pom 			= false,
+		autonormal 		= false,
 
 		shadowsQuality	= 0,
 		materialIndex	= 0,
@@ -768,6 +796,7 @@ local knownBitOptions = {
 	["metal_highlight"] = 7,
 	["treewind"] = 8,
 	["pom"] = 9,
+	["autonormal"] = 10,
 }
 
 local knownIntOptions = {
@@ -776,6 +805,7 @@ local knownIntOptions = {
 
 }
 local knownFloatOptions = {
+	["autoNormalAmmount"] = 1,
 	["pomParams"] = 4,
 	["sunSpecularParams"] = 3,
 }
@@ -852,15 +882,14 @@ local function ApplyOptions(luaShader, materialDef, key)
 
 		elseif knownIntOptions[optName] then --integer
 
-			if type(optValue) == "number" then
+			if type(optValue) == "number" and knownFloatOptions[optName] == 1 then
 				luaShader:SetUniformInt(optName, optValue)
 			elseif type(optValue) == "table" and knownIntOptions[optName] == #optValue then
 				luaShader:SetUniformInt(optName, unpack(optValue))
 			end
 
 		elseif knownFloatOptions[optName] then --float
-
-			if type(optValue) == "number" then
+			if type(optValue) == "number" and knownFloatOptions[optName] == 1 then
 				luaShader:SetUniformFloat(optName, optValue)
 			elseif type(optValue) == "table" and knownFloatOptions[optName] == #optValue then
 				luaShader:SetUniformFloat(optName, unpack(optValue))

--- a/ModelMaterials/Templates/defaultMaterialTemplate.lua
+++ b/ModelMaterials/Templates/defaultMaterialTemplate.lua
@@ -887,7 +887,7 @@ local function ApplyOptions(luaShader, materialDef, key)
 
 		elseif knownIntOptions[optName] then --integer
 
-			if type(optValue) == "number" and knownFloatOptions[optName] == 1 then
+			if type(optValue) == "number" and knownIntOptions[optName] == 1 then
 				luaShader:SetUniformInt(optName, optValue)
 			elseif type(optValue) == "table" and knownIntOptions[optName] == #optValue then
 				luaShader:SetUniformInt(optName, unpack(optValue))


### PR DESCRIPTION
As I couldn't do anything productive this weekend I came by shadertoy to see if anything inspires and it truly did (like always). Here is the port of https://www.shadertoy.com/view/ttlSRS to ZK units/features that have no artist normal map. Call it crazybump for poor && lazy.

Autonormal on
![Spring Screenshot 2019 08 04 - 13 53 36 64](https://user-images.githubusercontent.com/1476261/62422726-b0a31f80-b6bf-11e9-9dd6-9b55992bf348.png)

Autonormal off
![Spring Screenshot 2019 08 04 - 13 53 32 78](https://user-images.githubusercontent.com/1476261/62422727-b13bb600-b6bf-11e9-9567-728d11132d8c.png)

Individual units and wrecks might require some hand tuning on how pronounced the effect is. 
