### PR TITLE
Minor fixes and precautions in case objects are nil

### DIFF
--- a/LuaRules/Gadgets/api_custom_unit_shaders.lua
+++ b/LuaRules/Gadgets/api_custom_unit_shaders.lua
@@ -532,12 +532,10 @@ local function BindMaterials()
 end
 
 local function ToggleAdvShading()
-	if (not advShading) then
-		unitRendering.drawList = {}
-		featureRendering.drawList = {}
+	unitRendering.drawList = {}
+	featureRendering.drawList = {}
 
-		BindMaterials()
-	end
+	BindMaterials()
 end
 
 local function GetShaderOverride(objectID, objectDefID)
@@ -595,7 +593,7 @@ local function _CleanupEverything(rendering)
 		if mat.Finalize then
 			mat.Finalize(matName, matSrc)
 		end
-		for _, shaderObject in ipairs({mat.standardShaderObj, mat.deferredShaderObj, mat.shadowShaderObj}) do
+		for _, shaderObject in pairs({mat.standardShaderObj, mat.deferredShaderObj, mat.shadowShaderObj}) do
 			if shaderObject then
 				shaderObject:Finalize()
 			end
@@ -657,7 +655,7 @@ function gadget:DrawGenesis()
 			local ApplyOptionsFunc = mat.ApplyOptions
 
 			if SunChangedFunc or DrawGenesisFunc or (optionsChanged and ApplyOptionsFunc) then
-				for key, shaderObject in ipairs({mat.standardShaderObj, mat.deferredShaderObj, mat.shadowShaderObj}) do
+				for key, shaderObject in pairs({mat.standardShaderObj, mat.deferredShaderObj, mat.shadowShaderObj}) do
 					if shaderObject then
 						shaderObject:ActivateWith( function ()
 
@@ -698,8 +696,11 @@ local function GameFrameSlow(gf)
 		for _, mat in pairs(rendering.materialDefs) do
 			local gameFrameSlowFunc = mat.GameFrameSlow
 			if gameFrameSlowFunc then
-				for key, shaderObject in ipairs({mat.standardShaderObj, mat.deferredShaderObj}) do
-					gameFrameSlowFunc(gf, mat, (key == 2))
+				if mat.standardShaderObj then
+					gameFrameSlowFunc(gf, mat, false)
+				end
+				if mat.deferredShaderObj then
+					gameFrameSlowFunc(gf, mat, true)
 				end
 			end
 		end

--- a/ModelMaterials/128_features_special.lua
+++ b/ModelMaterials/128_features_special.lua
@@ -49,7 +49,7 @@ local function GameFrameSlow(gf, mat, isDeferred)
 		highlightActive = mat.shaderOptions.metal_highlight
 	end
 
-	if highlightActive and (isDeferred ~= nil) then
+	if highlightActive then
 		local fs = Spring.GetAllFeatures()
 		--local fs = Spring.GetVisibleFeatures(-1, 30, false)
 		for _, fID in ipairs(fs) do


### PR DESCRIPTION
Mostly just in case.

In case you missed the chat message:

> @GoogleFrog wrt https://github.com/ZeroK-RTS/CrashReports/issues/23504
> The bug happened on the engine version that didn't have Spring.FeatureRendering.SetForwardMaterialUniform,Spring.FeatureRendering.SetDeferredMaterialUniform functions
> I have little idea why someone ran new ZK on the old engine
> This engine is June 30 built, while the relevant functions were added on July 8th
> Mystery solved.