### PR TITLE
Fixing wreck collision boxes for some of the worst factories

### DIFF
--- a/units/factoryamph.lua
+++ b/units/factoryamph.lua
@@ -76,6 +76,9 @@ unitDef = {
       footprintX       = 7,
       footprintZ       = 7,
       object           = [[FACTORY2_DEAD.s3o]],
+      collisionVolumeOffsets = [[0 0 -16]],
+      collisionVolumeScales  = [[104 70 36]],
+      collisionVolumeType    = [[box]],
     },
 
     HEAP  = {

--- a/units/factorygunship.lua
+++ b/units/factorygunship.lua
@@ -79,6 +79,9 @@ unitDef = {
       footprintX       = 7,
       footprintZ       = 6,
       object           = [[corplas_dead.s3o]],
+      collisionVolumeOffsets        = [[0 -20 0]],
+      collisionVolumeScales         = [[86 86 86]],
+      collisionVolumeType           = [[ellipsoid]],
     },
 
 

--- a/units/factoryhover.lua
+++ b/units/factoryhover.lua
@@ -74,11 +74,15 @@ unitDef = {
   featureDefs      = {
 
     DEAD  = {
-      blocking         = false,
+      blocking         = true,
       featureDead      = [[HEAP]],
       footprintX       = 8,
       footprintZ       = 7,
       object           = [[ARMFHP_DEAD.s3o]],
+      collisionVolumeOffsets  = [[0 -2 -50]],
+      collisionVolumeScales   = [[124 32 124]],
+      collisionVolumeType     = [[cylY]],
+
     },
 
 

--- a/units/factoryjump.lua
+++ b/units/factoryjump.lua
@@ -82,6 +82,9 @@ unitDef = {
       footprintX       = 5,
       footprintZ       = 6,
       object           = [[factoryjump_dead.s3o]],
+      collisionVolumeOffsets        = [[0 0 -18]],
+      collisionVolumeScales         = [[104 70 40]],
+      collisionVolumeType           = [[box]],
     },
 
 

--- a/units/factoryspider.lua
+++ b/units/factoryspider.lua
@@ -80,6 +80,9 @@ unitDef = {
       footprintX       = 5,
       footprintZ       = 6,
       object           = [[factory3_dead.s3o]],
+      collisionVolumeOffsets        = [[0 0 -16]],
+      collisionVolumeScales         = [[104 50 36]],
+      collisionVolumeType           = [[box]],
     },
 
     HEAP  = {


### PR DESCRIPTION
Mostly done by copying the collision boxes of the intact factories (and maybe moving them slightly).
Also, hoverfac wrecks are no longer intangible!