### PR TITLE
Fix https://github.com/ZeroK-RTS/Zero-K/issues/3692

### DIFF
--- a/units/cloakaa.lua
+++ b/units/cloakaa.lua
@@ -19,6 +19,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[11]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/cloakassault.lua
+++ b/units/cloakassault.lua
@@ -20,6 +20,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[12]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/cloakcon.lua
+++ b/units/cloakcon.lua
@@ -26,6 +26,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[14]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/cloakheavyraid.lua
+++ b/units/cloakheavyraid.lua
@@ -22,6 +22,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[14]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[SMALL_UNITEX]],

--- a/units/cloakjammer.lua
+++ b/units/cloakjammer.lua
@@ -22,6 +22,7 @@ unitDef = {
     area_cloak_decloak_distance = 75,
     
     priority_misc = 2, -- High
+    cus_noflashlight = 1,
   },
 
   energyUse              = 1.5,

--- a/units/cloakraid.lua
+++ b/units/cloakraid.lua
@@ -17,6 +17,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[16]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[SMALL_UNITEX]],

--- a/units/cloakriot.lua
+++ b/units/cloakriot.lua
@@ -20,6 +20,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[7]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[SMALL_UNITEX]],

--- a/units/cloakskirm.lua
+++ b/units/cloakskirm.lua
@@ -19,6 +19,7 @@ unitDef = {
     modelradius    = [[18]],
     midposoffset   = [[0 6 0]],
     reload_move_penalty = 0.8,
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/factoryamph.lua
+++ b/units/factoryamph.lua
@@ -45,6 +45,7 @@ unitDef = {
     selectionscalemult = 1,
     factorytab       = 1,
     shared_energy_gen = 1,
+    cus_noflashlight = 1,
   },
 
   energyUse        = 0,

--- a/units/factoryship.lua
+++ b/units/factoryship.lua
@@ -43,6 +43,7 @@ unitDef = {
     selectionscalemult = 1,
     factorytab       = 1,
     shared_energy_gen = 1,
+    cus_noflashlight = 1,
   },
 
   energyUse              = 0,

--- a/units/factoryspider.lua
+++ b/units/factoryspider.lua
@@ -46,6 +46,7 @@ unitDef = {
     selectionscalemult = 1,
     factorytab       = 1,
     shared_energy_gen = 1,
+    cus_noflashlight = 1,
   },
 
   energyUse                     = 0,

--- a/units/shieldassault.lua
+++ b/units/shieldassault.lua
@@ -18,6 +18,7 @@ unitDef = {
 
   customParams        = {
     shield_emit_height = 17,
+    cus_noflashlight = 1,
   },
 
   explodeAs           = [[BIG_UNITEX]],
@@ -109,7 +110,7 @@ unitDef = {
         light_color = [[0.80 0.54 0.23]],
         light_radius = 200,
       },
-      
+
       damage                  = {
         default = 170,
         planes  = 170,

--- a/units/spideraa.lua
+++ b/units/spideraa.lua
@@ -13,6 +13,7 @@ unitDef = {
   corpse                 = [[DEAD]],
 
   customParams           = {
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/spiderantiheavy.lua
+++ b/units/spiderantiheavy.lua
@@ -20,6 +20,7 @@ unitDef = {
 
   customParams          = {
     dontfireatradarcommand = '1',
+    cus_noflashlight = 1,
   },
 
   explodeAs             = [[BIG_UNITEX]],

--- a/units/spiderassault.lua
+++ b/units/spiderassault.lua
@@ -17,6 +17,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[12]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/tankheavyarty.lua
+++ b/units/tankheavyarty.lua
@@ -18,6 +18,7 @@ unitDef = {
 
   customParams           = {
     modelradius    = [[17]],
+    cus_noflashlight = 1,
   },
 
   explodeAs              = [[BIG_UNIT]],

--- a/units/tankriot.lua
+++ b/units/tankriot.lua
@@ -17,6 +17,7 @@ unitDef = {
   corpse              = [[DEAD]],
 
   customParams        = {
+    cus_noflashlight = 1,
   },
 
   explodeAs           = [[BIG_UNITEX]],

--- a/units/turretlaser.lua
+++ b/units/turretlaser.lua
@@ -19,6 +19,7 @@ unitDef = {
 
   customParams                  = {
     aimposoffset   = [[0 22 0]],
+    cus_noflashlight = 1,
   },
 
   explodeAs                     = [[SMALL_BUILDINGEX]],

--- a/units/vehcapture.lua
+++ b/units/vehcapture.lua
@@ -22,6 +22,7 @@ unitDef = {
   customParams        = {
     modelradius    = [[13]],
     turnatfullspeed = [[1]],
+    cus_noflashlight = 1,
   },
 
   explodeAs           = [[BIG_UNITEX]],

--- a/units/vehcon.lua
+++ b/units/vehcon.lua
@@ -24,6 +24,7 @@ unitDef = {
   customParams           = {
     modelradius    = [[20]],
     selection_scale = 1.2,
+    cus_noflashlight = 1,
   },
 
   energyUse              = 0,


### PR DESCRIPTION
The next step would be to enable flashlights for units w/o normal maps (somehow I thought that units with normal maps have polished tex2 as well, but apparently it was not the case).
Once enabled the ones that glow badly will need to be disabled too. Perhaps if too many are bad, then it won't make sense to enable glow on non-normal mapped units.