### PR TITLE
Claw is `untargetable` and `neutral` after firing

### DIFF
--- a/scripts/wolverine_mine.lua
+++ b/scripts/wolverine_mine.lua
@@ -54,7 +54,8 @@ local function Remove ()
 	Spring.MoveCtrl.Enable(unitID, true)
 	Spring.MoveCtrl.SetNoBlocking(unitID, true)
 	Spring.MoveCtrl.SetPosition(unitID, x, Spring.GetGroundHeight(x, z) - 1000, z)
-
+	Spring.SetUnitRulesParam(unitID,'untargetable',1)
+	Spring.SetUnitNeutral(unitID,true)
 	Sleep(5000)
 	Spring.DestroyUnit(unitID, false, true)
 end


### PR DESCRIPTION
Takes a few tricks out of Glint's playbook and applies them to Claw after it fires.

The `untargetable` URP prevents everything that could affect the Claw while mediated through a command (with gadget help).

The `neutral` property prevents auto-targeting by units that don't have an explicit command to target that unit.

This should fix #3413, fix https://github.com/ZeroK-RTS/Zero-K/issues/2214 and fix https://github.com/ZeroK-RTS/Zero-K/issues/3339.

Untested. If this works, should also be applied to tac silo missiles and Puppy.