### PR TITLE
Transfer capture damage progress on morph finish

### DIFF
--- a/LuaRules/Gadgets/unit_morph.lua
+++ b/LuaRules/Gadgets/unit_morph.lua
@@ -507,13 +507,12 @@ local function FinishMorph(unitID, morphData)
 		newHealth = 1
 	end
 	
-	local newPara = 0
-	newPara = paralyzeDamage*newMaxHealth/oldMaxHealth
+	local newPara = paralyzeDamage*newMaxHealth/oldMaxHealth
 	local slowDamage = Spring.GetUnitRulesParam(unitID,"slowState")
 	if slowDamage then
 		GG.addSlowDamage(newUnit, slowDamage*newMaxHealth)
 	end
-	Spring.SetUnitHealth(newUnit, {health = newHealth, build = buildProgress, paralyze = newPara})
+	Spring.SetUnitHealth(newUnit, {health = newHealth, build = buildProgress, paralyze = newPara, capture = captureProgress })
 	
 	--//transfer experience
 	newXp = newXp * (oldBuildTime / Spring.Utilities.GetUnitCost(unitID, morphData.def.into))


### PR DESCRIPTION
This transfers both the visual progress indication and the internal state
from the capture gadget.

Tested:
 - Morphs without any capture damage
 - Morphs with some capture damage
 - Morphs under control of a mastermind
 - Morphs finishing after a mastermind capture while morph was in-progress
 - Morphs started and finished after mastermind capture
 - Mastermind self destruction in all of the above cases
 - No errors from a checkThingsDoubleTable call after the inserted code block during all of the above cases

Resolves #3704.