### PR TITLE
Boxing Trinity and Starlight hitboxes so fleas can no longer hide inside them.

### DIFF
--- a/units/mahlazer.lua
+++ b/units/mahlazer.lua
@@ -14,8 +14,8 @@ unitDef = {
   buildPic                      = [[mahlazer.png]],
   category                      = [[SINK]],
   collisionVolumeOffsets        = [[0 0 0]],
-  collisionVolumeScales         = [[160 160 160]],
-  collisionVolumeType           = [[ellipsoid]],
+  collisionVolumeScales         = [[120 100 120]],
+  collisionVolumeType           = [[box]],
   corpse                        = [[DEAD]],
 
   customParams                  = {

--- a/units/staticnuke.lua
+++ b/units/staticnuke.lua
@@ -12,6 +12,9 @@ unitDef = {
   buildingGroundDecalType       = [[staticnuke_aoplane.dds]],
   buildPic                      = [[staticnuke.png]],
   category                      = [[SINK UNARMED]],
+  collisionVolumeOffsets        = [[0 0 0]],
+  collisionVolumeScales         = [[90 55 115]],
+  collisionVolumeType           = [[box]],
   corpse                        = [[DEAD]],
 
   customParams                  = {


### PR DESCRIPTION
Fixes issues like the one that appeared towards the end of this game: https://zero-k.info/Battles/Detail/780636 Where a flea was untargettable when too close to the Trinity and could have killed the Trinity with little to stop it.

Someone similar happened a few months ago in a lobsterpot where a sunken Starlight got a flea stuck in it that slowly killed it over the space of five minutes.