### PR TITLE
Elevating centre of Bertha so that terraformed Berthas are targettable

### DIFF
--- a/units/staticheavyarty.lua
+++ b/units/staticheavyarty.lua
@@ -10,15 +10,13 @@ unitDef = {
   buildingGroundDecalType       = [[staticheavyarty_aoplane.dds]],
   buildPic                      = [[staticheavyarty.png]],
   category                      = [[SINK]],
-  selectionVolumeOffsets        = [[0 -40 0]],
-  collisionVolumeOffsets        = [[0 -40 0]],
+  collisionVolumeOffsets        = [[0 0 0]],
   collisionVolumeScales         = [[70 194 70]],
   collisionVolumeType           = [[cylY]],
   corpse                        = [[DEAD]],
 
   customParams                  = {
-
-    midposoffset   = [[0, 40, 0]],
+    aimposoffset = [[0 50 0]],
     modelradius    = [[35]],
     selectionscalemult = 1,
   },

--- a/units/staticheavyarty.lua
+++ b/units/staticheavyarty.lua
@@ -10,13 +10,15 @@ unitDef = {
   buildingGroundDecalType       = [[staticheavyarty_aoplane.dds]],
   buildPic                      = [[staticheavyarty.png]],
   category                      = [[SINK]],
-  collisionVolumeOffsets        = [[0 0 0]],
+  selectionVolumeOffsets        = [[0 -40 0]],
+  collisionVolumeOffsets        = [[0 -40 0]],
   collisionVolumeScales         = [[70 194 70]],
   collisionVolumeType           = [[cylY]],
   corpse                        = [[DEAD]],
 
   customParams                  = {
 
+    midposoffset   = [[0, 40, 0]],
     modelradius    = [[35]],
     selectionscalemult = 1,
   },

--- a/units/staticheavyarty.lua
+++ b/units/staticheavyarty.lua
@@ -110,6 +110,9 @@ unitDef = {
 
     DEAD  = {
       blocking         = true,
+      collisionVolumeOffsets        = [[0 0 -7]],
+      collisionVolumeScales         = [[70 194 70]],
+      collisionVolumeType           = [[cylY]],
       featureDead      = [[HEAP]],
       footprintX       = 4,
       footprintZ       = 4,

--- a/units/staticheavyarty.lua
+++ b/units/staticheavyarty.lua
@@ -10,13 +10,13 @@ unitDef = {
   buildingGroundDecalType       = [[staticheavyarty_aoplane.dds]],
   buildPic                      = [[staticheavyarty.png]],
   category                      = [[SINK]],
-  collisionVolumeOffsets        = [[0 0 0]],
-  collisionVolumeScales         = [[70 194 70]],
+  collisionVolumeOffsets        = [[0 0 -7]],
+  collisionVolumeScales         = [[65 194 65]],
   collisionVolumeType           = [[cylY]],
   corpse                        = [[DEAD]],
 
   customParams                  = {
-    aimposoffset = [[0 50 0]],
+    aimposoffset = [[0 50 -7]],
     modelradius    = [[35]],
     selectionscalemult = 1,
   },


### PR DESCRIPTION
Currently Redbacks, Scorpions and Fleas can't target Berthas that have been terraformed up on high spikes. This is because the targetting centre of the Bertha is so low that the ground of the platform it's on blocks line of sight.

This pull request elevates the Berthas centre so that Fleas, Redbacks and Scorpions will be able to fire at it, while leaving the collision volumes and selection volumes untouched.