### PR TITLE
Preserve build queue from an incomplete builder

### DIFF
--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -36,6 +36,7 @@ local spGetMyTeamID     = Spring.GetMyTeamID
 local spGetTeamUnits    = Spring.GetTeamUnits
 local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 local spGetUnitDefID    = Spring.GetUnitDefID
+local spGetUnitIsStunned = Spring.GetUnitIsStunned
 local spGetUnitPosition = Spring.GetUnitPosition
 local spGiveOrderToUnit = Spring.GiveOrderToUnit
 local spGetGameRulesParam = Spring.GetGameRulesParam
@@ -172,11 +173,13 @@ function widget:UnitGiven(unitID, unitDefID, unitTeam)
 end
 
 function widget:UnitIdle(unitID, unitDefID, unitTeam)
+	local _,_,isNanoframe = spGetUnitIsStunned(unitID)
 	if not enableIdleNanos
 	or stoppedUnit[unitID]
 	or unitTeam ~= spGetMyTeamID()
 	or not IsImmobileBuilder(UnitDefs[unitDefID])
 	or spGetGameRulesParam("loadPurge") == 1
+	or isNanoframe
 	then
 		return
 	end


### PR DESCRIPTION
The unit must be an immobile builder capable of starting construction,
so this only applies to an incomplete Strider Hub.

When shift was pressed, cmd_guard_remove.lua triggers, removing the
old patrol command. Because the Strider Hub is still a nanoframe and
can't do anything, UnitIdle was immediately called for
unit_auto_patrol_nanos, which calls SetupUnit and overwrites the newly
queued build order with an unshifted patrol command.

Checking that the Idle unit was complete and therefore has a meaningful
idle state resolves this problem.