### PR TITLE
Only specteam if selected team actually changed

### DIFF
--- a/LuaUI/Widgets/gui_spectate_selected_team.lua
+++ b/LuaUI/Widgets/gui_spectate_selected_team.lua
@@ -12,6 +12,7 @@ function widget:GetInfo()
 end
 
 local spGetUnitTeam = Spring.GetUnitTeam
+local spGetMyTeamID = Spring.GetMyTeamID
 local spSendCommands = Spring.SendCommands
 
 local specOld = false
@@ -75,7 +76,8 @@ function widget:SelectionChanged(selection)
   if selection and #selection > 0 then
     -- I cannot read users mind, use first unit
     team = spGetUnitTeam(selection[1])
-    if team then
+    local lastTeam = spGetMyTeamID()
+    if team and team ~= lastTeam then
       spSendCommands("specteam "..team)
     end
   end


### PR DESCRIPTION
Since spring/spring@9d3cfda, widgets get a PlayerChanged event whenever
a spectator changes spectating teams. This causes a lot of recomputation,
so to avoid unnecessary load we only issue a specteam command if the new
team differs.

See #3730