### PR TITLE
Blind fix for widget local include

### DIFF
--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -676,7 +676,7 @@ function widgetHandler:NewWidget()
   widget.widgetHandler = {}
   local wh = widget.widgetHandler
   local self = self
-  widget.include  = function (f) return include(f, widget) end
+  widget.include  = function (f,_,MODE) return include(f, widget, MODE) end
   wh.ForceLayout  = function (_) self:ForceLayout() end
   wh.RaiseWidget  = function (_) self:RaiseWidget(widget) end
   wh.LowerWidget  = function (_) self:LowerWidget(widget) end


### PR DESCRIPTION
include() within a widget seems to always use defaults in the 3rd arg,
and, given gdb says that VFS.Include sees the second, environment
parameter as a table that appears to be an entire widget, I believe
this is the culprit.

I cannot test this, as everything works fine when in a local skirmish.
Some engine code appears to relax some restrictions in devmode.
I cannot be sure that this is why, but it seems plausible.