### PR TITLE
Increase Raptor air superiority

### DIFF
--- a/scripts/planeheavyfighter.lua
+++ b/scripts/planeheavyfighter.lua
@@ -13,7 +13,7 @@ local smokePiece = {base, engineL, engineR}
 --variables
 local gun = false
 
-local RESTORE_DELAY = 250
+local RESTORE_DELAY = 150
 local FIRE_SLOWDOWN = tonumber(UnitDef.customParams.combat_slowdown)
 
 --signals

--- a/units/planeheavyfighter.lua
+++ b/units/planeheavyfighter.lua
@@ -28,7 +28,7 @@ return { planeheavyfighter = {
     modelradius    = [[10]],
     refuelturnradius = [[120]],
 
-    combat_slowdown = 0.5,
+    combat_slowdown = 0.35,
     selection_scale = 1.4,
   },
 
@@ -41,7 +41,7 @@ return { planeheavyfighter = {
   iconType               = [[stealthfighter]],
   idleAutoHeal           = 5,
   idleTime               = 1800,
-  maxAcc                 = 0.5,
+  maxAcc                 = 0.55,
   maxDamage              = 1100,
   maxRudder              = 0.006,
   maxVelocity            = 7.6,


### PR DESCRIPTION
Planes can be superfluid, too.

Combat speed: 50% -> 35%
Combat turn speed: 200% -> 286%
Slowdown restore delay: 250ms -> 150ms
Acceleration increased 10%

With these changes Raptors spend more time firing during each pass and are more responsive to micro, e.g. firing then retreating to limit exposure to ground fire.

Trident can still get two salvos out before the Raptor's second pass when not microed.

Raptor can still chase and shoot at Nimbus and Krow.