### PR TITLE
Make land units faster in shallows.

### DIFF
--- a/gamedata/movedefs.lua
+++ b/gamedata/movedefs.lua
@@ -9,8 +9,8 @@
 --------------------------------------------------------------------------------
 
 local common_depthmodparams = {
-	quadraticCoeff = 0,
-	linearCoeff = 0.07,
+	quadraticCoeff = 0.0027,
+	linearCoeff = 0.02,
 }
 
 local moveDefs = {


### PR DESCRIPTION
Slightly slower near the depth limit. Examples:
Depth 3: 0.82 -> 0.92
Depth 6: 0.70 -> 0.82
Depth 9: 0.61 -> 0.71
Depth 15: 0.49 -> 0.52
Depth 21: 0.40 -> 0.38