### PR TITLE
Tighter velocity prediction for Scorcher

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -633,6 +633,7 @@ local behaviourConfig = {
 		swarmLeeway = 300,
 		skirmLeeway = 10,
 		stoppingDistance = 8,
+		velocityPrediction = 20,
 	},
 	
 	["hoverscout"] = {


### PR DESCRIPTION
Match Scorcher's velocity prediction to the frame rate of tactical AI.  This is specifically to prevent "overshoot" when predicting the movements of Locust and should help it keep close range against other units too.