### PR TITLE
Set gui_attrition_counter to draggable=false

### DIFF
--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -488,7 +488,7 @@ function CreateWindow()
 		minHeight = 65,
 		maxHeight = 65,
 		minWidth = 250,
-		draggable = true,
+		draggable = false,
 		resizable = false,
 		tweakDraggable = true,
 		tweakResizable = true,


### PR DESCRIPTION
A quick test PR for a personal pet peeve, I don't see a strong reason to have info widgets be draggable outside of the UI tweak mode since all other default widgets cannot be dragged during play.