### PR TITLE
subs can traverse shallows, but don't get super armor

### DIFF
--- a/gamedata/movedefs.lua
+++ b/gamedata/movedefs.lua
@@ -228,7 +228,7 @@ local moveDefs = {
 	UBOAT3 = {
 		footprintx = 3,
 		footprintz = 3,
-		minwaterdepth = 15,
+		minwaterdepth = 5,
 		crushstrength = 150,
 		subMarine = 1,
 	},

--- a/gamedata/weapondefs_post.lua
+++ b/gamedata/weapondefs_post.lua
@@ -365,6 +365,20 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 --
+-- Remove submarine damage modifier 
+-- TODO: also remove from defs
+
+for _, weaponDef in pairs(WeaponDefs) do
+	if weaponDef.damage then
+		if weaponDef.damage.subs and weaponDef.damage.default then
+			weaponDef.damage.subs = weaponDef.damage.default
+		end
+	end
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+--
 -- Fix the canAttack tag
 --
 

--- a/units/subraider.lua
+++ b/units/subraider.lua
@@ -45,7 +45,7 @@ return { subraider = {
   turninplace            = 0,
   turnRate               = 600,
   upright                = true,
-  waterline              = 20,
+  waterline              = 55,
   workerTime             = 0,
 
   weapons                = {

--- a/units/subtacmissile.lua
+++ b/units/subtacmissile.lua
@@ -47,7 +47,7 @@ return { subtacmissile = {
   turninplace            = 0,
   turnRate               = 307,
   upright                = true,
-  waterline              = 25,
+  waterline              = 55,
   workerTime             = 0,
 
   weapons                = {


### PR DESCRIPTION
Currently:

- They take 1/20 of damage from non-waterweapon sources, so that they are not killable with AoE weapons shooting at the water plane. This is inconsistent with amphs, who take full damage, submerged buildings, etc.
- ~~They can be physically thrown out of water, in which case the armor fails to go away.~~
- They can travel on water which is too shallow to hide their collision volume - Scylla, for example, has waterline 25 and minDepth 15. It will poke out if it travels at depths of -15, and will be shot by surface units. An example of this occuring is straits on Scorpio.
- Their min water depths are higher than for most other ships (excluding striders). This makes designing maps with borderline ship-navigable areas annoying.

Proposed:
- Submarines have same water depth as other ships
- Submarines have no special armor.
- Poking out of water behaviour is no longer a bug, but a feature. The player gets to decide whether to send them into shallows where they can be attacked, or not.