### PR TITLE
Fix Overkill Prevention tooltips

### DIFF
--- a/LuaRules/Gadgets/unit_overkill_prevention.lua
+++ b/LuaRules/Gadgets/unit_overkill_prevention.lua
@@ -128,7 +128,7 @@ local preventOverkillCmdDesc = {
 	name    = "Prevent Overkill.",
 	action  = 'preventoverkill',
 	tooltip	= 'Enable to prevent units shooting at units which are already going to die.',
-	params 	= {0, "Prevent Overkill", "Fire at anything"}
+	params 	= {0, "Fire at anything", "Prevent Overkill"}
 }
 
 -------------------------------------------------------------------------------------


### PR DESCRIPTION
"Prevents overkill" when enabled, "Fires at anything" when disabled,
rather than the reverse.