### PR TITLE
Implement weapon lookahead mechanics

### DIFF
--- a/LuaRules/Configs/target_lookahead_defs.lua
+++ b/LuaRules/Configs/target_lookahead_defs.lua
@@ -2,10 +2,7 @@
 local unitArray = {}
 
 for i=1,#UnitDefs do
-	local cp = UnitDefs[i].customParams
-	if cp and cp.lookahead then
-		unitArray[i] = cp.lookahead
-	end
+	unitArray[i] = UnitDefs[i].customParams.lookahead
 end
 
 return unitArray

--- a/LuaRules/Configs/target_lookahead_defs.lua
+++ b/LuaRules/Configs/target_lookahead_defs.lua
@@ -1,0 +1,11 @@
+-- unitDefID -> lookahead
+local unitArray = {}
+
+for i=1,#UnitDefs do
+	local cp = UnitDefs[i].customParams
+	if cp and cp.lookahead then
+		unitArray[i] = cp.lookahead
+	end
+end
+
+return unitArray

--- a/LuaRules/Configs/target_lookahead_defs.lua
+++ b/LuaRules/Configs/target_lookahead_defs.lua
@@ -1,8 +1,0 @@
--- unitDefID -> lookahead
-local unitArray = {}
-
-for i=1,#UnitDefs do
-	unitArray[i] = UnitDefs[i].customParams.lookahead
-end
-
-return unitArray

--- a/LuaRules/Gadgets/unit_target_lookahead.lua
+++ b/LuaRules/Gadgets/unit_target_lookahead.lua
@@ -1,0 +1,29 @@
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
+function gadget:GetInfo()
+  return {
+    name      = "Auto-Target Lookahead",
+    desc      = "Has units with slow moving/high AoE attacks look outside of their immediate range for automatic targeting.\n"..
+    "This obsoletes the aspect of PreFire that predicts when enemies will be in range by the time a projectile would hit them.",
+    author    = "esainane",
+    date      = "2020-05-03",
+    license   = "GNU GPL, v2 or later",
+    layer     = -1,
+    enabled   = true,
+  }
+end
+local lookaheadUnitDefs = include("LuaRules/Configs/target_lookahead_defs.lua")
+
+function gadget:UnitCreated(unitID, unitDefID)
+	local lookahead = lookaheadUnitDefs[unitDefID]
+	if not lookahead then
+		return
+	end
+	for weaponIdx=1,#UnitDefs[unitDefID].weapons do
+		Spring.SetUnitWeaponState(unitID,weaponIdx,"autoTargetRangeBoost",lookahead)
+	end
+end

--- a/LuaRules/Gadgets/unit_target_lookahead.lua
+++ b/LuaRules/Gadgets/unit_target_lookahead.lua
@@ -16,7 +16,11 @@ function gadget:GetInfo()
     enabled   = true,
   }
 end
-local lookaheadUnitDefs = include("LuaRules/Configs/target_lookahead_defs.lua")
+
+local lookaheadUnitDefs = {}
+for i=1,#UnitDefs do
+	lookaheadUnitDefs[i] = UnitDefs[i].customParams.lookahead
+end
 
 function gadget:UnitCreated(unitID, unitDefID)
 	local lookahead = lookaheadUnitDefs[unitDefID]

--- a/LuaRules/Gadgets/unit_target_lookahead.lua
+++ b/LuaRules/Gadgets/unit_target_lookahead.lua
@@ -18,8 +18,11 @@ function gadget:GetInfo()
 end
 
 local lookaheadUnitDefs = {}
-for i=1,#UnitDefs do
-	lookaheadUnitDefs[i] = UnitDefs[i].customParams.lookahead
+local weaponCounts = {}
+for i=1, #UnitDefs do
+	local unitDef = UnitDefs[i]
+	lookaheadUnitDefs[i] = unitDef.customParams.lookahead
+	weaponCounts[i] = #unitDef.weapons -- even for non-lookaheads, this keeps the internal representation an array
 end
 
 function gadget:UnitCreated(unitID, unitDefID)
@@ -27,7 +30,7 @@ function gadget:UnitCreated(unitID, unitDefID)
 	if not lookahead then
 		return
 	end
-	for weaponIdx=1,#UnitDefs[unitDefID].weapons do
-		Spring.SetUnitWeaponState(unitID,weaponIdx,"autoTargetRangeBoost",lookahead)
+	for weaponIdx=1, weaponCounts[unitDefID] do
+		Spring.SetUnitWeaponState(unitID, weaponIdx, "autoTargetRangeBoost", lookahead)
 	end
 end

--- a/units/cloakriot.lua
+++ b/units/cloakriot.lua
@@ -22,6 +22,8 @@ return { cloakriot = {
     modelradius       = [[7]],
     cus_noflashlight  = 1,
     selection_scale   = 0.85,
+
+    lookahead = 300,
   },
 
   explodeAs              = [[SMALL_UNITEX]],

--- a/units/gunshipheavyskirm.lua
+++ b/units/gunshipheavyskirm.lua
@@ -23,6 +23,7 @@ return { gunshipheavyskirm = {
   customParams        = {
     airstrafecontrol = [[0]],
     modelradius    = [[10]],
+    lookahead = 300,
   },
 
   explodeAs           = [[GUNSHIPEX]],

--- a/units/jumpraid.lua
+++ b/units/jumpraid.lua
@@ -24,6 +24,8 @@ return { jumpraid = {
     jump_from_midair   = 1,
     fireproof      = [[1]],
     stats_show_death_explosion = 1,
+
+    lookahead = 300,
   },
 
   explodeAs             = [[PYRO_DEATH]],

--- a/units/spideremp.lua
+++ b/units/spideremp.lua
@@ -19,6 +19,8 @@ return { spideremp = {
     aimposoffset   = [[0 0 0]],
     midposoffset   = [[0 -6 0]],
     modelradius    = [[19]],
+
+    lookahead    = 300,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/spiderskirm.lua
+++ b/units/spiderskirm.lua
@@ -14,6 +14,8 @@ return { spiderskirm = {
 
   customParams           = {
     midposoffset   = [[0 -5 0]],
+
+    lookahead = 300,
   },
 
   explodeAs              = [[BIG_UNITEX]],

--- a/units/striderdante.lua
+++ b/units/striderdante.lua
@@ -13,8 +13,9 @@ return { striderdante = {
   canPatrol           = true,
   category            = [[LAND]],
   corpse              = [[DEAD]],
-  
+
   customParams        = {
+    lookahead = 300,
   },
 
   explodeAs           = [[CRAWL_BLASTSML]],

--- a/units/tankraid.lua
+++ b/units/tankraid.lua
@@ -25,6 +25,8 @@ return { tankraid = {
     modelradius       = [[20]],
     aimposoffset      = [[0 5 0]],
     selection_scale   = 0.85,
+
+    lookahead      = 300,
   },
 
   explodeAs           = [[BIG_UNITEX]],

--- a/units/tankriot.lua
+++ b/units/tankriot.lua
@@ -19,6 +19,8 @@ return { tankriot = {
   customParams        = {
     cus_noflashlight  = 1,
     selection_scale   = 0.92,
+
+    lookahead         = 300,
   },
 
   explodeAs           = [[BIG_UNITEX]],

--- a/units/turretemp.lua
+++ b/units/turretemp.lua
@@ -16,9 +16,10 @@ return { turretemp = {
   corpse                        = [[DEAD]],
 
   customParams                  = {
-
     aimposoffset   = [[0 10 0]],
     modelradius    = [[16]],
+
+    lookahead    = 300,
   },
 
   damageModifier                = 0.25,

--- a/units/turretriot.lua
+++ b/units/turretriot.lua
@@ -19,6 +19,8 @@ return { turretriot = {
   customParams                  = {
     aimposoffset   = [[0 12 0]],
     midposoffset   = [[0 4 0]],
+
+    lookahead = 300,
   },
 
   explodeAs                     = [[LARGE_BUILDINGEX]],

--- a/units/vehriot.lua
+++ b/units/vehriot.lua
@@ -18,6 +18,8 @@ return { vehriot = {
 
   customParams        = {
     selection_scale   = 0.85,
+
+    lookahead    = 300,
   },
 
   explodeAs           = [[BIG_UNITEX]],


### PR DESCRIPTION
This obsoletes and implements in gadgetspace most of what the prefire
widgets did in widgetspace: Look at nearby units, including ones out
of immediate range, and if they would be in range when a projectile
would hit, fire in that direction.

Unlike PreFire, this also causes units to aim their weapons toward that
direction in advance, provided they don't already have a better target.
Units are now that much smarter!

This effectively implements PreFire without latency issues or lua speed,
fully uses engine synced target prediction, preserves all Zero-K
target priorities, and leaves the user free to use manual set-target
without interference.

Caveats:
 - Due to an engine issue, this won't do anything for Cannon
   projectile types until mantis #6382 is resolved.
 - terve's PreFire widgets consider weapon inaccuracy when deciding
   whether to set target on the ground. In rare cases you can have
   positions where a Reaver won't fire with engine lookahead but would
   fire and sometimes hit with PreFire. Similar cases are more common
   with Stardust.

This is applied to a fairly conservative list of units right now,
taken from the list of PreFire widgets and the subset of SweepAttack
widgets where I think PreFire is a non-trivial component. This list
could easily be extended to units where swiveling to aim at units
before they are immediately in range (but not firing until they would
hit) to make units feel much smarter in a many situations.

Some possible follow-ups:
 - Raider exchanges are more even when the retreating side has their
   body aimed away in advance, but pre-aims the weapon so they can fire
   at the same time chasers begin firing. Currently chasers win even
   engagements due retreaters having to waste time either repositioning
   their body or repositioning their weapons.
 - Stingers look a lot smarter when they move to aim in advance.
   This might be due to the visual prominence of their turret, but it
   does save a lot of very real frames if care wasn't taken to build
   the stinger facing the direction of expected attacks.
   (I freely admit I haven't bothered to do this)
 - Units that receive a height range bonus (such as Crab) seem to already
   lookahead slightly as they seem to overestimate the range bonus.
   The difference doesn't seem to be as large as expected, but Crab fits
   the definition of "uses slow moving projectiles with large AoE", and
   being as smart on even ground probably helps a little.
 - Vehicles with slowly turning turrets feel smarter during early
   engagements, though nothing compensates for body turn outpacing
   turret turn when the user really wants to spin corners.
 - Cyclops broadsides become fun and (maybe) practical. TAAAAAANKS!