### PR TITLE
show states hotkeys in chili integral menu tooltips

### DIFF
--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -18,8 +18,10 @@ end
 --------------------------------------------------------------------------------
 -- Configuration
 
+include("colors.lua")
 include("keysym.lua")
 local specialKeyCodes = include("Configs/integral_menu_special_keys.lua")
+local custom_cmd_actions = include("Configs/customCmdTypes.lua")
 
 -- Chili classes
 local Chili
@@ -478,12 +480,33 @@ local function RemoveAction(cmd, types)
 	return widgetHandler.actionHandler:RemoveAction(widget, cmd, types)
 end
 
+--- Returns:
+--- - hotkey: string - nil if hotkey is not set
 local function GetHotkeyText(actionName)
 	local hotkey = WG.crude.GetHotkey(actionName)
 	if hotkey ~= '' then
-		return '\255\0\255\0' .. hotkey
+		return GetGreenStr(hotkey)
 	end
 	return nil
+end
+
+--- Returns:
+--- - hotkeys: Table[state_name, value_text], nil if action cannot be found or action has no states; value_text is
+---   "(none)" if a hotkey is not set
+local function GetHotkeysForStatesText(action_name)
+	local action = custom_cmd_actions[action_name]
+	if not action then return nil end
+	local states = action.states
+	if not states then return nil end
+	local hotkeys = {}
+	local n = 0
+	for state_idx = 1, #states do
+		local hotkey = WG.crude.GetHotkey(action_name .. " " .. (state_idx - 1))
+		if not hotkey or hotkey == '' then hotkey = "(none)" end
+		hotkeys[states[state_idx]] = hotkey
+		n = n + 1
+	end
+	return hotkeys
 end
 
 local function GetActionHotkey(actionName)
@@ -495,10 +518,29 @@ local function GetButtonTooltip(displayConfig, command, state)
 	if not tooltip then
 		tooltip = (displayConfig and displayConfig.tooltip) or (command and command.tooltip)
 	end
+	if not tooltip then
+		return nil
+	end
 	if command and command.action then
-		local hotkey = GetHotkeyText(command.action)
-		if tooltip and hotkey then
-			tooltip = tooltip .. " (\255\0\255\0" .. hotkey .. "\008)"
+		local hotkey_for_toggle = GetHotkeyText(command.action)
+		local hotkeys_for_states = GetHotkeysForStatesText(command.action)
+		local sep = "\n  "
+		if hotkeys_for_states then -- long list
+			tooltip = tooltip .. sep .. "Hotkeys:"
+		end
+		if hotkey_for_toggle then
+			local prefix, suffix = "", ""
+			if hotkeys_for_states then -- long list
+				prefix = sep .. GetGreenStr("Toggle: ")
+			else -- short form
+				prefix, suffix = " (", ")"
+			end
+			tooltip = tooltip .. prefix .. GetGreenStr(hotkey_for_toggle) .. suffix
+		end
+		if hotkeys_for_states then
+			for state_name, hotkey in pairs(hotkeys_for_states) do
+				tooltip = tooltip .. sep .. GetGreenStr(state_name .. ": " .. hotkey)
+			end
 		end
 	end
 	return tooltip
@@ -986,7 +1028,7 @@ local function GetButton(parent, name, selectionIndex, x, y, xStr, yStr, width, 
 	
 	local function SetGridKey(key)
 		usingGrid = true
-		hotkeyText = '\255\0\255\0' .. key
+		hotkeyText = GetGreenStr(key)
 		SetText(textConfig.topLeft.name, hotkeyText)
 	end
 	
@@ -1430,7 +1472,7 @@ local function GetTabButton(panel, contentControl, name, humanName, hotkey, loit
 	local hideHotkey = loiterable
 	
 	if hotkey and (not hideHotkey) and (not disabled) then
-		button:SetCaption(humanName .. " (\255\0\255\0" .. hotkey .. "\008)")
+		button:SetCaption(humanName .. " (" .. GetGreenStr(hotkey) .. ")")
 	end
 	
 	local externalFunctionsAndData = {
@@ -1456,7 +1498,7 @@ local function GetTabButton(panel, contentControl, name, humanName, hotkey, loit
 		end
 		
 		if isActive then
-			button:SetCaption(humanName .. " (\255\0\255\0" .. hotkey .. "\008)")
+			button:SetCaption(humanName .. " (" .. GetGreenStr(hotkey) .. ")")
 		else
 			button:SetCaption(humanName .. " (" .. hotkey .. ")")
 		end

--- a/LuaUI/colors.lua
+++ b/LuaUI/colors.lua
@@ -11,16 +11,17 @@
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-WhiteStr   = "\255\255\255\255"
-BlackStr   = "\255\001\001\001"
-GreyStr    = "\255\128\128\128"
-RedStr     = "\255\255\001\001"
-PinkStr    = "\255\255\123\128"
-GreenStr   = "\255\001\255\001"
-BlueStr    = "\255\001\001\255"
-CyanStr    = "\255\001\255\255"
-YellowStr  = "\255\255\255\001"
-MagentaStr = "\255\255\001\255"
+ResetColorStr = "\008"
+WhiteStr      = "\255\255\255\255";    function GetWhiteStr   (str) return WhiteStr   .. str .. ResetColorStr end
+BlackStr      = "\255\001\001\001";    function GetBlackStr   (str) return BlackStr   .. str .. ResetColorStr end
+GreyStr       = "\255\128\128\128";    function GetGreyStr    (str) return GreyStr    .. str .. ResetColorStr end
+RedStr        = "\255\255\001\001";    function GetRedStr     (str) return RedStr     .. str .. ResetColorStr end
+PinkStr       = "\255\255\123\128";    function GetPinkStr    (str) return PinkStr    .. str .. ResetColorStr end
+GreenStr      = "\255\001\255\001";    function GetGreenStr   (str) return GreenStr   .. str .. ResetColorStr end
+BlueStr       = "\255\001\001\255";    function GetBlueStr    (str) return BlueStr    .. str .. ResetColorStr end
+CyanStr       = "\255\001\255\255";    function GetCyanStr    (str) return CyanStr    .. str .. ResetColorStr end
+YellowStr     = "\255\255\255\001";    function GetYellowStr  (str) return YellowStr  .. str .. ResetColorStr end
+MagentaStr    = "\255\255\001\255";    function GetMagentaStr (str) return MagentaStr .. str .. ResetColorStr end
 
 Colors = {}
 Colors.white   = { 1.0, 1.0, 1.0, 1.0 }


### PR DESCRIPTION
From https://github.com/ZeroK-RTS/Zero-K/issues/3917:

Hi, I've been augmenting my UI with hotkeys, chaning and experimenting with them a lot to develop an optimal hotkey config for my playstyle. Because of that I sometimes might forget a new hotkey that I'm trying out.
If it's a State hotkey, to recall it I open Epic Menu, click Search, type the name of the action if I remember the name, and find the hotkey in the result list.

I think command tooltips can be extended to contain more info about configured hotkeys, because we all are sometimes in that moment when you are morphing your geo in 1 match out of 30, and you cannot remember what key you have binded to Low Misc. Priority. I think it's a not neccessary moment of stress so I propose extending the tooltips so they look like in the following examples

- A subset of states has hotkeys:
![states](https://user-images.githubusercontent.com/20540273/81130546-c2686a80-8f50-11ea-9f80-8c4e58940013.png)

- Only toggle has a hotkey:
![toggle](https://user-images.githubusercontent.com/20540273/81130552-cbf1d280-8f50-11ea-86af-849959c05e59.png)

- States do not exist:
(no change)
![short](https://user-images.githubusercontent.com/20540273/81130563-df04a280-8f50-11ea-9b5d-2a94bd7a94e4.png)

In short, making all the hotkeys for a State command displayed in the tooltips.

Criticism is welcome.

> Sprunk:
Sounds like it would be good to make all of the states show up if any of them has a hotkey (in this example with Low: (none)).