### PR TITLE
Don't draw unit shapes and friends for radar icons

### DIFF
--- a/LuaUI/Widgets/gfx_halo.lua
+++ b/LuaUI/Widgets/gfx_halo.lua
@@ -303,7 +303,7 @@ local function SetTeamColor(teamID)
 end
 
 local function DrawVisibleUnitsAll()
-  local visibleUnits = GetVisibleUnits(ALL_UNITS,nil,true)
+  local visibleUnits = GetVisibleUnits(ALL_UNITS,nil,false)
   for i=1,#visibleUnits do
     local unitID = visibleUnits[i]
     SetTeamColor(GetUnitTeam(unitID))

--- a/LuaUI/Widgets/gfx_outline_shader.lua
+++ b/LuaUI/Widgets/gfx_outline_shader.lua
@@ -77,6 +77,8 @@ local applicationShader
 local pingPongIdx = 1
 
 local shadersEnabled = Spring.Utilities.IsCurrentVersionNewerThan(104, 1243) and LuaShader.isDeferredShadingEnabled and LuaShader.GetAdvShadingActive()
+
+local unitsVisible = false
 -----------------------------------------------------------------
 -- Configuration
 -----------------------------------------------------------------
@@ -453,13 +455,20 @@ function widget:Shutdown()
 	applicationShader:Finalize()
 end
 
+function widget:Update()
+	local units = Spring.GetVisibleUnits(-1, nil, false)
+	unitsVisible = #units > 0
+end
+
 function widget:DrawWorld()
+	if not unitsVisible then return end
 	if options.drawUnderCeg.value then
 		EnterLeaveScreenSpace(DrawOutline, OUTLINE_STRENGTH_ALWAYS_ON, true, true)
 	end
 end
 
 function widget:DrawUnitsPostDeferred()
+	if not unitsVisible then return end
 	EnterLeaveScreenSpace(function ()
 		PrepareOutline(false)
 		DrawOutline(OUTLINE_STRENGTH_BLENDED, false, false)

--- a/LuaUI/Widgets/gui_icontransition.lua
+++ b/LuaUI/Widgets/gui_icontransition.lua
@@ -321,7 +321,7 @@ local function DrawWorldFunc()
 	
 	-- this is probably faster than spIsUnitInView() for all the units
 	-- but that's probably worth testing to confirm
-	local unitsInView = spGetVisibleUnits()
+	local unitsInView = spGetVisibleUnits(-1, nil, true)
 	local unitIsInView = {}
 	for k, v in pairs(unitsInView) do
 		unitIsInView[v] = true

--- a/LuaUI/Widgets/gui_spotter.lua
+++ b/LuaUI/Widgets/gui_spotter.lua
@@ -217,7 +217,7 @@ end
 function widget:DrawWorldPreUnit()
 	glDepthTest(true)
 	glPolygonOffset(-10000, -2)  -- draw on top of water/map - sideeffect: will shine through terrain/mountains
-	for _,unitID in ipairs(Spring.GetVisibleUnits()) do
+	for _,unitID in ipairs(Spring.GetVisibleUnits(-1, nil, false)) do
 		local team = spGetUnitTeam(unitID)
 		if (team) then
 			local radius = GetUnitDefRealRadius(spGetUnitDefID(unitID))

--- a/LuaUI/Widgets/gui_spotter.lua
+++ b/LuaUI/Widgets/gui_spotter.lua
@@ -71,7 +71,6 @@ local spGetUnitRadius        = Spring.GetUnitRadius
 local spGetUnitTeam          = Spring.GetUnitTeam
 local spGetUnitViewPosition  = Spring.GetUnitViewPosition
 local spIsUnitSelected       = Spring.IsUnitSelected
-local spIsUnitVisible        = Spring.IsUnitVisible
 local spSendCommands         = Spring.SendCommands
 
 

--- a/LuaUI/Widgets/gui_team_platter.lua
+++ b/LuaUI/Widgets/gui_team_platter.lua
@@ -335,9 +335,8 @@ if not spIsGUIHidden() then
   glColor(1, 1, 1, alpha)
 
   -- for _,unitID in ipairs(spGetSelectedUnits()) do
-  local units = spGetVisibleUnits(-1, nil, true)
-  for i=1, #units do
-    local unitID = units[i]
+  for i=1, #visUnits do
+    local unitID = visUnits[i]
     if IsUnitInSelectionBox(unitID) or (GetUnitUnderCursor() == unitID and not spIsUnitSelected(unitID)) then
       glColor(1, 1, 1, 0.5)
     else

--- a/LuaUI/Widgets/gui_xrayhaloselect.lua
+++ b/LuaUI/Widgets/gui_xrayhaloselect.lua
@@ -172,7 +172,7 @@ local uCycle = 1
 
 
 local function GetVisibleUnits()
-  local units = spGetVisibleUnits(-1, nil, true)
+  local units = spGetVisibleUnits(-1, nil, false)
   --local visibleUnits = {}
   local boxedUnits = GetUnitsInSelectionBox();
 
@@ -354,17 +354,14 @@ local function DrawWorldFunc()
 	local visUnit,visCloakUnit,n,nc = {},{},1, 1
     for i=1, #visibleSelected do
         local unitID = visibleSelected[i]
-        if IsUnitVisible(unitID,nil,true) then
-			if Spring.GetUnitIsCloaked(unitID) then
-			--if true then
-				visCloakUnit[nc] = unitID
-				nc = nc+1
-			else
-				visUnit[n] = unitID
-				n = n+1
-			end
-			
-        end
+		if Spring.GetUnitIsCloaked(unitID) then
+		--if true then
+			visCloakUnit[nc] = unitID
+			nc = nc+1
+		else
+			visUnit[n] = unitID
+			n = n+1
+		end
     end
     n = n - 1
     nc = nc - 1

--- a/LuaUI/Widgets/snd_music.lua
+++ b/LuaUI/Widgets/snd_music.lua
@@ -233,7 +233,7 @@ function widget:Update(dt)
 		newTrackWait = newTrackWait + 1
 		local PlayerTeam = Spring.GetMyTeamID()
 		numVisibleEnemy = 0
-		local doods = Spring.GetVisibleUnits()
+		local doods = Spring.GetVisibleUnits(-1, nil, true)
 		for i=1,#doods do
 			if (Spring.IsUnitAllied(doods[i]) ~= true) then
 				numVisibleEnemy = numVisibleEnemy + 1

--- a/LuaUI/Widgets/unit_shapes.lua
+++ b/LuaUI/Widgets/unit_shapes.lua
@@ -244,7 +244,7 @@ local function GetVisibleUnits()
 		local boxedUnits, boxedUnitsIDs = GetBoxedUnits()
 
 		if IsSelectionBoxActive() then --It's not worth rebuilding visible selected lists for selection box, but selection box needs to be updated per-frame
-			local units = spGetVisibleUnits(-1, nil, true)
+			local units = spGetVisibleUnits(-1, nil, false)
 			for i = 1, #units do
 				local unitID = units[i]
 				if boxedUnitsIDs[units[i]] and not WG.drawtoolKeyPressed then
@@ -258,7 +258,7 @@ local function GetVisibleUnits()
 	end
 
 	if (HasVisibilityChanged()) then
-		local units = spGetVisibleUnits(-1, nil, true)
+		local units = spGetVisibleUnits(-1, nil, false)
 		--local visibleUnits = {}
 		local visibleAllySelUnits = {}
 		local visibleSelected = {}


### PR DESCRIPTION
Waste less widget time when controlling units while zoomed out.