### PR TITLE
fix order and performance of hotkey tooltips in integral menu

### DIFF
--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -520,33 +520,40 @@ end
 
 --- Combines the information about the command, its state and hotkeys
 local function GetButtonTooltip(displayConfig, command, state)
-	local SEP = "\n  "
-	
-	local tooltip = displayConfig and displayConfig.stateTooltip and displayConfig.stateTooltip[state]
-	if not tooltip then
-		tooltip = (displayConfig and displayConfig.tooltip) or (command and command.tooltip)
+	local PARAGRAPH = "\n  "
+
+	local tooltip
+	if displayConfig and state then
+		tooltip = (displayConfig.stateTooltip and displayConfig.stateTooltip[state]) or displayConfig.tooltip
+	elseif command then
+		tooltip = command.tooltip
 	end
 	if not tooltip then
 		return nil
 	end
-	if command then
-		local action_name = command.action
-		if command.action then
-			local hotkey_for_toggle = GetHotkeyText(action_name)
-			local states, hotkeys_for_states, number_of_set_hotkeys = GetHotkeysForStatesText(action_name)
-			if hotkey_for_toggle then
-				tooltip = tooltip .. " (" .. GetGreenStr(hotkey_for_toggle) .. ")"
-			end
-			if hotkeys_for_states and number_of_set_hotkeys > 0 then
-				tooltip = tooltip .. SEP .. "State Hotkeys:"
-				for i = 1, #states do
-					local state_name = states[i]
-					local hotkey = hotkeys_for_states[i]
-					tooltip = tooltip .. SEP .. GetGreenStr(state_name .. ": " .. hotkey)
-				end
-			end
+
+	local action_name = command.action
+	if not action_name then
+		return nil
+	end
+
+	-- Append Toggle hotkey
+	local hotkey_for_toggle = GetHotkeyText(action_name)
+	if hotkey_for_toggle then
+		tooltip = tooltip .. " (" .. GetGreenStr(hotkey_for_toggle) .. ")"
+	end
+
+	-- Append State hotkeys if any are set
+	local states, hotkeys_for_states, number_of_set_hotkeys = GetHotkeysForStatesText(action_name)
+	if hotkeys_for_states and number_of_set_hotkeys > 0 then
+		tooltip = tooltip .. PARAGRAPH .. "State Hotkeys:"
+		for i = 1, #states do
+			local state_name = states[i]
+			local hotkey = hotkeys_for_states[i]
+			tooltip = tooltip .. PARAGRAPH .. GetGreenStr(state_name .. ": " .. hotkey)
 		end
 	end
+
 	return tooltip
 end
 

--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -491,7 +491,8 @@ local function GetHotkeyText(actionName)
 end
 
 --- Returns:
---- - hotkeys: Table[state_name, value_text], nil if action cannot be found or action has no states; value_text is
+--- - states: Table - See customCmdTypes.lua
+--- - hotkeys: Table[state_idx, value_text], nil if action cannot be found or action has no states; value_text is
 ---   "(none)" if a hotkey is not set
 --- - n: Integer - number of hotkeys that are set, nil under same conditions as for hotkeys
 local function GetHotkeysForStatesText(action_name)
@@ -508,9 +509,9 @@ local function GetHotkeysForStatesText(action_name)
 		else
 			n = n + 1
 		end
-		hotkeys[states[state_idx]] = hotkey
+		hotkeys[state_idx] = hotkey
 	end
-	return hotkeys, n
+	return action.states, hotkeys, n
 end
 
 local function GetActionHotkey(actionName)
@@ -528,16 +529,21 @@ local function GetButtonTooltip(displayConfig, command, state)
 	if not tooltip then
 		return nil
 	end
-	if command and command.action then
-		local hotkey_for_toggle = GetHotkeyText(command.action)
-		local hotkeys_for_states, states_n = GetHotkeysForStatesText(command.action)
-		if hotkey_for_toggle then
-			tooltip = tooltip .. " (" .. GetGreenStr(hotkey_for_toggle) .. ")"
-		end
-		if hotkeys_for_states and states_n > 0 then
-			tooltip = tooltip .. SEP .. "State Hotkeys:"
-			for state_name, hotkey in pairs(hotkeys_for_states) do
-				tooltip = tooltip .. SEP .. GetGreenStr(state_name .. ": " .. hotkey)
+	if command then
+		local action_name = command.action
+		if command.action then
+			local hotkey_for_toggle = GetHotkeyText(action_name)
+			local states, hotkeys_for_states, number_of_set_hotkeys = GetHotkeysForStatesText(action_name)
+			if hotkey_for_toggle then
+				tooltip = tooltip .. " (" .. GetGreenStr(hotkey_for_toggle) .. ")"
+			end
+			if hotkeys_for_states and number_of_set_hotkeys > 0 then
+				tooltip = tooltip .. SEP .. "State Hotkeys:"
+				for i = 1, #states do
+					local state_name = states[i]
+					local hotkey = hotkeys_for_states[i]
+					tooltip = tooltip .. SEP .. GetGreenStr(state_name .. ": " .. hotkey)
+				end
 			end
 		end
 	end


### PR DESCRIPTION
follow-up for https://github.com/ZeroK-RTS/Zero-K/pull/3919

- avoid using `pairs` to improve performance
- the refactoring happens to fix the order of the list. it is
now listed as the states are defined in customCmdTypes

| before | after |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/20540273/82598116-ca601580-9bb2-11ea-8b02-a3e24e1595d3.png) | ![after](https://user-images.githubusercontent.com/20540273/82598121-ccc26f80-9bb2-11ea-8323-c3d48610f7e1.png) |
