### PR TITLE
Small fixes to unit categorization for end graph

### DIFF
--- a/LuaRules/Configs/unit_category.lua
+++ b/LuaRules/Configs/unit_category.lua
@@ -28,8 +28,8 @@ local function GetUnitCategory(unitDefID)
 	if cp.level then -- commander
 		return "other"
 	end
-	
-	if cp.ismex or cp.income_energy or (cp.pylonrange and ((tonumber(cp.pylonrange) or 0) > 400)) or ud.energyStorage > 0 then
+
+	if cp.ismex or cp.income_energy or (cp.pylonrange and ((tonumber(cp.pylonrange) or 0) > 400)) or ud.energyStorage > 0 or ud.isBuilder then
 		return "econ"
 	end
 	

--- a/LuaRules/Configs/unit_category.lua
+++ b/LuaRules/Configs/unit_category.lua
@@ -37,7 +37,7 @@ local function GetUnitCategory(unitDefID)
 		return "army"
 	end
 	
-	if string.find(name, "turret") or string.find(name, "shield") then
+	if string.find(name, "turret") or (name ~= "factoryshield" and string.find(name, "shield")) then
 		return "def"
 	end
 	

--- a/LuaRules/Configs/unit_category.lua
+++ b/LuaRules/Configs/unit_category.lua
@@ -37,7 +37,7 @@ local function GetUnitCategory(unitDefID)
 		return "army"
 	end
 	
-	if string.find(name, "turret") or (name ~= "factoryshield" and string.find(name, "shield")) then
+	if string.find(name, "turret") or string.find(name, "shield") then
 		return "def"
 	end
 	

--- a/LuaUI/Widgets/gui_chili_endgraph.lua
+++ b/LuaUI/Widgets/gui_chili_endgraph.lua
@@ -39,7 +39,7 @@ local buttongroups = {
 	{"Units", {
 		{"unit_value"      , "Total Value", "Total value of units and structures."},
 		{"unit_value_army" , "Army Value", "Value of mobile units excluding constructors, commanders, Iris, Owl, Djinn, Charon and Hercules."},
-		{"unit_value_def"  , "Defense Value", "Value of armed structures (and shields) with range up to and including Cerebus and Aretemis."},
+		{"unit_value_def"  , "Defense Value", "Value of armed structures (and shields) with range up to and including Cerberus and Artemis."},
 		{"unit_value_econ" , "Economy Value", "Value of economic structures, factories and constructors."},
 		{"unit_value_other", "Other Value", "Value of units and structures that do not fit any other category."},
 		{"unit_value_killed", "Value Killed", "Cumulative total of value of enemy units and structured destroyed by the team. Includes nanoframes."},


### PR DESCRIPTION
The second commit is the one I'm least sure about, I followed the tooltips but I'm happy to update this further.

One more question I have: should the Funnelweb be defense by virtue of having shields, economy by virtue of being a builder, or other by virtue of being a weird mixture?

Feel free to suggest any additional known bugs or fixes to the end graphs too!