### PR TITLE
Fix #3929 (Ultimatum cylindrical targeting)

### DIFF
--- a/gamedata/modularcomms/weapons/disintegrator.lua
+++ b/gamedata/modularcomms/weapons/disintegrator.lua
@@ -23,6 +23,7 @@ local weaponDef = {
 	},
 
 	explosionGenerator      = [[custom:DGUNTRACE]],
+	heightMod               = 1,
 	impulseBoost            = 0,
 	impulseFactor           = 0,
 	interceptedByShieldType = 0,

--- a/gamedata/modularcomms/weapons/disintegrator.lua
+++ b/gamedata/modularcomms/weapons/disintegrator.lua
@@ -23,7 +23,6 @@ local weaponDef = {
 	},
 
 	explosionGenerator      = [[custom:DGUNTRACE]],
-	heightMod               = 1,
 	impulseBoost            = 0,
 	impulseFactor           = 0,
 	interceptedByShieldType = 0,

--- a/units/striderantiheavy.lua
+++ b/units/striderantiheavy.lua
@@ -91,6 +91,7 @@ return { striderantiheavy = {
       },
 
       explosionGenerator      = [[custom:DGUNTRACE]],
+      heightMod               = 1,
       impulseBoost            = 0,
       impulseFactor           = 0,
       interceptedByShieldType = 0,


### PR DESCRIPTION
Changed Ultimatum targeting to spherical to match projectile reach (targeting was cylindrical, but reach was spherical). This caused Ultimatums to fire early (projectile disappeared mid-air) when there was a height difference to the target.