### PR TITLE
DRP blue bullet damage: 12K → 30K

### DIFF
--- a/units/raveparty.lua
+++ b/units/raveparty.lua
@@ -270,7 +270,10 @@ return { raveparty = {
       },
 
       damage                  = {
-        default        = 12003,
+        --[[ huge value to burst Funnelweb shields, since most of DRP's
+             power is in effects normally crappy vs them but we don't want
+             DRP to arbitrarily suck vs Funnel if the other supers don't ]]
+        default        = 30000,
       },
 
       edgeEffectiveness       = 0.75,


### PR DESCRIPTION
DRP was designed back when the largest shield had 3600 health,
so despite a large chunk of its power being concentrated in effects
normally crappy vs shields (impulse, ground napalm, AoE) it could
still counter shields because the blue bullet pierced them.

Funnelweb broke this. A larger redesign of Funnel would probably be
the proper solution (since both a powerful shield and a strider weight
builder have enough merit to stand on their own) but fortunately a
caveman style blue bullet buff happens to affect Funnel disproportionately
since everything else gets stunned after one shot already anyway.