### PR TITLE
TableEcho: be defensive around key printing

### DIFF
--- a/LuaRules/Utilities/tablefunctions.lua
+++ b/LuaRules/Utilities/tablefunctions.lua
@@ -126,7 +126,8 @@ local function TableEcho(data, name, indent, tableChecked)
 	end
 	Spring.Echo(indent .. name .. " = {")
 	local newIndent = indent .. "    "
-	for name, v in pairs(data) do
+	for nameRaw, v in pairs(data) do
+		local name = tostring(nameRaw)
 		local ty = type(v)
 		if ty == "table" then
 			TableEcho(v, name, newIndent, true)


### PR DESCRIPTION
While, for example, a table ending up as a key for another table is
almost always an error, this at least lets us know what's going on.