### PR TITLE
Deluxe Playerlist: Unique window name

### DIFF
--- a/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_deluxeplayerlist.lua
@@ -1508,7 +1508,7 @@ SetupPanels = function ()
 	
 	window_cpl = Window:New{
 		dockable = true,
-		name = "Player List",
+		name = "Deluxe Player List",
 		color = {0,0,0,0},
 		x = x,
 		y = y,


### PR DESCRIPTION
This just lets us have both Deluxe and Crude enabled during development
for comparative purposes.