### PR TITLE
GBC: Remove another crash source

### DIFF
--- a/LuaUI/Widgets/unit_global_build_command.lua
+++ b/LuaUI/Widgets/unit_global_build_command.lua
@@ -1440,8 +1440,9 @@ function GiveWorkToUnit(unitID)
 			for i=1, #localUnits do -- locate the 'terraunit' if it still exists, and give a repair order for it
 				local target = localUnits[i]
 				local udid = spGetUnitDefID(target)
+				-- Note: This can be nil if eg. it's a radar dot we don't know the unit type for
 				local unitDef = UnitDefs[udid]
-				if string.match(unitDef.humanName, "erraform") and spGetUnitTeam(target) == myTeamID then
+				if unitDef and string.match(unitDef.humanName, "erraform") and spGetUnitTeam(target) == myTeamID then
 					spGiveOrderToUnit(unitID, CMD_REPAIR, {target}, 0)
 					break
 				end

--- a/LuaUI/Widgets/unit_global_build_command.lua
+++ b/LuaUI/Widgets/unit_global_build_command.lua
@@ -282,6 +282,7 @@ local myTeamID = spGetMyTeamID()
 local statusColor = {1.0, 1.0, 1.0, 0.85}
 local queueColor = {1.0, 1.0, 1.0, 0.9}
 local textSize = 12.0
+local terraunitDefID = UnitDefNames.terraunit.id
 
 -- Zero-K specific icons for drawing repair/reclaim/resurrect, customize if porting!
 local rec_icon = "LuaUI/Images/commands/Bold/reclaim.png"
@@ -1441,8 +1442,7 @@ function GiveWorkToUnit(unitID)
 				local target = localUnits[i]
 				local udid = spGetUnitDefID(target)
 				-- Note: This can be nil if eg. it's a radar dot we don't know the unit type for
-				local unitDef = UnitDefs[udid]
-				if unitDef and string.match(unitDef.humanName, "erraform") and spGetUnitTeam(target) == myTeamID then
+				if terraunitDefID == udid and spGetUnitTeam(target) == myTeamID then
 					spGiveOrderToUnit(unitID, CMD_REPAIR, {target}, 0)
 					break
 				end


### PR DESCRIPTION
This happened whenever there was an unidentified enemy very, very
close to the location of a soon-to-be build site.

This could only really happen when:
 - you're building something on the frontline
 - you're using GBC to do so
 - you don't have clear los to the build site
 - you do have clear radar coverage of the build site

This meant it was both very rare, and typically happened in moments
where you really don't want to take time out to go bug hunting.

It's even harder to reproduce locally unless you knew what
you were looking for, since global spec control (for positioning
enemy units) was usually paired with globallos, which prevents
this condition from happening.