### PR TITLE
Impaler reload animation matches its reloadtime

### DIFF
--- a/scripts/vehheavyarty.lua
+++ b/scripts/vehheavyarty.lua
@@ -14,7 +14,7 @@ local SIG_AIM = 2
 local SIG_MOVE = 1
 
 local RESTORE_DELAY = 5000
-local LOAD_DELAY = 500
+local LOAD_DELAY = 4800
 local TRACK_PERIOD = 50
 
 local BAY_DISTANCE = -10


### PR DESCRIPTION
fixes #3973
* Impaler reload delay increased to 4.8s. This means its reload animation perfectly matches the reload time of 10 seconds.