### PR TITLE
More intuitive missile stockpile behavior

### DIFF
--- a/LuaUI/Widgets/unit_healthbars.lua
+++ b/LuaUI/Widgets/unit_healthbars.lua
@@ -430,7 +430,7 @@ local function GetBarDrawer()
 		if freeStockpile then
 			glText(numStockpiled, barWidth + 1.7, -(11*barHeight - 2) - 16, 7.5, "cno")
 		else
-			glText(numStockpiled .. '/' .. numStockpileQued, barWidth + 1.7, -(11*barHeight-2)-16, 7.5, "cno")
+			glText(numStockpiled .. '/' .. (numStockpiled + numStockpileQued), barWidth + 1.7, -(11*barHeight-2)-16, 7.5, "cno")
 		end
 	end
 


### PR DESCRIPTION
Set a desired size of stockpile and build more missiles whenever the current supply is lower than that. Rather than building forever (Artemis) or building a fixed number and then stopping (Trinity, Reef, Scylla).
Also add an option for the stockpile size, rather than hardcoded.
