### PR TITLE
add missing comma to unit marker config

### DIFF
--- a/LuaUI/Configs/unit_marker.lua
+++ b/LuaUI/Configs/unit_marker.lua
@@ -5,7 +5,7 @@ local unitlistNames = {
 	cloakjammer = { mark_each_appearance = true, },
 
 	energyheavygeo = {},
-	energyfusion = {}
+	energyfusion = {},
 	energysingu = {},
 
 	chicken_dragon = {},


### PR DESCRIPTION
Thanks PetTurtle for pointing it out.