### PR TITLE
GBC: Cancel jobs inverse to commands given

### DIFF
--- a/LuaUI/Widgets/unit_global_build_command.lua
+++ b/LuaUI/Widgets/unit_global_build_command.lua
@@ -1263,8 +1263,7 @@ function widget:CommandNotify(id, params, options, isZkMex, isAreaMex)
 						-- Cancel inverse jobs
 						if id == CMD_RECLAIM then
 							-- A reclaim command on a target cancels jobs to repair, resurect, or build that target.
-							local inverseHash
-							inverseHash = BuildHash({id=CMD_REPAIR, target=target})
+							local inverseHash = BuildHash({id=CMD_REPAIR, target=target})
 							if buildQueue[inverseHash] then
 								StopAnyWorker(inverseHash)
 								buildQueue[inverseHash] = nil

--- a/LuaUI/Widgets/unit_global_build_command.lua
+++ b/LuaUI/Widgets/unit_global_build_command.lua
@@ -1259,6 +1259,36 @@ function widget:CommandNotify(id, params, options, isZkMex, isAreaMex)
 						myCmd = {id=id, target=target, x=x, y=y, z=z, assignedUnits={}}
 					else -- if the target is a unit
 						myCmd = {id=id, target=target, assignedUnits={}}
+
+						-- Cancel inverse jobs
+						if id == CMD_RECLAIM then
+							-- A reclaim command on a target cancels jobs to repair, resurect, or build that target.
+							local inverseHash
+							inverseHash = BuildHash({id=CMD_REPAIR, target=target})
+							if buildQueue[inverseHash] then
+								StopAnyWorker(inverseHash)
+								buildQueue[inverseHash] = nil
+							end
+							inverseHash = BuildHash({id=CMD_RESURRECT, target=target})
+							if buildQueue[inverseHash] then
+								StopAnyWorker(inverseHash)
+								buildQueue[inverseHash] = nil
+							end
+							local ux,_,uz = spGetUnitPosition(target)
+							local udID = spGetUnitDefID(target)
+							inverseHash = BuildHash({id=-udID, x=ux, z=uz})
+							if buildQueue[inverseHash] then
+								StopAnyWorker(inverseHash)
+								buildQueue[inverseHash] = nil
+							end
+						elseif id == CMD_RESURRECT or id == CMD_REPAIR then
+							-- A resurect or repair command cancels jobs to reclaim that target.
+							local inverseHash = BuildHash({id=CMD_RECLAIM, target=target})
+							if buildQueue[inverseHash] then
+								StopAnyWorker(inverseHash)
+								buildQueue[inverseHash] = nil
+							end
+						end
 					end
 					
 					local hash = BuildHash(myCmd)


### PR DESCRIPTION
If we issue a command to reclaim a unit (or nanoframe), we probably
don't want to have jobs to repair it, resurrect it, or to build
an identical copy in its place.

If we issue a command to repair or resurrect a unit, we probably
don't want to have jobs to reclaim it.

Area commands are unaffected, as covering all of the cases that can
happen (such as those that involve alt permanent area commands)
is a headache.
Perhaps they shouldn't be.

This eliminates 4-7 seconds of fighting with your builder every time
you accidentally queue up a Desolator instead of a Caretaker.
(This was totally done for code correctness and not because
this was a regular occurrence, ahem.)