### PR TITLE
Stop Likho missing target when terrain rapidly changes.

### DIFF
--- a/units/bomberheavy.lua
+++ b/units/bomberheavy.lua
@@ -30,6 +30,7 @@ return { bomberheavy = {
     reammoseconds    = [[20]],
     refuelturnradius = [[150]],
     reallyabomber    = [[1]],
+    fighter_pullup_dist = 800, -- pullup at the end of attack dive to avoid hitting terrain
   },
 
   explodeAs           = [[GUNSHIPEX]],


### PR DESCRIPTION
This change causes the Likho to pull up from its attack dive before the reaches the target. This stops the bomb from hitting small terraformed walls or the side of cliffs.