### PR TITLE
Fix auto-retreat for planes.

### DIFF
--- a/LuaRules/Gadgets/unit_bomber_command.lua
+++ b/LuaRules/Gadgets/unit_bomber_command.lua
@@ -340,7 +340,7 @@ end
 
 local function RequestRearm(unitID, team, forceNow, replaceExisting)
 	if spGetUnitRulesParam(unitID, "airpadReservation") == 1 then
-		return false --already reserved an airpad, do not reserve another one again
+		return true --already reserved an airpad, do not reserve another one again
 	end
 	team = team or spGetUnitTeam(unitID)
 	if spGetUnitRulesParam(unitID, "noammo") ~= 1 then


### PR DESCRIPTION
If a plane was already flying to an airpad, and then took enough damage to trigger the auto-retreat threshold, it would try to issue another rearm order, incorrectly think it failed, and switch to just retreating instead.