### PR TITLE
Chili Spectator Panels: Fix rare crash

### DIFF
--- a/LuaUI/Widgets/gui_chili_spectator_panels.lua
+++ b/LuaUI/Widgets/gui_chili_spectator_panels.lua
@@ -406,7 +406,7 @@ local function UpdateResourcePanel(panel, income, net, overdrive, reclaim, stora
 	
 	-- local newFontSize = math.round(GetFontMult(income)*options.resourceMainFontSize.value)
 	-- panel.label_income.font.size = newFontSize
-	panel.label_income.font.size =math.round(GetFontMult(income)*options.resourceMainFontSize.value)
+	panel.label_income.font.size = math.floor(GetFontMult(income)*options.resourceMainFontSize.value)
 	panel.label_income:Invalidate()
 	panel.label_income:SetCaption(Format(income, ""))
 	


### PR DESCRIPTION
Perhaps counter-intuitively, math.round actually returns a string.

See: https://github.com/ZeroK-RTS/Zero-K/blob/master/LuaRules/Utilities/numberfunctions.lua#L6

While this branch of logic was encountered rarely, you could reach it by,
for example, restarting the Showeco and Grid Drawer widget.

Once .font was set to a string, the immediately following SetCaption
call would eventually call WrapText.

WrapText would compare a number (width) to a string (size), causing the
entire Spectator Panels widget to crash.

See: https://github.com/ZeroK-RTS/Zero-K/blob/master/LuaUI/Widgets/chili/Controls/font.lua#L173