### PR TITLE
Softban AutoLLT

### DIFF
--- a/LuaUI/Widgets/api_widget_disabler.lua
+++ b/LuaUI/Widgets/api_widget_disabler.lua
@@ -26,11 +26,13 @@ local spEcho = Spring.Echo
 local badwidgets = {
 	[1] = "*Mearth Location Tags*1.0", -- Map: Mearth_v4.
 	[2] = "Metalspot Finder (map)", -- oktogon v3
+	[3] = "Auto LLT", -- troublesome public widget
 }
 
 local reason = {
 	[1] = "Causes black ground on some graphics cards, possible copyright issues.",
 	[2] = "breaks everything mex-related",
+	[3] = "Majorly inefficient use of commands that can lag games out. WARNING: USE AT YOUR OWN RISK. USE OF THIS WIDGET MAY GET YOU BANNED. YOU HAVE BEEN WARNED.",
 }
 
 -- callins --


### PR DESCRIPTION
Auto LLT or disco lotus is a troublesome public widget that can end up making games literally unplayable with 3+ sec latency after even just a handful of lotuses. This pr seeks to softban it (see requiring users to load it twice) to help discourage casual users. It comes with an authorative warning that use may result in bans (due to its antisocial network use). A better version of the widget could be publicized that would be unaffected by this ban.