### PR TITLE
DualScreenMode fixes

### DIFF
--- a/LuaUI/Widgets/api_draw_mouse_build.lua
+++ b/LuaUI/Widgets/api_draw_mouse_build.lua
@@ -87,7 +87,7 @@ function widget:DrawScreen()
 end
 
 function widget:Initialize()
-	screenHeight = select(2, Spring.GetWindowGeometry())
+	screenHeight = select(2, Spring.GetViewGeometry())
 	WG.DrawMouseBuild = externalFunctions
 	widgetHandler:RemoveWidgetCallIn("DrawScreen", widget)
 end

--- a/LuaUI/Widgets/gui_attrition_counter.lua
+++ b/LuaUI/Widgets/gui_attrition_counter.lua
@@ -467,7 +467,6 @@ end
 ------------------------------------------------------------------------------------------------------------------------------------
 
 function CreateWindow()
-	-- local screenWidth,screenHeight = Spring.GetWindowGeometry()
 	local countsOffset = 43;
 	
 	--// WINDOW

--- a/LuaUI/Widgets/gui_chili_chat2_1.lua
+++ b/LuaUI/Widgets/gui_chili_chat2_1.lua
@@ -959,7 +959,7 @@ function widget:Initialize()
 	
 	local inputsize = 33
 	
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	
 	stack_console = WG.Chili.StackPanel:New{
 		name = "stack_console",

--- a/LuaUI/Widgets/gui_chili_chicken.lua
+++ b/LuaUI/Widgets/gui_chili_chicken.lua
@@ -409,8 +409,6 @@ function widget:Initialize()
 	screen0 = Chili.Screen0
 	
 	--create main Chili elements
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
-	
 	local labelHeight = 22
 	local fontSize = 16
 	

--- a/LuaUI/Widgets/gui_chili_commander_upgrade.lua
+++ b/LuaUI/Widgets/gui_chili_commander_upgrade.lua
@@ -184,7 +184,7 @@ local function CreateModuleSelectionWindow()
 		children = {selectionButtonPanel}
 	}
 	
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local minimapHeight = screenWidth/6 + 45
 	
 	local selectionWindowMain = Window:New{
@@ -600,7 +600,7 @@ local function HideMainWindow()
 end
 
 local function CreateMainWindow()
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	local minimapHeight = screenWidth/6 + 45
 	
 	local mainHeight = math.min(420, math.max(325, screenHeight - 450))

--- a/LuaUI/Widgets/gui_chili_core_selector.lua
+++ b/LuaUI/Widgets/gui_chili_core_selector.lua
@@ -1560,7 +1560,7 @@ end
 
 local function InitializeControls()
 	-- Set the size for the default settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	local BUTTON_HEIGHT = 55*options.buttonSizeLong.value/60
 	local integralWidth = math.max(350, math.min(450, screenWidth*screenHeight*0.0004))
 	local integralHeight = math.min(screenHeight/4.5, 200*integralWidth/450)

--- a/LuaUI/Widgets/gui_chili_crudeplayerlist.lua
+++ b/LuaUI/Widgets/gui_chili_crudeplayerlist.lua
@@ -614,7 +614,7 @@ local function InitializePlayerlist()
 		playersByPlayerID = {}
 		teamByTeamID = {}
 	end
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	local windowWidth = MAX_NAME_LENGTH + 10*(options.text_height.value or 13)
 
 	--// WINDOW

--- a/LuaUI/Widgets/gui_chili_display_keys.lua
+++ b/LuaUI/Widgets/gui_chili_display_keys.lua
@@ -59,8 +59,6 @@ local highlightColor = {1,0.7, 0, 1}
 local function InitializeDisplayLabelControl(name)
 	local data = {}
 	
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
-
 	local window = Chili.Window:New{
 		parent = screen0,
 		dockable = true,

--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -1110,7 +1110,7 @@ function CreateWindow(oldX, oldY, oldW, oldH)
 		end
 	end
 	
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local mouseDownOnReserve = false
 	
 	--// Some (only some) Configuration for shared values

--- a/LuaUI/Widgets/gui_chili_endgamewindow.lua
+++ b/LuaUI/Widgets/gui_chili_endgamewindow.lua
@@ -449,7 +449,7 @@ function widget:Update(dt)
 		return
 	end
 
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	window_endgame:SetPos(screenWidth*0.2,screenHeight*0.2,screenWidth*0.6,screenHeight*0.6)
 	statsPanel:SetPosRelative(10, 50, -(10+10), -(50+10))
 	statsSubPanel.graphButtons[1].OnClick[1](statsSubPanel.graphButtons[1])

--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -1816,7 +1816,7 @@ local gridKeyMap, gridMap, gridCustomOverrides -- Configuration requires this
 
 local function InitializeControls()
 	-- Set the size for the default settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	local width = math.max(350, math.min(450, screenWidth*screenHeight*0.0004))
 	local height = math.min(screenHeight/4.5, 200*width/450)  + 8
 

--- a/LuaUI/Widgets/gui_chili_minimap.lua
+++ b/LuaUI/Widgets/gui_chili_minimap.lua
@@ -955,7 +955,11 @@ end
 function widget:Initialize()
 	if (Spring.GetMiniMapDualScreen()) then
 		Spring.Echo("ChiliMinimap: auto disabled (DualScreen is enabled).")
-		widgetHandler:RemoveWidget()
+		-- we still depend on the minimap widget to provide fog of war / radar and config, so we can't outright disable it.
+		widgetHandler:RemoveCallIn("DrawScreen")
+		widgetHandler:RemoveCallIn("MousePress")
+		widgetHandler:RemoveCallIn("MouseMove")
+		widgetHandler:RemoveCallIn("MouseRelease")
 		return
 	end
 

--- a/LuaUI/Widgets/gui_chili_minimap.lua
+++ b/LuaUI/Widgets/gui_chili_minimap.lua
@@ -729,7 +729,7 @@ MakeMinimapWindow = function()
 	end
 	
 	-- Set the size for the default settings.
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local width, height = screenWidth/6, screenWidth/6
 	
 	if options.buttonsOnRight.value then

--- a/LuaUI/Widgets/gui_chili_minimap.lua
+++ b/LuaUI/Widgets/gui_chili_minimap.lua
@@ -640,8 +640,8 @@ function widget:Update() --Note: these run-once codes is put here (instead of in
 		updateRunOnceRan = true
 	end
 
-	local cs = Spring.GetCameraState()
 	if not options.hideOnOverview.value then
+		local cs = Spring.GetCameraState()
 		if cs.name == "ov" and not tabbedMode then
 			Chili.Screen0:RemoveChild(window)
 			tabbedMode = true

--- a/LuaUI/Widgets/gui_chili_minimap.lua
+++ b/LuaUI/Widgets/gui_chili_minimap.lua
@@ -430,6 +430,7 @@ options = {
 			{key = 'arnone',    name = 'Map Fills Window'},
 		},
 		OnChange = function(self)
+			if not window then return end
 			local arwindow = self.value == 'arwindow'
 			window.fixedRatio = arwindow
 			if arwindow then
@@ -454,7 +455,6 @@ options = {
 			final_opacity = self.value * last_alpha
 			last_alpha = 2 --invalidate last_alpha so it needs to be recomputed
 			MakeMinimapWindow()
-			window:Invalidate()
 		end,
 		path = minimap_path,
 	},
@@ -536,6 +536,7 @@ options = {
 			{key = 'panel_1001', name = 'Top Left',},
 		},
 		OnChange = function (self)
+			if not Chili then return end
 			local currentSkin = Chili.theme.skin.general.skinName
 			local skin = Chili.SkinHandler.GetSkin(currentSkin)
 			
@@ -715,6 +716,10 @@ local function MakeMinimapButton(file, params)
 end
 
 MakeMinimapWindow = function()
+	if not Chili then
+		return
+	end
+
 	if (window) then
 		window:Dispose()
 	end

--- a/LuaUI/Widgets/gui_chili_minimap.lua
+++ b/LuaUI/Widgets/gui_chili_minimap.lua
@@ -639,6 +639,7 @@ function widget:Update() --Note: these run-once codes is put here (instead of in
 		options.use_map_ratio.OnChange(options.use_map_ratio) -- Wait for docking to provide saved window size
 		updateRunOnceRan = true
 	end
+	if not window then return end
 
 	if not options.hideOnOverview.value then
 		local cs = Spring.GetCameraState()

--- a/LuaUI/Widgets/gui_chili_nuke_warning.lua
+++ b/LuaUI/Widgets/gui_chili_nuke_warning.lua
@@ -66,7 +66,7 @@ end
 local function CreateWindow()
 	local data = {}
 	
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local screenHorizCentre = screenWidth / 2
 	local windowWidth = 500
 	local resourcePanelHeight = 100

--- a/LuaUI/Widgets/gui_chili_proconsole2.lua
+++ b/LuaUI/Widgets/gui_chili_proconsole2.lua
@@ -1174,9 +1174,8 @@ end
 local function MakeMessageWindow(name, enabled)
 
 	local x,y,bottom,width,height
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	if name == "ProChat" then
-		local screenWidth, screenHeight = Spring.GetWindowGeometry()
 		local integralWidth = math.max(350, math.min(450, screenWidth*screenHeight*0.0004))
 		local integralHeight = math.min(screenHeight/4.5, 200*integralWidth/450)
 		width = 450

--- a/LuaUI/Widgets/gui_chili_proconsole_test.lua
+++ b/LuaUI/Widgets/gui_chili_proconsole_test.lua
@@ -1192,9 +1192,8 @@ end
 local function MakeMessageWindow(name, enabled, ParentFunc)
 
 	local x,y,bottom,width,height
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	if name == "ProChat" then
-		local screenWidth, screenHeight = Spring.GetWindowGeometry()
 		local integralWidth = math.max(350, math.min(450, screenWidth*screenHeight*0.0004))
 		local integralHeight = math.min(screenHeight/4.5, 200*integralWidth/450)
 		width = 450

--- a/LuaUI/Widgets/gui_chili_rejoin_progress.lua
+++ b/LuaUI/Widgets/gui_chili_rejoin_progress.lua
@@ -130,7 +130,7 @@ end
 
 function widget:Initialize()
 
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	local y = screenWidth*2/11 + 32
 
 	screen0 = WG.Chili.Screen0

--- a/LuaUI/Widgets/gui_chili_resource_bars.lua
+++ b/LuaUI/Widgets/gui_chili_resource_bars.lua
@@ -547,7 +547,7 @@ function CreateWindow()
 	end
 	
 	-- Set the size for the default settings.
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local width = 430
 	local x = math.min(screenWidth/2 - width/2, screenWidth - 400 - width)
 	

--- a/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
+++ b/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
@@ -55,7 +55,7 @@ local selectionTooltip = "\n" .. green .. WG.Translate("interface", "lmb") .. ":
 local Chili
 local screen0
 
-local screenWidth, screenHeight = Spring.GetWindowGeometry()
+local screenWidth, screenHeight = Spring.GetViewGeometry()
 
 local tooltipWindow
 local selectionWindow

--- a/LuaUI/Widgets/gui_chili_spectator_panels.lua
+++ b/LuaUI/Widgets/gui_chili_spectator_panels.lua
@@ -698,7 +698,7 @@ local function AddEconomyWindows()
 	else
 		Spring.SendCommands("resbar 0")
 		
-		local screenWidth,screenHeight = Spring.GetWindowGeometry()
+		local screenWidth,screenHeight = Spring.GetViewGeometry()
 		local screenHorizCentre = screenWidth / 2
 		local spacing = 360
 		local econWidth = 480
@@ -726,7 +726,7 @@ end
 local function CreatePlayerWindow()
 	local data = {}
 	
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local screenHorizCentre = screenWidth / 2
 	local playerWindowWidth = 500
 

--- a/LuaUI/Widgets/gui_chili_vote.lua
+++ b/LuaUI/Widgets/gui_chili_vote.lua
@@ -190,7 +190,7 @@ function widget:Initialize()
 	screen0 = Chili.Screen0
 	
 	--create main Chili elements
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local height = tostring(math.floor(screenWidth/screenHeight*0.35*0.35*100)) .. "%"
 	local y = tostring(math.floor((1-screenWidth/screenHeight*0.35*0.35)*100)) .. "%"
 	

--- a/LuaUI/Widgets/gui_epicmenu.lua
+++ b/LuaUI/Widgets/gui_epicmenu.lua
@@ -2146,7 +2146,7 @@ end
 WG.crude.UnpauseFromExitConfirmWindow = UnpauseFromExitConfirmWindow
 
 local function MakeExitConfirmWindow(text, action, height, unpauseOnYes, unpauseOnNo)
-	local screen_width, screen_height = Spring.GetWindowGeometry()
+	local screen_width, screen_height = Spring.GetViewGeometry()
 	local menu_width = 320
 	local menu_height = height or 64
 

--- a/LuaUI/Widgets/gui_hud_presets.lua
+++ b/LuaUI/Widgets/gui_hud_presets.lua
@@ -196,7 +196,7 @@ end
 ----------------------------------------------------
 
 local function SetupMissionGUI(preset)
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	-- mission objectives
 	local objOnLeft = (preset == "new") or (preset == "newMinimapLeft") or (preset == "newMinimapRight") or (preset == "westwood") or (preset == "crafty") or (preset == "ensemble")
 	local objX = objOnLeft and 0 or screenWidth - 64
@@ -289,7 +289,7 @@ local function SetupDefaultPreset()
 	ResetOptionsFromNew()
 	
 	-- Settings for window positions and settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	
 	-- Minimap
 	local minimapWidth = math.ceil(screenWidth*2/11)
@@ -427,7 +427,7 @@ local function SetupNewPreset()
 	SetNewOptions()
 	
 	-- Settings for window positions and settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	
 	------------------------------------------------------------------------
 	------------------------------------------------------------------------
@@ -722,7 +722,7 @@ local function GetBottomSizes(screenWidth, screenHeight, parity)
 end
 
 local function SetupNewUITop()
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	screenHeight = math.floor(screenHeight)
 	local SIZE_FACTOR = 1
 	if screenWidth > 3000 and USE_SIZE_FACTOR then
@@ -820,7 +820,7 @@ local function SetupMinimapLeftPreset()
 	SetupNewWidgets()
 	
 	-- Settings for window positions and settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	screenHeight = math.ceil(screenHeight)
 	
 	if screenWidth <= 1650 then
@@ -926,7 +926,7 @@ local function SetupMinimapRightPreset()
 	SetupNewWidgets()
 	
 	-- Settings for window positions and settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	screenHeight = math.ceil(screenHeight)
 	
 	if screenWidth <= 1650 then
@@ -1051,7 +1051,7 @@ local function SetupCraftyPreset()
 	ResetOptionsFromNew()
 	
 	-- Settings for window positions and settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	
 	-- Minimap
 	local minimapWidth = screenWidth*9/44 + 20
@@ -1179,7 +1179,7 @@ local function SetupEnsemblePreset()
 	ResetOptionsFromNew()
 	
 	-- Settings for window positions and settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	
 	-- Integral Menu
 	local integralWidth = math.max(350, math.min(500, screenWidth*screenHeight*0.0004))
@@ -1306,7 +1306,7 @@ local function SetupWestwoodPreset()
 	ResetOptionsFromNew()
 	
 	-- Settings for window positions and settings.
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	
 	-- Resource Bar
 	local resourceBarWidth = screenWidth*5/22 + 20
@@ -1548,7 +1548,7 @@ function widget:Update(dt)
 	if firstUpdate then
 		firstUpdate = false
 		
-		local screenWidth, screenHeight = Spring.GetWindowGeometry()
+		local screenWidth, screenHeight = Spring.GetViewGeometry()
 		oldWidth = screenWidth
 		oldHeight = screenHeight
 		UpdateInterfacePreset(options.interfacePreset)
@@ -1557,7 +1557,7 @@ function widget:Update(dt)
 	if options.maintainDefaultUI.value  then
 		timeSinceUpdate = timeSinceUpdate + dt
 		if timeSinceUpdate > UPDATE_FREQUENCY then
-			local screenWidth, screenHeight = Spring.GetWindowGeometry()
+			local screenWidth, screenHeight = Spring.GetViewGeometry()
 			if oldWidth ~= screenWidth or oldHeight ~= screenHeight then
 				oldWidth = screenWidth
 				oldHeight = screenHeight
@@ -1577,7 +1577,7 @@ function widget:ViewResize(screenWidth, screenHeight)
 end
 
 function widget:GetConfigData()
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	return {oldScreenWidth = screenWidth, oldScreenHeight = screenHeight}
 end
 

--- a/LuaUI/Widgets/gui_news_ticker.lua
+++ b/LuaUI/Widgets/gui_news_ticker.lua
@@ -428,8 +428,6 @@ function widget:Initialize()
 	Panel = Chili.Panel
 	screen0 = Chili.Screen0
 	
-	--local screenWidth, screenHeight = Spring.GetWindowGeometry()
-	
 	window_ticker = Window:New{
 		padding = {0,0,0,0},
 		--itemMargin = {0, 0, 0, 0},

--- a/LuaUI/Widgets/gui_replay_controls.lua
+++ b/LuaUI/Widgets/gui_replay_controls.lua
@@ -118,7 +118,7 @@ end
 
 function CreateTheUI()
 	--create main Chili elements
-	local screenWidth,screenHeight = Spring.GetWindowGeometry()
+	local screenWidth,screenHeight = Spring.GetViewGeometry()
 	local height = tostring(math.floor(screenWidth/screenHeight*0.35*0.35*100)) .. "%"
 	local windowY = math.floor(screenWidth*2/11 + 32)
 	

--- a/LuaUI/Widgets/gui_roi_tracker.lua
+++ b/LuaUI/Widgets/gui_roi_tracker.lua
@@ -80,8 +80,6 @@ function widget:Update(s)
 end
 
 function CreateWindow()
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
-
 	fake_window = Chili.Window:New {
 		color = {1,1,1,0.7},
 		parent = Chili.Screen0,

--- a/LuaUI/Widgets/gui_unit_target_command_helper.lua
+++ b/LuaUI/Widgets/gui_unit_target_command_helper.lua
@@ -14,7 +14,7 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-local SIZE_FACTOR = ((select(1, Spring.GetWindowGeometry()) > 3000) and 2) or 1
+local SIZE_FACTOR = ((select(1, Spring.GetViewGeometry()) > 3000) and 2) or 1
 
 local function SetCircleDragThreshold(value)
 	value = value*SIZE_FACTOR

--- a/LuaUI/Widgets/mission_galaxy_battle_handler.lua
+++ b/LuaUI/Widgets/mission_galaxy_battle_handler.lua
@@ -134,7 +134,7 @@ local function TakeMouseOffEdge()
 		return
 	end
 	
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	local changed = false
 	
 	if mx < SCREEN_EDGE then
@@ -256,7 +256,7 @@ local function InitializeBriefingWindow()
 	
 	local externalFunctions = {}
 	
-	local screenWidth, screenHeight = Spring.GetWindowGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	
 	local briefingWindow = Chili.Window:New{
 		classname = "main_window",

--- a/LuaUI/Widgets/mission_objectives.lua
+++ b/LuaUI/Widgets/mission_objectives.lua
@@ -324,7 +324,7 @@ function widget:Initialize()
 	Image       = Chili.Image
 	screen0     = Chili.Screen0
 	
-	local vsx, vsy = Spring.GetWindowGeometry()
+	local vsx, vsy = Spring.GetViewGeometry()
 	local width, height = 480, 240
 	local y = vsy * 0.20 + 50	-- put it under proconsole
 	


### PR DESCRIPTION
While the widget disables itself in DualScreenMode, Epic Menu still
tries to configure it using returned references to the options table.

This adds defensiveness to some options OnChange functions, to prevent
a LuaUI-crashing error in Epic Menu. This is not necessarily exhaustive,
or even the best approach to take.

Perhaps Epic Menu should check to make sure the widget is still enabled
before configuring.

In any case, window:Invalidate is redundant after MakeMinimapWindow, as
the old window is Dispose()'d and an entirely new one created.

DualScreenMode itself still depends on a sister engine commit before
becoming usable.
See https://github.com/spring/spring/pull/541