### PR TITLE
Actually fix this check.

### DIFF
--- a/LuaRules/Gadgets/share_control.lua
+++ b/LuaRules/Gadgets/share_control.lua
@@ -17,7 +17,7 @@ local gaiaTeamID = Spring.GetGaiaTeamID()
 
 local function IsTeamAfk(teamID)
 	local _, shares = GG.Lagmonitor.GetResourceShares()
-	return shares == 0
+	return shares[teamID] == 0
 end
 
 function gadget:AllowResourceTransfer(oldTeam, newTeam, resource_type, amount)


### PR DESCRIPTION
Shares is actually a table of teamIDs that are never nil. Apparently we assumed it wasn't broken because it never complained.