### PR TITLE
Fixed a typo in the info box

### DIFF
--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -162,7 +162,7 @@ options = {
 	},
 	enable_roam = {
 		name = "Enable roam move state",
-		desc = "When enabled, the Hold Position state is extended to a three-option toggle with with Roam as an additional option.",
+		desc = "When enabled, the Hold Position state is extended to a three-option toggle with Roam as an additional option.",
 		type = 'bool',
 		value = false,
 		OnChange = function(self)


### PR DESCRIPTION
Fix for info box typo "three-option toggle with WITH roam as an additional option.