### PR TITLE
Make unit_auto_patrol_nanos smarter

### DIFF
--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -12,8 +12,8 @@
 --      includes repair units), area reclaim metal, area reclaim energy, or patrol,
 --      depending on available resources.
 --   2. For each caretaker under this widget's control, re-evaluate the behavior based
---		on the economy every 20 seconds. (Controlled by checkInterval.)
---   3. For each caretaker, never issue a command more than once every 5 seconds.
+--		on the economy every 10 seconds. (Controlled by checkInterval.)
+--   3. For each caretaker, never issue a command more than once every 2.5 seconds.
 --      (Controlled by settleInterval.)
 --   4. When a user issues a stop command, this behavior is inhibited, until a
 --      different command issued by the user completes. (Unless stop_disables option
@@ -86,6 +86,8 @@ local mapCenterZ = Game.mapSizeZ / 2
 --------------------------------------------------------------------------------
 -- Constants
 
+local FPS = 30
+
 local PATROL = 1
 local RECLAIM_METAL = 2
 local RECLAIM_ENERGY = 3
@@ -94,12 +96,12 @@ local BUILD_ASSIST = 5
 
 -- Check that a unit is still doing the right thing every `checkInterval`
 -- frames.
-local checkInterval = 300
+local checkInterval = 10 * FPS
 -- Don't issue a new command if less than `settleInterval` frames have passed,
 -- even if the unit became idle. This is a simple rate limiter on issuing
 -- commands in case there are caretakers with nothing to do for their current
 -- state.
-local settleInterval = 75
+local settleInterval = 2.5 * FPS
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -164,11 +166,12 @@ local function DecideCommands()
 
 	local metal, metalStorage, metalPull, metalIncome =
 			spGetTeamResources(spGetMyTeamID(), "metal")
-	metal = metal + metalIncome - metalPull
+	metal = metal + checkInterval * (metalIncome - metalPull) / FPS
 	metalStorage = metalStorage - HIDDEN_STORAGE
+	Log("metal=" .. metal .. "; storage=" .. metalStorage .. "; pull=" .. metalPull .. "; income=" .. metalIncome)
 	local energy, energyStorage, energyPull, energyIncome =
 			spGetTeamResources(spGetMyTeamID(), "energy")
-	energy = energy + energyIncome - energyPull
+	energy = energy + checkInterval * (energyIncome - energyPull) / FPS
 	energyStorage = energyStorage - HIDDEN_STORAGE
 
 	local slop = 5

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -59,17 +59,9 @@ local CMD_PATROL        = CMD.PATROL
 local CMD_RECLAIM       = CMD.RECLAIM
 local CMD_REPAIR        = CMD.REPAIR
 local CMD_STOP          = CMD.STOP
-local CMD_INSERT        = CMD.INSERT
 local CMD_OPT_CTRL      = CMD.OPT_CTRL
-local CMD_OPT_ALT       = CMD.OPT_ALT
 local CMD_OPT_SHIFT     = CMD.OPT_SHIFT
-
-local CommandNames = {
-	[CMD_PATROL] = "PATROL",
-	[CMD_RECLAIM] = "RECLAIM",
-	[CMD_REPAIR] = "REPAIR",
-	[CMD_STOP] = "STOP"
-}
+local CMD_OPT_META      = CMD.OPT_META
 
 local spGetMyTeamID     = Spring.GetMyTeamID
 local spGetTeamUnits    = Spring.GetTeamUnits
@@ -220,16 +212,14 @@ local function DecideCommands(x, y, z, buildDistance)
 		use_energy = energy > slop and energy > energyStorage * 0.1
 	end
 
-	Log("get_metal=" .. tostring(get_metal) .. ", " ..
-		"use_metal=" .. tostring(use_metal) .. ", " ..
-		"get_energy=" .. tostring(get_energy) .. ", " ..
-		"use_energy=" .. tostring(use_energy))
+	--Log("get_metal=" .. tostring(get_metal) .. ", " ..
+	--	"use_metal=" .. tostring(use_metal) .. ", " ..
+	--	"get_energy=" .. tostring(get_energy) .. ", " ..
+	--	"use_energy=" .. tostring(use_energy))
 
 	local reclaim_metal = {CMD_RECLAIM, {x, y, z, buildDistance}, 0, "reclaim metal"}
 	local reclaim_energy = {CMD_RECLAIM, {x, y, z, buildDistance}, CMD_OPT_CTRL, "reclaim energy"}
-	-- TODO: This doesn't work right. When we issue this command it still
-	-- assists in building units.
-	local repair_units = {CMD_REPAIR, {x, y, z, buildDistance}, CMD_OPT_CTRL, "repair units"}
+	local repair_units = {CMD_REPAIR, {x, y, z, buildDistance}, CMD_OPT_META, "repair units"}
 	local build_assist = {CMD_REPAIR, {x, y, z, buildDistance}, 0, "build assist"}
 
 	-- Patrolling doesn't do anything if you target the current location of
@@ -326,7 +316,7 @@ local function SetupUnit(unitID)
 		end
 
 		if AllTrue(foundCommand) then
-			Log("All commands were already issued")
+			--Log("All commands were already issued")
 			return
 		end
 
@@ -337,12 +327,14 @@ local function SetupUnit(unitID)
 		end
 
 		for i, cmd in ipairs(cmds) do
-			Log("give order " .. cmd[4] .. " to " .. unitID ..
-					" @ " .. x .. ", " .. y .. ", " .. z)
 			if i == 1 then
 				spGiveOrderToUnit(unitID, cmd[1], cmd[2], cmd[3])
+				Log("give order " .. cmd[4] .. " to " .. unitID ..
+						" @ " .. x .. ", " .. y .. ", " .. z)
 			else
 				spGiveOrderToUnit(unitID, cmd[1], cmd[2], cmd[3] + CMD_OPT_SHIFT)
+				Log("queue order " .. cmd[4] .. " to " .. unitID ..
+						" @ " .. x .. ", " .. y .. ", " .. z)
 			end
 		end
 		trackedUnits[unitID].settleTime = time + settleInterval

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -83,7 +83,7 @@ local max = math.max
 local mapCenterX = Game.mapSizeX / 2
 local mapCenterZ = Game.mapSizeZ / 2
 
-local debug = true
+local debug = false
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -143,10 +143,6 @@ local function IsImmobileBuilder(ud)
 end
 
 local function DecideCommands(unitID)
-	-- For now, assume the unit is currently idle. We really ought to figure out
-	-- if it is doing something because there's a big different between going
-	-- from idle to repair and going from reclaiming metal to repair.
-
 	local trackedUnit = trackedUnits[unitID]
 
 	local metalMake, metalUse, energyMake, energyUse = spGetUnitResources(unitID)
@@ -390,7 +386,7 @@ local function SetupUnit(unitID)
 
 	trackedUnit.checkFrame = currentFrame + RandomInterval(checkInterval)
 	queue:push({trackedUnit.checkFrame, unitID})
-	Log(unitID, "; push for ", trackedUnit.checkFrame)
+	--Log(unitID, "; push for ", trackedUnit.checkFrame)
 
 	local decisions = DecideCommands(unitID)
 	local cmds = MakeCommands(decisions, unitID)
@@ -404,9 +400,9 @@ local function SetupUnit(unitID)
 	local currentID, currentOpt, _, currentParam1,
 			currentParam2, currentParam3, currentParam4, currentParam5 =
 			spGetUnitCurrentCommand(unitID)
-	Log(unitID, "; currently executing ", currentID, "(", currentParam1,
-		", ", currentParam2, ", ", currentParam3, ", ", currentParam4, ", ",
-		currentParam5, ") ", currentOpt)
+	--Log(unitID, "; currently executing ", currentID, "(", currentParam1,
+	--	", ", currentParam2, ", ", currentParam3, ", ", currentParam4, ", ",
+	--	currentParam5, ") ", currentOpt)
 
 	if currentID then
 		if IssuedCausesCurrent(cmds[1], currentID, currentOpt,
@@ -618,7 +614,7 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 	-- If we're not idle at that point, we must have found some work to do.
 	trackedUnit.resetIdle = trackedUnit.checkFrame + 1
 	queue:push({trackedUnit.checkFrame, unitID})
-	Log(unitID, "; push for ", trackedUnit.checkFrame)
+	--Log(unitID, "; push for ", trackedUnit.checkFrame)
 end
 
 -- Called for every game simulation frame (30 per second).
@@ -637,8 +633,8 @@ function widget:GameFrame(frame)
 			local unitID = entry[2]
 
 			if trackedUnits[unitID] then
-				Log(unitID, "; ", frame, " >= ".. entry[1],
-						"; checkFrame=", trackedUnits[unitID].checkFrame)
+				--Log(unitID, "; ", frame, " >= ".. entry[1],
+				--		"; checkFrame=", trackedUnits[unitID].checkFrame)
 
 				if entry[1] == trackedUnits[unitID].checkFrame then
 					-- Otherwise, we queued this unit multiple times and this is not

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -261,7 +261,7 @@ local function SetupUnit(unitID)
 		trackedUnits[unitID] = trackedUnits[unitID] or {}
 		trackedUnits[unitID].checkTime = time + RandomInterval(checkInterval)
 		local cmds = DecideCommands(x, y, z, buildDistance)
-		TableEcho(cmds, "cmds: ")
+		--TableEcho(cmds, "cmds: ")
 
 		local commandQueue = spGetCommandQueue(unitID, -1)
 		--Log(time .. "; cmd queue for " .. unitID .. ":")

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -68,6 +68,8 @@ local spEcho            = Spring.Echo
 local spGetTeamResources = Spring.GetTeamResources
 local spValidUnitID		= Spring.ValidUnitID
 
+local TableEcho = Spring.Utilities.TableEcho
+
 local abs = math.abs
 local min = math.min
 local max = math.max
@@ -114,22 +116,6 @@ end
 
 local function Log(msg)
 	spEcho("[uapn] " .. msg)
-end
-
-local function LogTable(table, prefix)
-	if table == nil then
-		Log(prefix .. "nil")
-		return
-	end
-	prefix = prefix or ""
-	for key, value in pairs(table) do
-		if type(value) == "table" then
-			Log(prefix .. tostring(key) .. ":")
-			LogTable(value, prefix .. "  ")
-		else
-			Log(prefix .. tostring(key) .. ": " .. tostring(value))
-		end
-	end
 end
 
 local function TableEqual(a, b)
@@ -275,13 +261,12 @@ local function SetupUnit(unitID)
 		trackedUnits[unitID] = trackedUnits[unitID] or {}
 		trackedUnits[unitID].checkTime = time + RandomInterval(checkInterval)
 		local cmds = DecideCommands(x, y, z, buildDistance)
-		--LogTable(cmds, "cmds: ")
+		TableEcho(cmds, "cmds: ")
 
 		local commandQueue = spGetCommandQueue(unitID, -1)
 		--Log(time .. "; cmd queue for " .. unitID .. ":")
-		--LogTable(commandQueue, "commandQueue: ")
+		--TableEcho(commandQueue, "commandQueue: ")
 
-		--LogTable(cmd, "cmd: ")
 		local foundIssuedCommand = false
 		local foundAnyCommand = false
 
@@ -291,7 +276,7 @@ local function SetupUnit(unitID)
 		end
 
 		for _, current in pairs(commandQueue) do
-			--LogTable(current, "current:")
+			--TableEcho(current, "current:")
 			--Log(tostring(current.options.internal))
 			--Log(tostring(current.id == cmd[1]))
 			--Log(tostring(TableEqual(cmd[2], current.params)))
@@ -414,8 +399,8 @@ function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOp
 	end
 
 	--Log("UnitCommand(" .. unitID .. ", " .. unitDefID .. ", " .. unitTeam .. ", " .. cmdID .. ")")
-	--LogTable(cmdParams, "  params: ")
-	--LogTable(cmdOptions, "  options: ")
+	--TableEcho(cmdParams, "  params: ")
+	--TableEcho(cmdOptions, "  options: ")
 
 	if stopHalts then
 		if cmdID == CMD_STOP then
@@ -453,7 +438,7 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 	If the command was ordered with SHIFT it would get appended after the patrol. ]]
 
 	--Log("UnitIdle:")
-	--LogTable(trackedUnits[unitID], "- ")
+	--TableEcho(trackedUnits[unitID], "- ")
 
 	-- Check soon, but not right away. This time has to be long enough that the
 	-- factory we're assisting (while in repair mode) has started the next unit.
@@ -471,7 +456,7 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 	else
 		nextCheck = min(nextCheck, trackedUnits[unitID].checkTime)
 	end
-	--LogTable(trackedUnits[unitID], "+ ")
+	--TableEcho(trackedUnits[unitID], "+ ")
 end
 
 function widget:Update(dt)

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -12,9 +12,9 @@
 --    includes repair units), area reclaim metal, area reclaim energy, or patrol,
 --    depending on available resources.
 -- 2. For each caretaker under this widget's control, re-evaluate the behavior based
---    on the economy every 10 seconds. (Controlled by checkInterval.)
--- 3. For each caretaker, never issue a command more than once every 2.5 seconds.
---    (Controlled by settleInterval.)
+--    on the economy every 4 seconds. (Controlled by checkInterval.)
+-- 3. When a caretaker becomes idle, quickly issue new commands. This is
+--    essential to effectively assist factories.
 -- 4. When a user issues a stop command, this behavior is inhibited, until a
 --    different command issued by the user completes. (Unless stop_disables option
 --    is false.)
@@ -22,12 +22,12 @@
 --    until it becomes idle again.
 --
 -- Limitations:
--- 1. When the widget chooses repair only, there's a 0.5 second delay between
---    a unit becoming idle and being told to repair. This is to give the factory
---    that's being assisted time to start the next unit. It is not perfect, and the
---    factory will be assisted less than if a patrol was issued. This could be
---    improved by reducing the delay, and implementing a fancier incremental
---    back-off than the simple 0.5s - 5s that is currently implemented.
+-- 1. When a unit is assisting a factory and there is sufficient available
+--    metal/energy storage, then the unit will spend some time reclaiming
+--    metal/energy after the factory has finished building something, before being
+--    told to assist the factory again. This does not happen in a "normal" economy
+--    where you are limited by metal and have an energy surplus.
+--    As a workaround you can give a caretaker a patrol order.
 --
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -286,7 +286,7 @@ local function IssuedCausesCurrent(issued, currentID, currentOpt,
 --		tostring(currentParam4) .. ", " ..
 --		tostring(currentParam5) .. ") " .. tostring(currentOpt))
 
-	if currentID == nil then
+	if currentID == nil or issued == nil then
 		return false
 	end
 

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -12,7 +12,7 @@
 --    includes repair units), area reclaim metal, area reclaim energy, or patrol,
 --    depending on available resources.
 -- 2. For each caretaker under this widget's control, re-evaluate the behavior based
---	n the economy every 10 seconds. (Controlled by checkInterval.)
+--    on the economy every 10 seconds. (Controlled by checkInterval.)
 -- 3. For each caretaker, never issue a command more than once every 2.5 seconds.
 --    (Controlled by settleInterval.)
 -- 4. When a user issues a stop command, this behavior is inhibited, until a
@@ -28,11 +28,6 @@
 --    factory will be assisted less than if a patrol was issued. This could be
 --    improved by reducing the delay, and implementing a fancier incremental
 --    back-off than the simple 0.5s - 5s that is currently implemented.
--- 2. When economy changes such that the best commands switch from
---    reclaim-metal;reclaim-energy to reclaim-energy;reclaim-metal, caretakers
---    won't actually switch until they complete reclaiming whatever they are
---    reclaiming. This is a problem if caretakers are reclaiming something huge and
---    they might excess metal until that is completely reclaimed.
 --
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
@@ -409,20 +404,20 @@ local function SetupUnit(unitID)
 	for i, cmd in ipairs(cmds) do
 		if i == 1 then
 			spGiveOrderToUnit(unitID, cmd[1], cmd[2], cmd[3])
-			Log(unitID .. "; give order " .. cmd[1] .. "(" ..
-				tostring(cmd[2][1]) .. ", " ..
-				tostring(cmd[2][2]) .. ", " ..
-				tostring(cmd[2][3]) .. ", " ..
-				tostring(cmd[2][4]) .. ", " ..
-				tostring(cmd[2][5]) .. ") " .. cmd[3] .. " (" .. cmd[4] .. ")")
+--			Log(unitID .. "; give order " .. cmd[1] .. "(" ..
+--				tostring(cmd[2][1]) .. ", " ..
+--				tostring(cmd[2][2]) .. ", " ..
+--				tostring(cmd[2][3]) .. ", " ..
+--				tostring(cmd[2][4]) .. ", " ..
+--				tostring(cmd[2][5]) .. ") " .. cmd[3] .. " (" .. cmd[4] .. ")")
 		else
 			spGiveOrderToUnit(unitID, cmd[1], cmd[2], cmd[3] + CMD_OPT_SHIFT)
-			Log(unitID .. "; queue order " .. cmd[1] .. "(" ..
-				tostring(cmd[2][1]) .. ", " ..
-				tostring(cmd[2][2]) .. ", " ..
-				tostring(cmd[2][3]) .. ", " ..
-				tostring(cmd[2][4]) .. ", " ..
-				tostring(cmd[2][5]) .. ") " .. cmd[3] .. " (" .. cmd[4] .. ")")
+--			Log(unitID .. "; queue order " .. cmd[1] .. "(" ..
+--				tostring(cmd[2][1]) .. ", " ..
+--				tostring(cmd[2][2]) .. ", " ..
+--				tostring(cmd[2][3]) .. ", " ..
+--				tostring(cmd[2][4]) .. ", " ..
+--				tostring(cmd[2][5]) .. ") " .. cmd[3] .. " (" .. cmd[4] .. ")")
 		end
 	end
 	trackedUnits[unitID].settleFrame = currentFrame + RandomInterval(settleInterval)

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -105,6 +105,13 @@ local nextCheck
 --------------------------------------------------------------------------------
 -- Functions
 
+-- Slightly randomize intervals, to prevent all caretakers from getting synced
+-- up and all of them deciding to reclaim now, while really what needs to happen
+-- is just some of them reclaiming.
+local function RandomInterval(interval)
+	return interval / 2 + math.random() * interval
+end
+
 local function Log(msg)
 	spEcho("[uapn] " .. msg)
 end
@@ -266,7 +273,7 @@ local function SetupUnit(unitID)
 		local unitDefID = spGetUnitDefID(unitID)
 		local buildDistance = UnitDefs[unitDefID].buildDistance
 		trackedUnits[unitID] = trackedUnits[unitID] or {}
-		trackedUnits[unitID].checkTime = time + checkInterval
+		trackedUnits[unitID].checkTime = time + RandomInterval(checkInterval)
 		local cmds = DecideCommands(x, y, z, buildDistance)
 		--LogTable(cmds, "cmds: ")
 
@@ -331,7 +338,7 @@ local function SetupUnit(unitID)
 						" @ " .. x .. ", " .. y .. ", " .. z)
 			end
 		end
-		trackedUnits[unitID].settleTime = time + settleInterval
+		trackedUnits[unitID].settleTime = time + RandomInterval(settleInterval)
 		trackedUnits[unitID].commands = cmds
 	end
 end

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -236,7 +236,7 @@ local function SetupUnit(unitID)
 				foundAnyCommand = true
 				if current.id == cmd[1] and
 					TableEqual(cmd[2], current.params) then
-					Log("order " .. CommandNames[cmd[1]] .. " to " .. unitID .. " already issued")
+					--Log("order " .. CommandNames[cmd[1]] .. " to " .. unitID .. " already issued")
 					return
 				end
 
@@ -257,7 +257,7 @@ local function SetupUnit(unitID)
 
 		Log("give order " .. CommandNames[cmd[1]] .. " to " .. unitID ..
 				" @ " .. x .. ", " .. y .. ", " .. z)
-		LogTable(cmd[2], "  order args: ")
+		--LogTable(cmd[2], "  order args: ")
 		spGiveOrderToUnit(unitID, cmd[1], cmd[2], {})
 		trackedUnits[unitID].settleTime = time + settleInterval
 		trackedUnits[unitID].command = cmd

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -8,9 +8,9 @@
 --  Licensed under the terms of the GNU GPL, v2 or later.
 --
 -- Features:
---   1. Idle caretakers will be set to area repair if metal is high, area reclaim
---      when metal is low, and patrol otherwise. (Unless patrol_idle_nanos option is
---      false.)
+--   1. Idle caretakers will be set to area repair units, area assist build (which
+--      includes repair units), area reclaim metal, area reclaim energy, or patrol,
+--      depending on available resources.
 --   2. For each caretaker under this widget's control, re-evaluate the behavior based
 --		on the economy every 20 seconds. (Controlled by checkInterval.)
 --   3. For each caretaker, never issue a command more than once every 5 seconds.
@@ -22,13 +22,7 @@
 --      until it becomes idle again.
 --
 -- Limitations:
---   1. Area reclaim does not reclaim energy sources. We'd have to call
---      GetFeaturesInRectangle() to improve this.
---   2. Area repair either assists in build (using both metal and energy) or
---      repairs damage (using only energy). Since assisting a factory is the most
---      common use for caretakers, we tell caretakers to reclaim if metal is low.
---      We'd have to call GetUnitsInCylinder() to do better.
---   3. When the widget chooses repair only, there's a 0.5 second delay between
+--   1. When the widget chooses repair only, there's a 0.5 second delay between
 --      a unit becoming idle and being told to repair. This is to give the factory
 --      that's being assisted time to start the next unit. It is not perfect, and the
 --      factory will be assisted less than if a patrol was issued. This could be

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -202,40 +202,40 @@ local function DecideCommands(x, y, z, buildDistance)
 	--	"get_energy=" .. tostring(get_energy) .. ", " ..
 	--	"use_energy=" .. tostring(use_energy))
 
-	local reclaim_metal = {CMD_RECLAIM, {x, y, z, buildDistance}, 0, "reclaim metal"}
-	local reclaim_energy = {CMD_RECLAIM, {x, y, z, buildDistance}, CMD_OPT_CTRL, "reclaim energy"}
-	local repair_units = {CMD_REPAIR, {x, y, z, buildDistance}, CMD_OPT_META, "repair units"}
-	local build_assist = {CMD_REPAIR, {x, y, z, buildDistance}, 0, "build assist"}
+	local function reclaim_metal() return {CMD_RECLAIM, {x, y, z, buildDistance}, 0, "reclaim metal"} end
+	local function reclaim_energy() return {CMD_RECLAIM, {x, y, z, buildDistance}, CMD_OPT_CTRL, "reclaim energy"} end
+	local function repair_units() return {CMD_REPAIR, {x, y, z, buildDistance}, CMD_OPT_META, "repair units"} end
+	local function build_assist() return {CMD_REPAIR, {x, y, z, buildDistance}, 0, "build assist"} end
 
 	-- Patrolling doesn't do anything if you target the current location of
 	-- the unit. Point patrol towards map center.
 	local vx = mapCenterX - x
 	local vz = mapCenterZ - z
-	local patrol = {CMD_PATROL, {x + vx*25/abs(vx), y, z + vz*25/abs(vz)}, 0, "patrol"}
+	local function patrol() return {CMD_PATROL, {x + vx*25/abs(vx), y, z + vz*25/abs(vz)}, 0, "patrol"} end
 
 	local commands = {}
 
 	if get_metal and use_metal and use_energy then
-		commands[#commands + 1] = patrol
+		commands[#commands + 1] = patrol()
 	else
 		if use_metal and use_energy then
-			commands[#commands + 1] = build_assist
+			commands[#commands + 1] = build_assist()
 		end
 		if use_energy then
-			commands[#commands + 1] = repair_units
+			commands[#commands + 1] = repair_units()
 		end
 		if get_metal and get_energy then
 			if metal > energy then
-				commands[#commands + 1] = reclaim_energy
-				commands[#commands + 1] = reclaim_metal
+				commands[#commands + 1] = reclaim_energy()
+				commands[#commands + 1] = reclaim_metal()
 			else
-				commands[#commands + 1] = reclaim_metal
-				commands[#commands + 1] = reclaim_energy
+				commands[#commands + 1] = reclaim_metal()
+				commands[#commands + 1] = reclaim_energy()
 			end
 		elseif get_metal then
-			commands[#commands + 1] = reclaim_metal
+			commands[#commands + 1] = reclaim_metal()
 		elseif get_energy then
-			commands[#commands + 1] = reclaim_energy
+			commands[#commands + 1] = reclaim_energy()
 		end
 	end
 
@@ -263,7 +263,7 @@ local function SetupUnit(unitID)
 
 		local commandQueue = spGetCommandQueue(unitID, -1)
 		--Log(currentFrame .. "; cmd queue for " .. unitID .. ":")
-		--TableEcho(commandQueue, "commandQueue: ")
+		TableEcho(commandQueue, "commandQueue: ")
 
 		local foundIssuedCommand = false
 		local foundAnyCommand = false
@@ -278,6 +278,25 @@ local function SetupUnit(unitID)
 			--Log(tostring(current.options.internal))
 			--Log(tostring(current.id == cmd[1]))
 			--Log(tostring(ITableEqual(cmd[2], current.params)))
+
+			-- A single command looks like:
+			-- id = 15
+			-- tag = 121
+			-- options = {
+			--     alt = false
+			--     ctrl = false
+			--     internal = false
+			--     coded = 0
+			--     right = false
+			--     meta = false
+			--     shift = false
+			-- },
+			-- params = {
+			--     1 = 4624
+			--     2 = 170.444534
+			--     3 = 4436
+			-- },
+
 
 			if not current.options.internal then
 				foundAnyCommand = true
@@ -466,7 +485,7 @@ function widget:GameFrame(frame)
 		if entry and frame >= entry[1] then
 			queue:pop()
 
-			unitID = entry[2]
+			local unitID = entry[2]
 
 			Log("Process unit " .. unitID .. " because " .. frame .. " >= ".. entry[1])
 

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -140,7 +140,7 @@ local currentFrame = 0
 -- up and all of them deciding to reclaim now, while really what needs to happen
 -- is just some of them reclaiming.
 local function RandomInterval(interval)
-	return interval / 2 + math.random() * interval
+	return math.floor(interval / 2 + math.random() * interval)
 end
 
 local function Log(msg)
@@ -383,7 +383,13 @@ local function SetupUnit(unitID)
 			while true do
 				local currentID, currentOpt, _, currentParam1,
 						currentParam2, currentParam3, currentParam4, currentParam5 =
-						spGetUnitCurrentCommand(unitID, i)
+						spGetUnitCurrentCommand(unitID)
+				Log(unitID .. "; currently executing " .. tostring(currentID) .. "(" ..
+					tostring(currentParam1) .. ", " ..
+					tostring(currentParam2) .. ", " ..
+					tostring(currentParam3) .. ", " ..
+					tostring(currentParam4) .. ", " ..
+					tostring(currentParam5) .. ") " .. tostring(currentOpt))
 				if currentID == nil then
 					break
 				end
@@ -633,17 +639,20 @@ function widget:GameFrame(frame)
 
 			local unitID = entry[2]
 
-			--Log("Process unit " .. unitID .. " because " .. frame .. " >= ".. entry[1])
+			if trackedUnits[unitID] then
+				Log(unitID .. "; " .. frame .. " >= ".. entry[1] ..
+						"; checkFrame=" .. tostring(trackedUnits[unitID].checkFrame))
 
-			if trackedUnits[unitID] and entry[1] == trackedUnits[unitID].checkFrame then
-				-- Otherwise, we queued this unit multiple times and this is not
-				-- the "real" one so discard it. That's simpler than removing a
-				-- stale entry from the queue.
+				if entry[1] == trackedUnits[unitID].checkFrame then
+					-- Otherwise, we queued this unit multiple times and this is not
+					-- the "real" one so discard it. That's simpler than removing a
+					-- stale entry from the queue.
 
-				if spValidUnitID(unitID) then
-					SetupUnit(unitID)
-				else
-					trackedUnits[unitID] = nil
+					if spValidUnitID(unitID) then
+						SetupUnit(unitID)
+					else
+						trackedUnits[unitID] = nil
+					end
 				end
 			end
 		else

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -118,15 +118,13 @@ local function Log(msg)
 	spEcho("[uapn] " .. msg)
 end
 
-local function TableEqual(a, b)
-	for k, v in pairs(a) do
-		if b[k] ~= v then
-			return false
-		end
+local function ITableEqual(a, b)
+	if #a ~= #b then
+		return false
 	end
 
-	for k, v in pairs(b) do
-		if a[k] ~= v then
+	for i = 1, #a do
+		if a[i] ~= b[i] then
 			return false
 		end
 	end
@@ -150,6 +148,9 @@ end
 
 local resourceCacheInterval = 1
 local resourceCache = { updated=nil }
+-- TODO:
+-- We should return which commands we do and which we do not want issued,
+-- so we will reissue if we have strictly fewer options than before.
 local function DecideCommands(x, y, z, buildDistance)
 	if resourceCache.updated == nil or
 			resourceCache.updated + resourceCacheInterval < time then
@@ -279,13 +280,14 @@ local function SetupUnit(unitID)
 			--TableEcho(current, "current:")
 			--Log(tostring(current.options.internal))
 			--Log(tostring(current.id == cmd[1]))
-			--Log(tostring(TableEqual(cmd[2], current.params)))
+			--Log(tostring(ITableEqual(cmd[2], current.params)))
 
 			if not current.options.internal then
 				foundAnyCommand = true
+				-- TODO: here and below also check cmd[3]
 				for i, cmd in ipairs(cmds) do
 					if current.id == cmd[1] and
-							TableEqual(cmd[2], current.params) then
+							ITableEqual(cmd[2], current.params) then
 						foundCommand[i] = true
 					end
 				end
@@ -293,7 +295,7 @@ local function SetupUnit(unitID)
 				if trackedUnits[unitID].commands then
 					for i, cmd in ipairs(trackedUnits[unitID].commands) do
 						if current.id == cmd[1] and
-								TableEqual(current.params, cmd[2]) then
+								ITableEqual(current.params, cmd[2]) then
 							foundIssuedCommand = true
 						end
 					end

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -136,7 +136,7 @@ local currentFrame = 0
 -- up and all of them deciding to reclaim now, while really what needs to happen
 -- is just some of them reclaiming.
 local function RandomInterval(interval)
-	return math.floor(interval / 2 + math.random() * interval)
+	return math.floor(interval + (math.random() * interval * 0.2 - 0.1))
 end
 
 local function Log(msg)

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -57,7 +57,7 @@ end
 -- Speedups
 
 local CMD_PATROL        = CMD.PATROL		-- 15
-local CMD_FIGHT         = CMD.CMD_FIGHT		-- 16
+local CMD_FIGHT         = CMD.FIGHT			-- 16
 local CMD_RECLAIM       = CMD.RECLAIM		-- 90
 local CMD_REPAIR        = CMD.REPAIR		-- 40
 local CMD_STOP          = CMD.STOP
@@ -146,20 +146,6 @@ end
 
 local function Log(msg)
 	spEcho("[uapn] " .. msg)
-end
-
-local function ITableEqual(a, b)
-	if #a ~= #b then
-		return false
-	end
-
-	for i = 1, #a do
-		if a[i] ~= b[i] then
-			return false
-		end
-	end
-
-	return true
 end
 
 local function IsImmobileBuilder(ud)
@@ -291,19 +277,19 @@ end
 local remove_shift_internal = math.bit_inv(CMD_OPT_SHIFT + CMD_OPT_INTERNAL)
 local function IssuedCausesCurrent(issued, currentID, currentOpt,
 		currentParam1, currentParam2, currentParam3, currentParam4, currentParam5)
-	Log("compare")
-	Log("    issued : " .. issued[1] .. "(" ..
-		tostring(issued[2][1]) .. ", " ..
-		tostring(issued[2][2]) .. ", " ..
-		tostring(issued[2][3]) .. ", " ..
-		tostring(issued[2][4]) .. ", " ..
-		tostring(issued[2][5]) .. ") " .. issued[3] .. " (" .. issued[4] .. ")")
-	Log("    current: " .. tostring(currentID) .. "(" ..
-		tostring(currentParam1) .. ", " ..
-		tostring(currentParam2) .. ", " ..
-		tostring(currentParam3) .. ", " ..
-		tostring(currentParam4) .. ", " ..
-		tostring(currentParam5) .. ") " .. tostring(currentOpt))
+--	Log("compare")
+--	Log("    issued : " .. issued[1] .. "(" ..
+--		tostring(issued[2][1]) .. ", " ..
+--		tostring(issued[2][2]) .. ", " ..
+--		tostring(issued[2][3]) .. ", " ..
+--		tostring(issued[2][4]) .. ", " ..
+--		tostring(issued[2][5]) .. ") " .. issued[3] .. " (" .. issued[4] .. ")")
+--	Log("    current: " .. tostring(currentID) .. "(" ..
+--		tostring(currentParam1) .. ", " ..
+--		tostring(currentParam2) .. ", " ..
+--		tostring(currentParam3) .. ", " ..
+--		tostring(currentParam4) .. ", " ..
+--		tostring(currentParam5) .. ") " .. tostring(currentOpt))
 
 	if currentID == nil then
 		return false
@@ -317,7 +303,7 @@ local function IssuedCausesCurrent(issued, currentID, currentOpt,
 			issued[2][4] == currentParam4 and
 			issued[2][5] == currentParam5 and
 			issued[3] == currentOpt then
-		Log("    -> equal")
+		--Log("    -> equal")
 		return true
 	end
 
@@ -332,7 +318,7 @@ local function IssuedCausesCurrent(issued, currentID, currentOpt,
 			issued[2][3] == currentParam4 and
 			issued[2][4] == currentParam5 and
 			issued[3] == math.bit_and(currentOpt, remove_shift_internal) then
-		Log("    -> repair/reclaim")
+		--Log("    -> repair/reclaim")
 		return true
 	end
 
@@ -343,19 +329,19 @@ local function IssuedCausesCurrent(issued, currentID, currentOpt,
 		if (currentID == CMD_REPAIR or currentID == CMD_RECLAIM) and
 				currentOpt == CMD_OPT_INTERNAL and
 				currentParam5 ~= nil then
-			Log("    -> patrol, repair")
+			--Log("    -> patrol, repair")
 			return true
 		elseif currentID == CMD_PATROL then
-			Log("    -> patrol")
+			--Log("    -> patrol")
 			return true
 		elseif currentID == CMD_FIGHT and
 				currentOpt == CMD_OPT_INTERNAL then
-			Log("    -> patrol, fight")
+			--Log("    -> patrol, fight")
 			return true
 		end
 	end
 
-	Log("    -> false")
+	--Log("    -> false")
 	return false
 end
 
@@ -376,12 +362,12 @@ local function SetupUnit(unitID)
 	local currentID, currentOpt, _, currentParam1,
 			currentParam2, currentParam3, currentParam4, currentParam5 =
 			spGetUnitCurrentCommand(unitID)
-	Log(unitID .. "; currently executing " .. tostring(currentID) .. "(" ..
-		tostring(currentParam1) .. ", " ..
-		tostring(currentParam2) .. ", " ..
-		tostring(currentParam3) .. ", " ..
-		tostring(currentParam4) .. ", " ..
-		tostring(currentParam5) .. ") " .. tostring(currentOpt))
+--	Log(unitID .. "; currently executing " .. tostring(currentID) .. "(" ..
+--		tostring(currentParam1) .. ", " ..
+--		tostring(currentParam2) .. ", " ..
+--		tostring(currentParam3) .. ", " ..
+--		tostring(currentParam4) .. ", " ..
+--		tostring(currentParam5) .. ") " .. tostring(currentOpt))
 
 	if currentID then
 		if IssuedCausesCurrent(cmds[1], currentID, currentOpt,
@@ -389,7 +375,7 @@ local function SetupUnit(unitID)
 				currentParam4, currentParam5) then
 			-- The unit is doing something that could be caused by the top command
 			-- we were going to issue. That's good enough.
-			Log("Unit is doing good work. Don't touch it.")
+			--Log("Unit is doing good work. Don't touch it.")
 			return
 		end
 
@@ -408,12 +394,12 @@ local function SetupUnit(unitID)
 		if not isIssued then
 			-- Unit is doing something we never asked for. Must have been commanded
 			-- by a user.
-			Log(unitID .. " was commanded " .. tostring(currentID) .. "(" ..
-				tostring(currentParam1) .. ", " ..
-				tostring(currentParam2) .. ", " ..
-				tostring(currentParam3) .. ", " ..
-				tostring(currentParam4) .. ", " ..
-				tostring(currentParam5) .. ") " .. tostring(currentOpt))
+--			Log(unitID .. " was commanded " .. tostring(currentID) .. "(" ..
+--				tostring(currentParam1) .. ", " ..
+--				tostring(currentParam2) .. ", " ..
+--				tostring(currentParam3) .. ", " ..
+--				tostring(currentParam4) .. ", " ..
+--				tostring(currentParam5) .. ") " .. tostring(currentOpt))
 			Log("Ignore unit " .. unitID .. " until it becomes idle.")
 			trackedUnits[unitID] = nil
 			return
@@ -536,28 +522,6 @@ function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOp
 		return
 	end
 
-	-- This is a command issued to a caretaker that we track. Check if it's a
-	-- command that we issued, or one issued by the user.
-
-	--Log("UnitCommand(" .. unitID .. ", " .. unitDefID .. ", " .. unitTeam .. ", " .. cmdID .. ")")
-	--TableEcho(cmdParams, "  params: ")
-	--TableEcho(cmdOptions, "  options: ")
-	--Log("options: " .. OptionValue(cmdOptions))
-
---	if trackedUnits[unitID] and trackedUnits[unitID].commands then
---		for _, command in ipairs(trackedUnits[unitID].commands) do
---			--Log("Compare against")
---			--TableEcho(command)
---			if command[1] == cmdID and ITableEqual(command[2], cmdParams) and
---					command[3] == OptionValue(cmdOptions) then
---				--Log("We issued this command. Ignore it.")
---				return
---			end
---		end
---	end
-
-	--Log("Found a user issued command!")
-
 	if stopHalts then
 		if cmdID == CMD_STOP then
 			if stoppedUnit[unitID] == nil then
@@ -571,11 +535,6 @@ function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOp
 			stoppedUnit[unitID] = nil
 		end
 	end
-
---	if stoppedUnit[unitID] ~= nil then
---		Log("Ignore unit " .. unitID .. " until it becomes idle.")
---		trackedUnits[unitID] = nil
---	end
 end
 
 function widget:UnitGiven(unitID, unitDefID, unitTeam)

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -219,26 +219,26 @@ local function DecideCommands(x, y, z, buildDistance)
 	local commands = {}
 
 	if get_metal and use_metal and use_energy then
-		table.insert(commands, patrol)
+		commands[#commands + 1] = patrol
 	else
 		if use_metal and use_energy then
-			table.insert(commands, build_assist)
+			commands[#commands + 1] = build_assist
 		end
 		if use_energy then
-			table.insert(commands, repair_units)
+			commands[#commands + 1] = repair_units
 		end
 		if get_metal and get_energy then
 			if metal > energy then
-				table.insert(commands, reclaim_energy)
-				table.insert(commands, reclaim_metal)
+				commands[#commands + 1] = reclaim_energy
+				commands[#commands + 1] = reclaim_metal
 			else
-				table.insert(commands, reclaim_metal)
-				table.insert(commands, reclaim_energy)
+				commands[#commands + 1] = reclaim_metal
+				commands[#commands + 1] = reclaim_energy
 			end
 		elseif get_metal then
-			table.insert(commands, reclaim_metal)
+			commands[#commands + 1] = reclaim_metal
 		elseif get_energy then
-			table.insert(commands, reclaim_energy)
+			commands[#commands + 1] = reclaim_energy
 		end
 	end
 

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -246,8 +246,7 @@ local function MakeCommands(decidedCommands, unitID)
 
 		trackedUnits[unitID].commandTables = {}
 
-		local unitDefID = spGetUnitDefID(unitID)
-		local buildDistance = UnitDefs[unitDefID].buildDistance
+		local buildDistance = trackedUnits[unitID].buildDistance
 
 		-- Patrolling doesn't do anything if you target the current location
 		-- of the unit. Point patrol towards map center.
@@ -347,12 +346,15 @@ local function IssuedCausesCurrent(issued, currentID, currentOpt,
 end
 
 local function caretaker_new(unitID)
+	local unitDefID = spGetUnitDefID(unitID)
+
 	return {
 		unitID=unitID,
 		idleWait=1,
 		checkFrame=currentFrame + checkInterval,
 		resetIdle=0,
-		idleAt=0
+		idleAt=0,
+		buildDistance=UnitDefs[unitDefID].buildDistance
 	}
 end
 

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -177,7 +177,7 @@ local function DecideCommands()
 		-- reclaiming when your storage is full.
 		get_metal = futureMetal < metalStorage and
 				metal < metalStorage * 0.75
-		use_metal = futureMetal > 0 and metal > metalStorage * 0.1
+		use_metal = futureMetal > 0 and metal > 0
 	end
 
 	if energyStorage < 1 then
@@ -187,7 +187,7 @@ local function DecideCommands()
 		local futureEnergy = energy + checkInterval * (energyIncome - energyPull) / FPS
 		get_energy = futureEnergy < energyStorage and
 				energy < energyStorage * 0.9
-		use_energy = futureEnergy > 0 and energy > energyStorage * 0.1
+		use_energy = futureEnergy > 0 and energy > 0
 	end
 
 	--Log("get_metal=" .. tostring(get_metal) .. ", " ..

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -89,7 +89,7 @@ local mapCenterZ = Game.mapSizeZ / 2
 --------------------------------------------------------------------------------
 -- Constants
 
-local FPS = 30
+local FPS = Game.gameSpeed
 
 local PATROL = 1
 local RECLAIM_METAL = 2

--- a/LuaUI/Widgets/unit_auto_patrol_nanos.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos.lua
@@ -274,8 +274,8 @@ local function SetupUnit(unitID)
 
 	queue:push({trackedUnits[unitID].checkFrame, unitID})
 
-	TableEcho(cmds, "want to issue cmds")
-	TableEcho(spGetCommandQueue(unitID, -1), "current command queue")
+	--TableEcho(cmds, "want to issue cmds")
+	--TableEcho(spGetCommandQueue(unitID, -1), "current command queue")
 
 	if trackedUnits[unitID].commands and #cmds == #trackedUnits[unitID].commands then
 		--Log("List lengths equal")
@@ -298,25 +298,21 @@ local function SetupUnit(unitID)
 			-- If the first command was a patrol, then it must still be
 			-- running, since patrol never terminates.
 			if cmds[1][1] == CMD_PATROL then
-				Log("Don't issue patrol again.")
+				--Log("Don't issue patrol again.")
 				return
 			end
 
 			-- Area repair commands end up changed into some internal format
 			-- when we issue them. Rather than relying on this internal format,
-			-- just compare command IDs and call it good enough.
+			-- just compare command IDs and call it good enough. This ignores
+			-- the difference between reclaim metal/energy and build
+			-- assist/repair units.
 
-			-- We expect at most one internal command to be issued.
 			local currentCmd, currentOpt = spGetUnitCurrentCommand(unitID)
 			--Log("currentCmd: " .. tostring(currentCmd))
-			
-			-- If CMD_OPT_ALT is set, it wasn't done by us. On repair unit
-			-- commands this has the effect of making them take forever, which
-			-- might end up with the caretaker stuck doing nothing and us not
-			-- reissuing because we think something is happening.
-			if currentCmd == cmds[1][1] and
-					math.bit_and(currentOpt, CMD_OPT_ALT) == 0 then
-				Log("Don't issue the same set of commands again.")
+
+			if currentCmd == cmds[1][1] then
+				--Log("Don't issue the same set of commands again.")
 				return
 			end
 		end
@@ -327,8 +323,7 @@ local function SetupUnit(unitID)
 			spGiveOrderToUnit(unitID, cmd[1], cmd[2], cmd[3])
 			Log("give order " .. cmd[4] .. " to " .. unitID)
 		else
-			cmd[3] = cmd[3] + CMD_OPT_SHIFT
-			spGiveOrderToUnit(unitID, cmd[1], cmd[2], cmd[3])
+			spGiveOrderToUnit(unitID, cmd[1], cmd[2], cmd[3] + CMD_OPT_SHIFT)
 			Log("queue order " .. cmd[4] .. " to " .. unitID)
 		end
 	end


### PR DESCRIPTION
  1. Idle caretakers will be set to area repair if metal is high, area reclaim
      when metal is low, and patrol otherwise. (Unless patrol_idle_nanos option is
      false.)
   2. For each caretaker under this widget's control, re-evaluate the behavior based
		on the economy every 20 seconds. (Controlled by checkInterval.)
   3. For each caretaker, never issue a command more than once every 5 seconds.
      (Controlled by settleInterval.)
   4. When a user issues a stop command, this behavior is inhibited, until a
      different command issued by the user completes. (Unless stop_disables option
      is false.)
   5. When a user issues some other kind of command, the widget ignores the unit
      until it becomes idle again.

 Limitations:
   1. Area reclaim does not reclaim energy sources. We'd have to call
      GetFeaturesInRectangle() to improve this.
   2. Area repair either assists in build (using both metal and energy) or
      repairs damage (using only energy). Since assisting a factory is the most
      common use for caretakers, we tell caretakers to reclaim if metal is low.
      We'd have to call GetUnitsInCylinder() to do better.
   3. When the widget chooses repair only, there's a 0.5 second delay between
      a unit becoming idle and being told to repair. This is to give the factory
      that's being assisted time to start the next unit. It is not perfect, and the
      factory will be assisted less than if a patrol was issued. This could be
      improved by reducing the delay, and implementing a fancier incremental
      back-off than the simple 0.5s - 5s that is currently implemented.

See discussion at https://zero-k.info/Forum/Thread/32014?page=1