### PR TITLE
Fix noncombat morph uncloaking during morph

### DIFF
--- a/LuaRules/Gadgets/unit_morph.lua
+++ b/LuaRules/Gadgets/unit_morph.lua
@@ -598,6 +598,10 @@ local function UpdateMorph(unitID, morphData)
 		FinishMorph(unitID, morphData)
 		return false -- remove from the list, all done
 	end
+	if not morphData.combatMorph then
+		local unitDefID = Spring.GetUnitDefID(unitID)
+		GG.PokeDecloakUnit(unitID, unitDefID)
+	end
 	return true
 end
 


### PR DESCRIPTION
Cornea would uncloak during morph briefly only to recloak later on. This should fix it.