### PR TITLE
Fix Pheonix CEG on sea impact

### DIFF
--- a/effects/napalm.lua
+++ b/effects/napalm.lua
@@ -32,6 +32,7 @@ local cegs = {
       count              = 6,
       ground             = true,
       water              = true,
+      underwater         = true,
       properties = {
         delay              = 0,
         explosiongenerator = [[custom:NAPALMFIREBALL_75]],


### PR DESCRIPTION
Fixes https://github.com/ZeroK-RTS/Zero-K/issues/3832

maybe this has terrible side effects, I don't know much about CEGs

before:  The shock waves were still visible above water, but not the fire

![image](https://user-images.githubusercontent.com/1731922/98993827-18167300-2583-11eb-8ae9-e182ade3b452.png)


after: 

![image](https://user-images.githubusercontent.com/1731922/98993837-1b116380-2583-11eb-8524-6d82d997a2d4.png)
