### PR TITLE
More [Show Unit Stats] buttons (closes #4221)

### DIFF
--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -1014,7 +1014,7 @@ local function ClickFunc(mouse, cmdID, isStructure, factoryUnitID, fakeFactory, 
 				end
 			end
 		else
-		QueueClickFunc(mouse, right, alt, ctrl, meta, shift, cmdID, factoryUnitID, queueBlock)
+			QueueClickFunc(mouse, right, alt, ctrl, meta, shift, cmdID, factoryUnitID, queueBlock)
 		end
 		return true
 	end

--- a/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
+++ b/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
@@ -49,8 +49,8 @@ local selectionTooltip = "\n" .. green .. WG.Translate("interface", "lmb") .. ":
 	green .. WG.Translate("interface", "rmb") .. ": " .. WG.Translate("interface", "deselect") .. "\n" ..
 	green .. WG.Translate("interface", "shift") .. "+" .. WG.Translate("interface", "lmb") .. ": " .. WG.Translate("interface", "select_type") .. "\n" ..
 	green .. WG.Translate("interface", "shift") .. "+" .. WG.Translate("interface", "rmb") .. ": " .. WG.Translate("interface", "deselect_type") .. "\n" ..
-	green .. WG.Translate("interface", "mmb") .. ": " .. WG.Translate("interface", "go_to") ..
-	"\n" .. green .. WG.Translate("interface", "space_click_show_stats")
+	green .. WG.Translate("interface", "mmb") .. ": " .. WG.Translate("interface", "go_to") .. "\n" .. 
+	green .. WG.Translate("interface", "space_click_show_stats")
 
 local singleSelectionTooltip = "\n" .. green .. WG.Translate("interface", "lmb") .. ": " .. "Center view" .. "\n" .. green .. WG.Translate("interface", "space_click_show_stats")
 

--- a/LuaUI/Widgets/gui_contextmenu.lua
+++ b/LuaUI/Widgets/gui_contextmenu.lua
@@ -2030,6 +2030,7 @@ function widget:Initialize()
 
 	widget:ViewResize(Spring.GetViewGeometry())
 	
+	WG.MakeStatsWindow = MakeStatsWindow
 end
 
 function widget:Shutdown()

--- a/LuaUI/Widgets/mission_galaxy_battle_handler.lua
+++ b/LuaUI/Widgets/mission_galaxy_battle_handler.lua
@@ -28,7 +28,11 @@ local BUTTON_SIZE = 25
 local BONUS_TOGGLE_IMAGE = 'LuaUI/images/plus_green.png'
 local BRIEFING_IMAGE = LUAUI_DIRNAME .. "images/advplayerslist/random.png"
 
+local spGetDescription = Spring.Utilities.GetDescription
+local spGetHumanName = Spring.Utilities.GetHumanName
+local spGetModKeyState = Spring.GetModKeyState
 local spGetMouseState = Spring.GetMouseState
+local spGetUnitDefID = Spring.GetUnitDefID
 
 local max, min = math.max, math.min
 
@@ -186,6 +190,23 @@ local function InitializeNewtonFirezones()
 	end
 end
 
+local function GetUnitDefFromIconFilename(filename)
+-- 	Spring.Echo('Searching for unit in filename: ' .. filename)
+	local name = string.match(filename, "unitpics/(%w+).png")
+	if name then
+-- 		Spring.Echo('Found unitname: ' .. name)
+		local udef = UnitDefNames[name]
+		if udef then
+			return udef
+		end
+	end
+	return
+end
+
+local function GetUnitTooltip(udef)
+	return spGetHumanName(udef) .. " - " .. spGetDescription(udef) .. "\n\255\1\255\1" .. WG.Translate("interface", "space_click_show_stats")
+end
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Briefing Window
@@ -209,7 +230,7 @@ local function GetNewTextHandler(parentControl, paragraphSpacing, imageSize)
 		if imageFile then
 			textPos = imageSize + 10
 			
-			Chili.Image:New{
+			local image = Chili.Image:New{
 				x = 4,
 				y = offset,
 				width = imageSize,
@@ -218,6 +239,21 @@ local function GetNewTextHandler(parentControl, paragraphSpacing, imageSize)
 				file = imageFile,
 				parent = holder
 			}
+			local udef = GetUnitDefFromIconFilename(imageFile)
+			if udef then
+				image.tooltip = GetUnitTooltip(udef)
+				image.OnClick = {
+						function(_, _, _, button)
+							local _, _, meta, _ = spGetModKeyState()
+							if meta and (button == 1) and WG.MakeStatsWindow then  -- Space+Click - show unit stats
+								local x, y = spGetMouseState()
+								WG.MakeStatsWindow(udef, x, y)
+								return true
+							end
+							return false
+						end
+				}
+			end
 		end
 		
 		local label = Chili.TextBox:New{
@@ -437,6 +473,21 @@ local function GetObjectivesBlock(holderWindow, position, items, gameRulesParam,
 			file = OBJECTIVE_ICON,
 			parent = holderControl,
 		}
+		local udef = GetUnitDefFromIconFilename(OBJECTIVE_ICON)
+		if udef then
+			image.tooltip = GetUnitTooltip(udef)
+			image.OnClick = {
+					function(_, _, _, button)
+						local _, _, meta, _ = spGetModKeyState()
+						if meta and (button == 1) and WG.MakeStatsWindow then  -- Space+Click - show unit stats
+							local x, y = spGetMouseState()
+							WG.MakeStatsWindow(udef, x, y)
+							return true
+						end
+						return false
+					end
+			}
+		end
 		objectives[i] = {
 			offset = offset,
 			label = label,


### PR DESCRIPTION
Adds the ability to space+click on:
- [x] Selection panel - icon (single unit selected)
- [x] Selection panel - icon (multiple units selected)
- [x] Factory queue unit icons
- [x] Mission briefing tip unit icons

Additionally adds the Helptext to the new tooltip on the single unit selected icon, as it looked a bit lonely otherwise and I've had friends complain about that useful info being hidden behind a popup.
![image](https://user-images.githubusercontent.com/5397662/101454129-62232680-3980-11eb-8a39-c531ed110d4b.png)

Edit: apparently titles don't link: closes #4221
