### PR TITLE
Fixes a consistent bug with state recall failing first try

### DIFF
--- a/LuaUI/Widgets/COFCtools/ExportUtilities.lua
+++ b/LuaUI/Widgets/COFCtools/ExportUtilities.lua
@@ -1,4 +1,12 @@
 
+function SetCameraState(cs, smoothness)
+	if WG.COFC_SetCameraState then
+		WG.COFC_SetCameraState(cs, smoothness or 0)
+	else
+		Spring.SetCameraState(cs, smoothness or 0)
+	end
+end
+
 function SetCameraTarget(x, y, z, smoothness, useSmoothMeshSetting, dist)
 	if WG.COFC_SetCameraTarget then
 		WG.COFC_SetCameraTarget(x, y, z, smoothness, useSmoothMeshSetting, dist)

--- a/LuaUI/Widgets/camera_cofc.lua
+++ b/LuaUI/Widgets/camera_cofc.lua
@@ -20,7 +20,8 @@ include("Widgets/COFCtools/TraceScreenRay.lua")
 
 local _, ToKeysyms = include("Configs/integral_menu_special_keys.lua")
 
---WG Exports: 	WG.COFC_SetCameraTarget: {number gx, number gy, number gz(, number smoothness(,boolean useSmoothMeshSetting(, number dist)))} -> {}, Set Camera target, ensures COFC options are respected
+--WG Exports: 	WG.COFC_SetCameraState: {table cs(, number smoothness)} -> {}, Set Camera State, ensures all COFC camera state changes go through the same logic chain
+--							WG.COFC_SetCameraTarget: {number gx, number gy, number gz(, number smoothness(,boolean useSmoothMeshSetting(, number dist)))} -> {}, Set Camera target, ensures COFC options are respected
 --						 	WG.COFC_SetCameraTargetBox: {number minX, number minZ, number maxX, number maxZ, number minDist(, number maxY(, number smoothness(,boolean useSmoothMeshSetting)))} -> {}, Set Camera to contain input box. maxY should be the highest point in the box, defaults to ground height of box center
 --							WG.COFC_SkyBufferProportion: {} -> number [0..1], proportion of maximum zoom height the camera is currently at. 0 is the ground, 1 is maximum zoom height.
 
@@ -2730,6 +2731,7 @@ function widget:Initialize()
 	end
 
 	WG.COFC_Enabled = true
+	WG.COFC_SetCameraState = OverrideSetCameraStateInterpolate
 	WG.COFC_SetCameraTarget = SetCameraTarget
 	WG.COFC_SetCameraTargetBox = SetCameraTargetBox
 

--- a/LuaUI/Widgets/camera_save_position.lua
+++ b/LuaUI/Widgets/camera_save_position.lua
@@ -132,7 +132,7 @@ for i = 1, 10 do
 		OnChange = function()
 			if options.savezoom.value then
 				if savedCameraStates[i] then
-					Spring.SetCameraState(savedCameraStates[i], recallTime)
+					SetCameraState(savedCameraStates[i], recallTime)
 				end
 			else
 				local data = savedCameraPositions[i]


### PR DESCRIPTION
Now only has an inconsistent bug when doing state recall while scrolling the camera, or right after finishing scrolling the camera while an early part of the smooth interpolation is happening. Works fine when state recall happens at the tail end of the smooth interpolation