### PR TITLE
Dis-Include drones from endgame graphs

### DIFF
--- a/LuaRules/Gadgets/endgame_graphs.lua
+++ b/LuaRules/Gadgets/endgame_graphs.lua
@@ -61,7 +61,7 @@ end
 
 local dontCountUnits = {}
 for unitDefID = 1, #UnitDefs do
-	if UnitDefs[unitDefID].customParams.dontcount then
+	if UnitDefs[unitDefID].customParams.dontcount or UnitDefs[unitDefID].customParams.is_drone then
 		dontCountUnits[unitDefID] = true
 	end
 end


### PR DESCRIPTION
Currently drones count towards total value, army value, value killed, ect.

damage dealt and received by drones still count