### PR TITLE
allow custom widget options icon

### DIFF
--- a/LuaUI/Widgets/gui_epicmenu.lua
+++ b/LuaUI/Widgets/gui_epicmenu.lua
@@ -1285,7 +1285,11 @@ local function IntegrateWidget(w, addoptions, index)
 	
 	local wname = w.whInfo.name
 	local defaultpath =  w.options_path or ('Settings/Misc/' .. wname)
-	
+
+	-- add the widget's icon to the subMenuIcons table if there isn't one in that spot already
+	if w.whInfo.icon and not confdata.subMenuIcons[defaultpath] then
+		confdata.subMenuIcons[defaultpath] = w.whInfo.icon
+	end
 	
 	--[[
 	--If a widget disables itself in widget:Initialize it will run the removewidget before the insertwidget is complete. this fix doesn't work


### PR DESCRIPTION
Allow widgets to declare their own options icon.

![image](https://user-images.githubusercontent.com/5386926/109265848-3112ff00-77d5-11eb-871f-139579cd1a68.png)
