### PR TITLE
Remove some broken explosions from hoversonic (for modders)

### DIFF
--- a/units/hoversonic.lua
+++ b/units/hoversonic.lua
@@ -72,8 +72,8 @@ return { hoversonic = {
             slot = [[5]],
             muzzleEffectFire = [[custom:HEAVY_CANNON_MUZZLE]],
             miscEffectFire   = [[custom:RIOT_SHELL_L]],
-            lups_explodelife = 100,
-            lups_explodespeed = 1,
+            lups_explodelife = 1.5,
+            lups_explodespeed = 0.44,
         },
 
         damage                  = {


### PR DESCRIPTION
It probably isn't perfectly precise but it will at least prevent map engulfing shockwaves for !cheats and modders.