### PR TITLE
Siren no longer stays at missile range during attack move

### DIFF
--- a/units/shipassault.lua
+++ b/units/shipassault.lua
@@ -137,7 +137,9 @@ return { shipassault = {
       collideFriendly         = false,
       craterBoost             = 1,
       craterMult              = 2,
-
+      customParams            = {
+        combatRange = 265,
+      },
       damage                  = {
         default = 400.01,
       },


### PR DESCRIPTION
https://youtu.be/Jlp6oqee0ps

It will however stay at max range if given an explicit attack command. Whether or not this is useful is up to you to decide.