### PR TITLE
Fix Clear Factory Queue from not stopping production on wait

### DIFF
--- a/LuaRules/Gadgets/cmd_factory_stop_production.lua
+++ b/LuaRules/Gadgets/cmd_factory_stop_production.lua
@@ -29,6 +29,8 @@ local spInsertUnitCmdDesc  = Spring.InsertUnitCmdDesc
 
 local CMD_OPT_CTRL = CMD.OPT_CTRL
 local CMD_REMOVE = CMD.REMOVE
+local CMD_WAIT = CMD.WAIT
+local EMPTY = {}
 
 include("LuaRules/Configs/customcmds.h.lua")
 
@@ -76,6 +78,9 @@ function gadget:AllowCommand(unitID, unitDefID, teamID, cmdID, cmdParams, cmdOpt
 	for i = 1, #commands do
 		spGiveOrderToUnit(unitID, CMD_REMOVE, commands[i].tag, CMD_OPT_CTRL)
 	end
+	spGiveOrderToUnit(unitID, CMD_WAIT, EMPTY, 0) -- Removes wait if there is a wait but doesn't readd it.
+	spGiveOrderToUnit(unitID, CMD_WAIT, EMPTY, 0) -- If a factory is waiting, it will not clear the current build command, even if the cmd is removed.
+	-- See: http://zero-k.info/Forum/Post/237176#237176 for details.
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Though now wait isn't re-added (which is acceptable losses, tbh)

See: http://zero-k.info/Battles/Detail/1072832