### PR TITLE
Misc unit_auto_patrol_nanos_v2 improvements.

### DIFF
--- a/LuaUI/Widgets/unit_auto_patrol_nanos_v2.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos_v2.lua
@@ -297,7 +297,7 @@ local function IssuedCausesCurrent(issued, currentID, currentOpt,
 			issued[2][3] == currentParam3 and
 			issued[2][4] == currentParam4 and
 			issued[2][5] == currentParam5 and
-			issued[3] == currentOpt then
+			issued[3] == math.bit_and(currentOpt, remove_shift_internal) then
 		Log("    -> equal")
 		return true
 	end

--- a/LuaUI/Widgets/unit_auto_patrol_nanos_v2.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos_v2.lua
@@ -74,7 +74,6 @@ local spValidUnitID     = Spring.ValidUnitID
 local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 local spGetUnitResources = Spring.GetUnitResources
 local spGetUnitHealth = Spring.GetUnitHealth
-local spIsReplay		= Spring.IsReplay
 
 local TableEcho = Spring.Utilities.TableEcho
 
@@ -526,14 +525,18 @@ options = {
 -- Callins
 
 function widget:Initialize()
+	if (Spring.GetSpectatingState() or Spring.IsReplay()) and (not Spring.IsCheatingEnabled()) then
+		Spring.Echo("uapn2 disabled for spectators")
+		widgetHandler:RemoveWidget()
+	end
+
 	SetupAll()
 end
 
 function widget:UnitCreated(unitID, unitDefID, unitTeam)
 	if not enableIdleNanos or unitTeam ~= spGetMyTeamID()
 			or not IsImmobileBuilder(UnitDefs[unitDefID])
-			or spGetGameRulesParam("loadPurge") == 1
-			or spIsReplay() then
+			or spGetGameRulesParam("loadPurge") == 1 then
 		return
 	end
 
@@ -612,8 +615,7 @@ function widget:UnitFinished(unitID, unitDefID, unitTeam)
 	if not enableIdleNanos or stoppedUnit[unitID]
 			or unitTeam ~= spGetMyTeamID()
 			or not IsImmobileBuilder(UnitDefs[unitDefID])
-			or spGetGameRulesParam("loadPurge") == 1
-			or spIsReplay() then
+			or spGetGameRulesParam("loadPurge") == 1 then
 		return
 	end
 
@@ -629,8 +631,7 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 	if not enableIdleNanos or stoppedUnit[unitID]
 			or unitTeam ~= spGetMyTeamID()
 			or not IsImmobileBuilder(UnitDefs[unitDefID])
-			or spGetGameRulesParam("loadPurge") == 1
-			or spIsReplay() then
+			or spGetGameRulesParam("loadPurge") == 1 then
 		return
 	end
 

--- a/LuaUI/Widgets/unit_auto_patrol_nanos_v2.lua
+++ b/LuaUI/Widgets/unit_auto_patrol_nanos_v2.lua
@@ -74,6 +74,7 @@ local spValidUnitID     = Spring.ValidUnitID
 local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
 local spGetUnitResources = Spring.GetUnitResources
 local spGetUnitHealth = Spring.GetUnitHealth
+local spIsReplay		= Spring.IsReplay
 
 local TableEcho = Spring.Utilities.TableEcho
 
@@ -93,8 +94,8 @@ local debug = false
 local FPS = Game.gameSpeed
 
 local PATROL = 1
-local RECLAIM_METAL = 2
-local RECLAIM_ENERGY = 3
+local RECLAIM_ALL = 2
+local RECLAIM_METAL = 3
 local REPAIR_UNITS = 4
 local BUILD_ASSIST = 5
 
@@ -124,6 +125,16 @@ local currentFrame = 0
 --------------------------------------------------------------------------------
 -- Functions
 
+local function mapEcho(unitID, text)
+	local x, y, z = spGetUnitPosition(unitID)
+	Spring.MarkerAddPoint(x, y, z, text)
+end
+
+local function mapClear(unitID)
+	local x, y, z = spGetUnitPosition(unitID)
+	Spring.MarkerErasePosition(x, y, z)
+end
+
 -- Slightly randomize intervals, to prevent all caretakers from getting synced
 -- up and all of them deciding to reclaim now, while really what needs to happen
 -- is just some of them reclaiming.
@@ -147,6 +158,11 @@ local function DecideCommands(unitID)
 	local trackedUnit = trackedUnits[unitID]
 
 	local metalMake, metalUse, energyMake, energyUse = spGetUnitResources(unitID)
+
+	-- One time, metalUse came back 0 and the script crashed.
+	if metalMake == nil or metalUse == nil or energyMake == nil or energyUse == nil then
+		return {trackedUnit.commandTables[REPAIR_UNITS]}
+	end
 
 	local metal, metalStorage, metalPull, metalIncome, metalExpense,
 			metalShare, metalSent, metalReceived, metalExcess =
@@ -205,9 +221,12 @@ local function DecideCommands(unitID)
 		use_energy = energyExpense <= energyIncome
 	else
 		local future = energy + checkInterval * (energyIncome - energyExpense) / FPS
-		-- Only get energy if we have storage for it.
+		-- Because there is no reclaim energy command, (the command will also
+		-- reclaim metal), only get energy if we won't exceed half of our storage.
+		-- That way we'll avoid energy stalls, but also avoid reclaiming metal if
+		-- we don't really need the energy right now.
 		local production = checkInterval * trackedUnit.reclaimSpeed / FPS
-		get_energy = future + production <= energyStorage
+		get_energy = future + production <= energyStorage / 2
 		-- Only use energy if we won't waste any build power by doing so. It
 		-- would go to overdrive, but it's better to keep reserves on the
 		-- ground.
@@ -229,17 +248,12 @@ local function DecideCommands(unitID)
 		commands[#commands + 1] = commandTables[REPAIR_UNITS]
 	end
 	if get_metal and get_energy then
-		if metal > energy then
-			commands[#commands + 1] = commandTables[RECLAIM_ENERGY]
-			commands[#commands + 1] = commandTables[RECLAIM_METAL]
-		else
-			commands[#commands + 1] = commandTables[RECLAIM_METAL]
-			commands[#commands + 1] = commandTables[RECLAIM_ENERGY]
-		end
+		commands[#commands + 1] = commandTables[RECLAIM_ALL]
 	elseif get_metal then
 		commands[#commands + 1] = commandTables[RECLAIM_METAL]
 	elseif get_energy then
-		commands[#commands + 1] = commandTables[RECLAIM_ENERGY]
+		-- There is no RECLAIM_ENERGY, unfortunately.
+		commands[#commands + 1] = commandTables[RECLAIM_ALL]
 	end
 
 	-- Queue up commands that would waste build power at the end, because build
@@ -262,15 +276,16 @@ end
 -- This code relies on implementation details of the spring engine, but I don't
 -- see any way around that.
 local remove_shift_internal = math.bit_inv(CMD_OPT_SHIFT + CMD_OPT_INTERNAL)
+local remove_control = math.bit_inv(CMD_OPT_CTRL)
 local function IssuedCausesCurrent(issued, currentID, currentOpt,
 		currentParam1, currentParam2, currentParam3, currentParam4, currentParam5)
-	--Log("compare")
-	--Log(" issued : ", issued[1], "(", issued[2][1], ", ", issued[2][2], ", ",
-	--	issued[2][3], ", ", issued[2][4], ", ", issued[2][5], ") ",
-	--	issued[3], " (", issued[4], ")")
-	--Log(" current: ", currentID, "(", currentParam1, ", ", currentParam2,
-	--	", ", currentParam3, ", ", currentParam4, ", ", currentParam5, ") ",
-	--	currentOpt)
+	Log("compare")
+	Log(" issued : ", issued[1], "(", issued[2][1], ", ", issued[2][2], ", ",
+		issued[2][3], ", ", issued[2][4], ", ", issued[2][5], ") ",
+		issued[3], " (", issued[4], ")")
+	Log(" current: ", currentID, "(", currentParam1, ", ", currentParam2,
+		", ", currentParam3, ", ", currentParam4, ", ", currentParam5, ") ",
+		currentOpt)
 
 	if not currentID or not issued then
 		return false
@@ -284,45 +299,41 @@ local function IssuedCausesCurrent(issued, currentID, currentOpt,
 			issued[2][4] == currentParam4 and
 			issued[2][5] == currentParam5 and
 			issued[3] == currentOpt then
-		--Log("    -> equal")
+		Log("    -> equal")
 		return true
 	end
 
-	-- Area repair/reclaim command. The spring engine puts the unit being
+	-- Area repair/reclaim commands. The spring engine puts the unit being
 	-- repaired/reclaimed as the first parameter, and moves the issued
 	-- parameters down one. (See CBuilderCAI::FindReclaimTargetAndReclaim() and
 	-- CBuilderCAI::FindRepairTargetAndRepair().)
-	if currentID == issued[1] and
-			(currentID == CMD_RECLAIM or currentID == CMD_REPAIR) and
-			#issued[2] == 4 and
-			issued[2][1] == currentParam2 and
-			issued[2][2] == currentParam3 and
-			issued[2][3] == currentParam4 and
-			issued[2][4] == currentParam5 and
-			issued[3] == math.bit_and(currentOpt, remove_shift_internal) then
-		return true
-	end
+	-- We explicitly ignore the options. The logic is hard to follow, and if the
+	-- command is a result of reclaim/repair with the exact area that we issued,
+	-- then that must be issued by our widget and not a user.
 
-	if issued[1] == CMD_PATROL then
-		-- Patrol commands are issued with a location, but that locations is
-		-- changed so we can't rely on it. Maybe it's getting changed because we
-		-- issue a location out of range or something. That might be fixable.
-		if (currentID == CMD_REPAIR or currentID == CMD_RECLAIM) and
-				currentOpt == CMD_OPT_INTERNAL and
-				currentParam5 ~= nil then
-			--Log("    -> patrol, repair")
+	if issued[1] == CMD_RECLAIM then
+		if currentID == CMD_RECLAIM and
+				#issued[2] == 4 and
+				issued[2][1] == currentParam2 and
+				issued[2][2] == currentParam3 and
+				issued[2][3] == currentParam4 and
+				issued[2][4] == currentParam5 then
+			Log("    -> reclaim")
 			return true
-		elseif currentID == CMD_PATROL then
-			--Log("    -> patrol")
-			return true
-		elseif currentID == CMD_FIGHT and
-				currentOpt == CMD_OPT_INTERNAL then
-			--Log("    -> patrol, fight")
+		end
+	elseif issued[1] == CMD_REPAIR then
+		if currentID == CMD_REPAIR and
+				#issued[2] == 4 and
+				issued[2][1] == currentParam2 and
+				issued[2][2] == currentParam3 and
+				issued[2][3] == currentParam4 and
+				issued[2][4] == currentParam5 then
+			Log("    -> repair")
 			return true
 		end
 	end
 
-	--Log("    -> false")
+	Log("    -> false")
 	return false
 end
 
@@ -344,8 +355,8 @@ local function unitNew(unitID)
 	-- the range giant so that when you hold down shift you don't see circles
 	-- around every caretaker.
 	local area = {x, y, z, 50000}
+	commandTables[RECLAIM_ALL] = {CMD_RECLAIM, area, CMD_OPT_CTRL, "reclaim all"}
 	commandTables[RECLAIM_METAL] = {CMD_RECLAIM, area, 0, "reclaim metal"}
-	commandTables[RECLAIM_ENERGY] = {CMD_RECLAIM, area, CMD_OPT_CTRL, "reclaim energy"}
 	commandTables[REPAIR_UNITS] = {CMD_REPAIR, area, CMD_OPT_META, "repair units"}
 	commandTables[BUILD_ASSIST] = {CMD_REPAIR, area, 0, "build assist"}
 
@@ -426,7 +437,8 @@ local function UpdateUnit(unitID)
 					currentParam3, ", ",
 					currentParam4, ", ",
 					currentParam5, ") ", currentOpt)
-				Log(unitID, "; Ignore until it becomes idle.")
+				Log(unitID, "; Ignore until it becomes idle (commanded).")
+				mapEcho(unitID, "Ignore until idle")
 			end
 			trackedUnits[unitID] = nil
 			return
@@ -520,7 +532,8 @@ end
 function widget:UnitCreated(unitID, unitDefID, unitTeam)
 	if not enableIdleNanos or unitTeam ~= spGetMyTeamID()
 			or not IsImmobileBuilder(UnitDefs[unitDefID])
-			or spGetGameRulesParam("loadPurge") == 1 then
+			or spGetGameRulesParam("loadPurge") == 1
+			or spIsReplay() then
 		return
 	end
 
@@ -554,6 +567,15 @@ end
 -- But does not get called when patrol or area reclaim/repair commands modify
 -- the command queue.
 function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOptions)
+	if debug and
+			unitTeam == spGetMyTeamID() and
+			not spGetGameRulesParam("loadPurge") and
+			IsImmobileBuilder(UnitDefs[unitDefID]) then
+		Log("UnitCommand ", unitID, ": ", cmdID, " (", cmdParams[1], ", ",
+				cmdParams[2], ", ", cmdParams[3], ", ", cmdParams[4],
+				", ", cmdParams[5], ") ", OptionValue(cmdOptions))
+	end
+
 	if not enableIdleNanos
 			or cmdOptions.internal
 			or unitTeam ~= spGetMyTeamID()
@@ -566,11 +588,13 @@ function widget:UnitCommand(unitID, unitDefID, unitTeam, cmdID, cmdParams, cmdOp
 		if cmdID == CMD_STOP then
 			if not stoppedUnit[unitID] then
 				Log("Ignore unit ", unitID, " until it is given a command.")
+				mapEcho(unitID, "Ignore until idle (stopped).")
 			end
 			stoppedUnit[unitID] = true
 		elseif stoppedUnit[unitID] then
 			if stoppedUnit[unitID] ~= nil then
 				Log("Pay attention to unit ", unitID, " again.")
+				mapClear(unitID)
 			end
 			stoppedUnit[unitID] = nil
 		end
@@ -584,7 +608,15 @@ function widget:UnitGiven(unitID, unitDefID, unitTeam)
 	widget:UnitCreated(unitID, unitDefID, unitTeam)
 end
 
-function widget:UnitFinished(unitID)
+function widget:UnitFinished(unitID, unitDefID, unitTeam)
+	if not enableIdleNanos or stoppedUnit[unitID]
+			or unitTeam ~= spGetMyTeamID()
+			or not IsImmobileBuilder(UnitDefs[unitDefID])
+			or spGetGameRulesParam("loadPurge") == 1
+			or spIsReplay() then
+		return
+	end
+
 	if trackedUnits[unitID] then
 		if debug then
 			Log(unitID, "; finished")
@@ -597,7 +629,8 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 	if not enableIdleNanos or stoppedUnit[unitID]
 			or unitTeam ~= spGetMyTeamID()
 			or not IsImmobileBuilder(UnitDefs[unitDefID])
-			or spGetGameRulesParam("loadPurge") == 1 then
+			or spGetGameRulesParam("loadPurge") == 1
+			or spIsReplay() then
 		return
 	end
 
@@ -611,6 +644,8 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 
 	if not trackedUnits[unitID] then
 		trackedUnits[unitID] = unitNew(unitID)
+		Log("Pay attention to unit ", unitID, " again.")
+		mapClear(unitID)
 	end
 	local trackedUnit = trackedUnits[unitID]
 


### PR DESCRIPTION
* Do less work when viewing a replay.
* Add some more debug info (only when the widget is edited to set
  debug=true).
* Fix my understanding of reclaim commands. There is no "reclaim
  energy," but only "reclaim all." I think this fixes #4226.
* Tolerate spGetUnitResources() returning nil, which happened to me
  once.

I've been using this for 2 weeks with no issues.