### PR TITLE
⚖️ Flea: don't suffer from retreat disadvantage

### DIFF
--- a/units/spiderscout.lua
+++ b/units/spiderscout.lua
@@ -100,6 +100,7 @@ return { spiderscout = {
       impulseFactor           = 0.4,
       interceptedByShieldType = 1,
       laserFlareSize          = 3.22,
+      leadLimit               = 0,
       minIntensity            = 1,
       noSelfDamage            = true,
       range                   = 150,


### PR DESCRIPTION
Flea beam leads the target a bit to hit it in the middle of its beam's duration, which can lead it to fail due to being out of range when chasing fast units (such as another Flea).