### PR TITLE
Allow moderators and game hosts to bypass specmute option

### DIFF
--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -1146,11 +1146,7 @@ local function GetPlayerAbilityToSpecchat(playerID)
 	local boss = cp["room_boss"] or "0"
 	local admin = cp.admin or "0"
 	local helpful = cp.helpful or "0"
-	if boss == "1" or admin == "1" or helpful == "1" then
-		return true
-	else
-		return false
-	end
+	return boss == "1" or admin == "1" or helpful == "1"
 end
 
 


### PR DESCRIPTION
Moderators, game hosts, and players with the TBI `helpful` custom param may bypass spectator mute modoption. This is to make it convenient for enforcement/information providing.

Implement/fixes #4192.