### PR TITLE
⚙️ Mex circle matches grid radius

### DIFF
--- a/LuaUI/Widgets/cmd_mex_placement.lua
+++ b/LuaUI/Widgets/cmd_mex_placement.lua
@@ -907,10 +907,10 @@ local function calcMainMexDrawList()
 
 		glColor(0,0,0,0.7)
 		glLineWidth(width*2.4)
-		glDrawGroundCircle(x, 1, z, 40, 21)
+		glDrawGroundCircle(x, 1, z, 50, 21)
 		glColor(r,g,b,0.7)
 		glLineWidth(width*1.5)
-		glDrawGroundCircle(x, 1, z, 40, 21)
+		glDrawGroundCircle(x, 1, z, 50, 21)
 
 		glPopMatrix()
 	end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2573076/121977033-59733900-cd85-11eb-8f24-8c76f189e0f7.png)

```diff
+ helps place early solars efficiently because you know the grid without even queuing up the mex
+ looks better when they match (maybe that's just my autism speaking)
- the border may make it harder to tell where the grid ends on very THICC ubermexes
- some maps seem to have the spots tight enough for the bigger circle to look a bit more odd? probably applies both ways though
```