### PR TITLE
Scallop Role Fix

### DIFF
--- a/units/amphriot.lua
+++ b/units/amphriot.lua
@@ -1,7 +1,7 @@
 return { amphriot = {
   unitname               = [[amphriot]],
   name                   = [[Scallop]],
-  description            = [[Amphibious Riot Bot (Anti-Sub)]],
+  description            = [[Amphibious Riot Bot]],
   acceleration           = 0.54,
   activateWhenBuilt      = true,
   brakeRate              = 2.25,


### PR DESCRIPTION
Remove Anti-Sub tag from Scallop. It can have it back when it can kill a Seawolf.