### PR TITLE
Configure startboxes for various remakes

### DIFF
--- a/LuaRules/Configs/StartBoxes/Altored Divide Bar Remake 1.55.lua
+++ b/LuaRules/Configs/StartBoxes/Altored Divide Bar Remake 1.55.lua
@@ -1,0 +1,1 @@
+return VFS.Include("LuaRules/Configs/StartBoxes/Altored Divide Remake V3.lua")

--- a/LuaRules/Configs/StartBoxes/Avalanche 3.4.lua
+++ b/LuaRules/Configs/StartBoxes/Avalanche 3.4.lua
@@ -1,0 +1,1 @@
+return VFS.Include("LuaRules/Configs/StartBoxes/Avalanche-v2.lua")

--- a/LuaRules/Configs/StartBoxes/BarR 1.1.lua
+++ b/LuaRules/Configs/StartBoxes/BarR 1.1.lua
@@ -1,0 +1,1 @@
+return VFS.Include("LuaRules/Configs/StartBoxes/Barren 2.lua")

--- a/LuaRules/Configs/StartBoxes/Centerrock Remake 1.2.lua
+++ b/LuaRules/Configs/StartBoxes/Centerrock Remake 1.2.lua
@@ -1,0 +1,1 @@
+return VFS.Include("LuaRules/Configs/StartBoxes/CenterrockV12.lua")

--- a/LuaRules/Configs/StartBoxes/DWorld_V3.lua
+++ b/LuaRules/Configs/StartBoxes/DWorld_V3.lua
@@ -1,0 +1,1 @@
+return VFS.Include("LuaRules/Configs/StartBoxes/Dworld_V1.lua")

--- a/LuaRules/Configs/StartBoxes/Tangerine_Remake 1.0.lua
+++ b/LuaRules/Configs/StartBoxes/Tangerine_Remake 1.0.lua
@@ -1,0 +1,1 @@
+return VFS.Include("LuaRules/Configs/StartBoxes/Tangerine.lua")


### PR DESCRIPTION
This pull request conforms startboxes for the following map remakes:
Altored Divide Bar Remake 1.55 <- Altored Divide Remake V3
Avalanche 3.4 <- Avalanche-v2
BarR 1.1 <- Barren 2 
Centerrock Remake 1.2 <- CenterrockV12
DWorld_V3 <- Dworld_V1
Tangerine_Remake 1.0 <- Tangerine

These changes have not been tested.
