### PR TITLE
Potentially fix subtacmissile's weapon spawning into shore

### DIFF
--- a/scripts/subtacmissile.lua
+++ b/scripts/subtacmissile.lua
@@ -13,7 +13,7 @@ function script.QueryWeapon()
 end
 
 function script.AimFromWeapon()
-	return aimpoint
+	return missile
 end
 
 local respawning_rocket = false
@@ -52,12 +52,17 @@ function script.AimWeapon(num, heading, pitch)
 	return true
 end
 
+local function RestoreMissile()
+	Sleep(100)
+	Turn (missile, x_axis, 0)
+end
+
 function script.FireWeapon()
 	respawning_rocket = true
 	Signal (SIG_AIM)
 
 	Hide (missile)
-	Turn (missile, x_axis, 0)
+	StartThread(RestoreMissile)
 
 	local slowMult = (Spring.GetUnitRulesParam(unitID,"baseSpeedMult") or 1)
 	Turn (door1, z_axis, 0, math.rad(80)*slowMult)


### PR DESCRIPTION
The turn occurred too soon and the missile would spawn at its zero position instead of the upward position. This caused it to spawn inside terrain potentially when the sub was clipping into the surrounding shoreline.