### PR TITLE
Improve logic for setting default myGravity on ballistic weapons.

### DIFF
--- a/gamedata/weapondefs_post.lua
+++ b/gamedata/weapondefs_post.lua
@@ -219,12 +219,18 @@ end
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 --
--- Set myGravity for Cannons because maps cannot be trusted. Standard is 120,
+-- Set myGravity for ballistic weapons because maps cannot be trusted. Standard is 120,
 -- gravity of 150 can cause high things (such as HLT) to be unhittable.
 
- for _, weaponDef in pairs(WeaponDefs) do
-	if weaponDef.weapontype == "Cannon" and not weaponDef.mygravity then
-		weaponDef.mygravity = 2/15 -- 120/(GAME_SPEED^2)
+local defaultMyGravity = 120 / (Game.gameSpeed^2)
+
+for _, weaponDef in pairs(WeaponDefs) do
+	local supportsMyGravity =
+		(weaponDef.weapontype == "Cannon") or
+		(weaponDef.weapontype == "AircraftBomb") -- other ballistic weapontypes don't support "myGravity" tag
+
+	if supportsMyGravity and (not weaponDef.mygravity) then -- setting myGravity = 0.0 will use map gravity anyway
+		weaponDef.mygravity = defaultMyGravity
 	end
 end
 --------------------------------------------------------------------------------


### PR DESCRIPTION
The new logic handles all cases where (unwanted) default map gravity would be used.