### PR TITLE
Add support for mod-side weapondefs_mod and explosions_mod files.

### DIFF
--- a/gamedata/explosions.lua
+++ b/gamedata/explosions.lua
@@ -5,13 +5,28 @@ local vfsDirList = VFS.DirList
 vfsInclude("LuaRules/Utilities/tablefunctions.lua")
 local suCopyTable = Spring.Utilities.CopyTable
 
+local explosionDefs = {}
+ExplosionDefs = explosionDefs
+
+local shared = {} -- shared amongst the lua explosiondef enviroments
+Shared = shared
+
 local files = vfsDirList("effects", "*.lua")
 suCopyTable(vfsDirList("gamedata/explosions", "*.lua", VFS.MAP), false, files)
 
-local explosionDefs = {}
 for i = 1, #files do
 	suCopyTable(vfsInclude(files[i]), false, explosionDefs)
 end
+
+--[[ This lets mutators add a bit of explosions_post processing without
+     losing access to future gameside updates to explosions_post. ]]
+local MODSIDE_POSTS_FILEPATH = 'gamedata/explosions_mod.lua'
+if VFS.FileExists(MODSIDE_POSTS_FILEPATH, VFS.GAME) then
+	vfsInclude(MODSIDE_POSTS_FILEPATH, nil, VFS.GAME)
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 
 for edName, eDef in pairs(explosionDefs) do
 	for fxName, fxDef in pairs(eDef) do

--- a/gamedata/explosions.lua
+++ b/gamedata/explosions.lua
@@ -2,6 +2,9 @@ local VFS = VFS
 local vfsInclude = VFS.Include
 local vfsDirList = VFS.DirList
 
+local system = vfsInclude('gamedata/system.lua')
+local lowerkeys = system.lowerkeys
+
 vfsInclude("LuaRules/Utilities/tablefunctions.lua")
 local suCopyTable = Spring.Utilities.CopyTable
 
@@ -15,7 +18,7 @@ local files = vfsDirList("effects", "*.lua")
 suCopyTable(vfsDirList("gamedata/explosions", "*.lua", VFS.MAP), false, files)
 
 for i = 1, #files do
-	suCopyTable(vfsInclude(files[i]), false, explosionDefs)
+	suCopyTable(lowerkeys(vfsInclude(files[i])), false, explosionDefs)
 end
 
 --[[ This lets mutators add a bit of explosions_post processing without

--- a/gamedata/weapondefs_post.lua
+++ b/gamedata/weapondefs_post.lua
@@ -12,6 +12,16 @@
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
+--[[ This lets mutators add a bit of weapondefs_post processing without
+     losing access to future gameside updates to weapondefs_post. ]]
+local MODSIDE_POSTS_FILEPATH = 'gamedata/weapondefs_mod.lua'
+if VFS.FileExists(MODSIDE_POSTS_FILEPATH, VFS.GAME) then
+	VFS.Include(MODSIDE_POSTS_FILEPATH, nil, VFS.GAME)
+end
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
+
 Spring.Echo("Loading WeaponDefs_posts")
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Additionally standardize ExplosionDefs names and tags to lowercase like it is done with UnitDefs, because some ExplosionDefs (exactly 4 of them) have random case.