### PR TITLE
Visual limit for rectangle terraform lasso

### DIFF
--- a/LuaUI/Widgets/gui_lasso_terraform.lua
+++ b/LuaUI/Widgets/gui_lasso_terraform.lua
@@ -1071,8 +1071,6 @@ function widget:MousePress(mx, my, button)
 		spSetActiveCommand(index)
 		currentlyActiveCommand = CMD_LEVEL
 		
-		local mx,my = spGetMouseState()
-		
 		setHeight = true
 		drawingRectangle = false
 		placingRectangle = false

--- a/LuaUI/Widgets/gui_lasso_terraform.lua
+++ b/LuaUI/Widgets/gui_lasso_terraform.lua
@@ -180,7 +180,9 @@ local posVolume   = {0, 1, 0, 0.1} -- posisive volume
 local groundGridColor  = {0.3, 0.2, 1, 0.8} -- grid representing new ground height
 
 -- colour of lasso during drawing
-local lassoColor = {0.2, 1.0, 0.2, 1.0}
+local lassoColorGood = {0.2, 1.0, 0.2, 1.0}
+local lassoColorBad  = {1.0, 0.2, 0.2, 1.0}
+local lassoColorCurrent = lassoColorGood
 
 -- colour of ramp
 local vehPathingColor = {0.2, 1.0, 0.2, 1.0}
@@ -1291,6 +1293,13 @@ function widget:MouseMove(mx, my, dx, dy, button)
 					point[2].z = z
 					point[3].z = point[1].z+16
 				end
+
+				if abs(point[2].x - point[3].x) > maxAreaSize
+				or abs(point[2].z - point[3].z) > maxAreaSize then
+					lassoColorCurrent = lassoColorBad
+				else
+					lassoColorCurrent = lassoColorGood
+				end
 			end
 		end
 		
@@ -2111,10 +2120,10 @@ function widget:DrawWorld()
 			
 			--glDepthTest(false)
 		elseif drawingLasso then
-			glColor(lassoColor)
+			glColor(lassoColorGood)
 			glBeginEnd(GL_LINE_STRIP, DrawLine)
 		elseif drawingRectangle or (placingRectangle and placingRectangle.legalPos) then
-			glColor(lassoColor)
+			glColor(lassoColorCurrent)
 			glBeginEnd(GL_LINE_STRIP, DrawRectangleLine)
 			local a,c,m,s = spGetModKeyState()
 			if c then


### PR DESCRIPTION
Gives a visual indication if the rectangle select of the terraform lasso is too big and will be ignored.
It turns red when it's too big.