### PR TITLE
Mex sanitization cleanup

### DIFF
--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -309,8 +309,7 @@ function GetSpots(gameConfig, mapConfig)
 			spots = SanitiseSpots(mapConfig.spots, mapConfig.metalValueOverride, nil)
 			return spots, false
 		else
-			Spring.Log(gadget:GetInfo().name, LOG.INFO, "Mapside mex config has no defined mexes. Aborting.")
-			Spring.SendCommands("quit","quitforce")
+			Spring.MarkerAddPoint(Game.mapSizeX / 2, 0, Game.mapSizeZ / 2, "Mapside mex config has no defined mex table")
 		end
 	end
 	

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -188,8 +188,26 @@ function gadget:Initialize()
 end
 
 ------------------------------------------------------------
--- Extractor Income Processing
+-- Extractor Processing
 ------------------------------------------------------------
+
+function AdjustCoordinates(x, z)
+	local centerX, centerZ
+
+	if (mexDefInfo.oddX) then
+		centerX = (floor( x / METAL_MAP_SQUARE_SIZE) + 0.5) * METAL_MAP_SQUARE_SIZE
+	else
+		centerX = floor( x / METAL_MAP_SQUARE_SIZE + 0.5) * METAL_MAP_SQUARE_SIZE
+	end
+	
+	if (mexDefInfo.oddZ) then
+		centerZ = (floor( z / METAL_MAP_SQUARE_SIZE) + 0.5) * METAL_MAP_SQUARE_SIZE
+	else
+		centerZ = floor( z / METAL_MAP_SQUARE_SIZE + 0.5) * METAL_MAP_SQUARE_SIZE
+	end
+	
+	return centerX, centerZ
+end
 
 function IntegrateMetal(x, z, radius)
 	local centerX, centerZ
@@ -242,10 +260,13 @@ local function SanitiseSpots(spots, metalValueOverride)
 	while i <= #spots do
 		local spot = spots[i]
 		if spot and spot.x and spot.z then
-			local metal
-			metal, spot.x, spot.z = IntegrateMetal(spot.x, spot.z)
+			spot.x, spot.z = AdjustCoordinates(spot.x, spotz)
 			spot.y = spGetGroundOrigHeight(spot.x, spot.z)
-			spot.metal = spot.metal or metalValueOverride or (metal > 0 and metal) or DEFAULT_MEX_INCOME
+			spot.metal = spot.metal or metalValueOverride
+			if not spot.metal then
+				local metal, _, _ = IntegrateMetal(spot.x, spot.z)
+				spot.metal = (metal > 0 and metal) or DEFAULT_MEX_INCOME
+			end
 			i = i + 1
 		else
 			spot[i] = spot[#spots]

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -308,6 +308,9 @@ function GetSpots(gameConfig, mapConfig)
 		if mapConfig.spots then
 			spots = SanitiseSpots(mapConfig.spots, mapConfig.metalValueOverride, nil)
 			return spots, false
+		else
+			Spring.Log(gadget:GetInfo().name, LOG.INFO, "Mapside mex config has no defined mexes. Aborting.")
+			Spring.SendCommands("quit","quitforce")
 		end
 	end
 	

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -291,8 +291,10 @@ function GetSpots(gameConfig, mapConfig)
 	
 	if mapConfig then
 		Spring.Log(gadget:GetInfo().name, LOG.INFO, "Loading mapside mex config")
-		spots = SanitiseSpots(mapConfig.spots, mapConfig.metalValueOverride)
-		return spots, false
+		if mapConfig.spots then
+			spots = SanitiseSpots(mapConfig.spots, mapConfig.metalValueOverride)
+			return spots, false
+		end
 	end
 	
 	Spring.Log(gadget:GetInfo().name, LOG.INFO, "Detecting mex config from metalmap")

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -25,7 +25,7 @@ local MAPSIDE_METALMAP = "mapconfig/map_metal_layout.lua"
 local GAMESIDE_METALMAP = "LuaRules/Configs/MetalSpots/" .. (Game.mapName or "") .. ".lua"
 
 local DEFAULT_MEX_INCOME = 2
-local MINIMUN_MEX_INCOME = 0.2
+local MINIMUM_MEX_INCOME = 0.2
 
 local gridSize = 16 -- Resolution of metal map
 local buildGridSize = 8 -- Resolution of build positions
@@ -163,7 +163,7 @@ function gadget:Initialize()
 		local i = 1
 		while i <= #metalSpots do
 			local spot = metalSpots[i]
-			if spot.metal > MINIMUN_MEX_INCOME then
+			if spot.metal > MINIMUM_MEX_INCOME then
 				if metalValueOverride then
 					spot.metal = metalValueOverride
 				end

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -159,19 +159,6 @@ function gadget:Initialize()
 	local metalValueOverride = gameConfig and gameConfig.metalValueOverride
 	
 	if metalSpots then
-		local mult = (modOptions and modOptions.metalmult) or 1
-		local i = 1
-		while i <= #metalSpots do
-			local spot = metalSpots[i]
-			if spot.metal > MINIMUM_MEX_INCOME then
-				spot.metal = spot.metal*mult
-				i = i + 1
-			else
-				metalSpots[i] = metalSpots[#metalSpots]
-				metalSpots[#metalSpots] = nil
-			end
-		end
-		
 		metalSpotsByPos = GetSpotsByPos(metalSpots)
 	end
 	
@@ -256,21 +243,35 @@ end
 -- Mex finding
 ------------------------------------------------------------
 local function SanitiseSpots(spots, metalValueOverride)
+	local mult = (modOptions and modOptions.metalmult) or 1
 	local i = 1
 	while i <= #spots do
 		local spot = spots[i]
+		local deleteSpot = false
 		if spot and spot.x and spot.z then
 			spot.x, spot.z = AdjustCoordinates(spot.x, spotz)
 			spot.y = spGetGroundOrigHeight(spot.x, spot.z)
+			
 			spot.metal = spot.metal or metalValueOverride
 			if not spot.metal then
 				local metal, _, _ = IntegrateMetal(spot.x, spot.z)
 				spot.metal = (metal > 0 and metal) or DEFAULT_MEX_INCOME
 			end
-			i = i + 1
+			
+			if spot.metal > MINIMUM_MEX_INCOME then
+				spot.metal = spot.metal*mult
+			else
+				deleteSpot = true
+			end
 		else
+			deleteSpot = true
+		end
+
+		if deleteSpot then
 			spot[i] = spot[#spots]
 			spot[#spots] = nil
+		else
+			i = i + 1
 		end
 	end
 	

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -242,7 +242,7 @@ end
 ------------------------------------------------------------
 -- Mex finding
 ------------------------------------------------------------
-local function SanitiseSpots(spots, metalValueOverride)
+local function SanitiseSpots(spots, softMetalOverride, hardMetalOverride)
 	local mult = (modOptions and modOptions.metalmult) or 1
 	local i = 1
 	while i <= #spots do
@@ -252,13 +252,16 @@ local function SanitiseSpots(spots, metalValueOverride)
 			spot.x, spot.z = AdjustCoordinates(spot.x, spotz)
 			spot.y = spGetGroundOrigHeight(spot.x, spot.z)
 			
-			spot.metal = spot.metal or metalValueOverride
+			spot.metal = spot.metal or softMetalOverride
 			if not spot.metal then
 				local metal, _, _ = IntegrateMetal(spot.x, spot.z)
 				spot.metal = (metal > 0 and metal) or DEFAULT_MEX_INCOME
 			end
 			
 			if spot.metal > MINIMUM_MEX_INCOME then
+				if hardMetalOverride then
+					spot.metal = hardMetalOverride
+				end
 				spot.metal = spot.metal*mult
 			else
 				deleteSpot = true
@@ -303,7 +306,7 @@ function GetSpots(gameConfig, mapConfig)
 	if gameConfig then
 		Spring.Log(gadget:GetInfo().name, LOG.INFO, "Loading gameside mex config")
 		if gameConfig.spots then
-			spots = SanitiseSpots(gameConfig.spots, gameConfig.metalValueOverride)
+			spots = SanitiseSpots(gameConfig.spots, nil, gameConfig.metalValueOverride)
 			return spots, false
 		end
 	end
@@ -311,7 +314,7 @@ function GetSpots(gameConfig, mapConfig)
 	if mapConfig then
 		Spring.Log(gadget:GetInfo().name, LOG.INFO, "Loading mapside mex config")
 		if mapConfig.spots then
-			spots = SanitiseSpots(mapConfig.spots, mapConfig.metalValueOverride)
+			spots = SanitiseSpots(mapConfig.spots, mapConfig.metalValueOverride, nil)
 			return spots, false
 		end
 	end

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -178,6 +178,12 @@ end
 -- Extractor Processing
 ------------------------------------------------------------
 
+function IntegrateMetal(x, z, radius)
+	local centerX, centerZ = AdjustCoordinates(x, z)
+	local metal = IntegrateMetalFromAdjusted(centerX, centerZ, radius)
+	return metal, centerX, centerZ
+end
+
 function AdjustCoordinates(x, z)
 	local centerX, centerZ
 
@@ -196,22 +202,8 @@ function AdjustCoordinates(x, z)
 	return centerX, centerZ
 end
 
-function IntegrateMetal(x, z, radius)
-	local centerX, centerZ
-	
+function IntegrateMetalFromAdjusted(centerX, centerZ, radius)
 	radius = radius or MEX_RADIUS
-	
-	if (mexDefInfo.oddX) then
-		centerX = (floor( x / METAL_MAP_SQUARE_SIZE) + 0.5) * METAL_MAP_SQUARE_SIZE
-	else
-		centerX = floor( x / METAL_MAP_SQUARE_SIZE + 0.5) * METAL_MAP_SQUARE_SIZE
-	end
-	
-	if (mexDefInfo.oddZ) then
-		centerZ = (floor( z / METAL_MAP_SQUARE_SIZE) + 0.5) * METAL_MAP_SQUARE_SIZE
-	else
-		centerZ = floor( z / METAL_MAP_SQUARE_SIZE + 0.5) * METAL_MAP_SQUARE_SIZE
-	end
 	
 	local startX = floor((centerX - radius) / METAL_MAP_SQUARE_SIZE)
 	local startZ = floor((centerZ - radius) / METAL_MAP_SQUARE_SIZE)
@@ -236,7 +228,7 @@ function IntegrateMetal(x, z, radius)
 		end
 	end
 	
-	return result * mult, centerX, centerZ
+	return result * mult
 end
 
 ------------------------------------------------------------
@@ -254,7 +246,7 @@ local function SanitiseSpots(spots, softMetalOverride, hardMetalOverride)
 			
 			spot.metal = spot.metal or softMetalOverride
 			if not spot.metal then
-				local metal, _, _ = IntegrateMetal(spot.x, spot.z)
+				local metal = IntegrateMetalFromAdjusted(spot.x, spot.z)
 				spot.metal = (metal > 0 and metal) or DEFAULT_MEX_INCOME
 			end
 			

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -164,9 +164,6 @@ function gadget:Initialize()
 		while i <= #metalSpots do
 			local spot = metalSpots[i]
 			if spot.metal > MINIMUM_MEX_INCOME then
-				if metalValueOverride then
-					spot.metal = metalValueOverride
-				end
 				spot.metal = spot.metal*mult
 				i = i + 1
 			else

--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -291,7 +291,6 @@ function GetSpots(gameConfig, mapConfig)
 	
 	if mapConfig then
 		Spring.Log(gadget:GetInfo().name, LOG.INFO, "Loading mapside mex config")
-		loadConfig = true
 		spots = SanitiseSpots(mapConfig.spots, mapConfig.metalValueOverride)
 		return spots, false
 	end


### PR DESCRIPTION
Started from a conversation with Sprunk - I noticed some odd metal spot sanitization code while passing over mex_spot_finder.lua for unrelated changes I want to push in a future pull request.

1) Sanitization code was split between the actual sanitize function and an extra loop in gadget:Initialize()

2) The code was contradictory - one loop had a very different idea as to what metalValueOverride did compared to the other, and as far as I can tell the only reason this didn't cause errors was because metalValueOverride wasn't passed properly years ago and defaulted to nil and never affected logical flow in one loop.

3) The sanitization code was doing full metal map integration math for every single mech even when the mechs had defined metal from a gameConfig or mapConfig. This felt really egregious for something run on every mex on a map during map load.

The PR isn't perfect, or particularly complete. Some thoughts:

1) Fully optimizing IntegrateMetal would involve adding an additional helper function and coding it to use that + AdjustCoordinates. I haven't done this yet because I'm new to Lua and have no idea if this'll behave nicely with being exported to GG.IntegrateMetal.

2) There's some funkiness in GetSpotsByPos that I just don't understand. I don't know if line 93 doesn't do anything or does something important and wizardy in Lua that's new to me.

3) I have no idea why #metalSpots is compared to 6. It's driving me crazy. Googlefrog probably knows? https://github.com/ZeroK-RTS/Zero-K/commit/cb95be4adaf1111fcf8ca3be613fccb28de7b58c

4) I've only tested this on a few maps I regularly play. I don't really know all the super funky maps (the speedmetal ones etc) so I'll need help from experienced players to check out the nightmare edge cases and see if this code holds up.

Anyway I'm going to bed.