### PR TITLE
Unhardcode teleport beacon unitname in gadget and widget + some various fixes

### DIFF
--- a/LuaRules/Configs/airpad_defs.lua
+++ b/LuaRules/Configs/airpad_defs.lua
@@ -14,7 +14,7 @@ for unitDefID, config in pairs(airpadDefs) do
     local ud = UnitDefs[unitDefID]
 
     config.mobile = (not ud.isImmobile)
-    config.cap = ud.customParams.pad_count
+    config.cap = tonumber(ud.customParams.pad_count)
 end
 
 return airpadDefs

--- a/LuaRules/Gadgets/unit_teleporter.lua
+++ b/LuaRules/Gadgets/unit_teleporter.lua
@@ -25,8 +25,20 @@ local BEACON_TELEPORT_RADIUS_SQR = BEACON_TELEPORT_RADIUS^2
 local canTeleport = {}
 for i = 1, #UnitDefs do
 	local ud = UnitDefs[i]
-	if ud.isFactory or not (ud.isImmobile or ud.isStrafingAirUnit) then
+	if not (ud.isImmobile or ud.isStrafingAirUnit) then
 		canTeleport[i] = true
+	elseif ud.isFactory and (not ud.customParams.notreallyafactory) and ud.buildOptions then
+		local buildOptions = ud.buildOptions
+
+		for j = 1, #buildOptions do
+			local boDefID = buildOptions[j]
+			local bod = UnitDefs[boDefID]
+
+			if bod and not (bod.isImmobile or bod.isStrafingAirUnit) then
+				canTeleport[i] = true  -- only factories that can build teleportable units are included
+				break
+			end
+		end
 	end
 end
 

--- a/LuaRules/Gadgets/unit_teleporter.lua
+++ b/LuaRules/Gadgets/unit_teleporter.lua
@@ -30,6 +30,20 @@ for i = 1, #UnitDefs do
 	end
 end
 
+local beaconDefsByTeleporterDef = {}
+local isBeaconDef = {}
+
+for unitDefID, ud in pairs(UnitDefs) do
+	if (ud.customParams.teleporter and ud.customParams.teleporter_beacon_unit) then
+		local beaconDef = UnitDefNames[ ud.customParams.teleporter_beacon_unit ]
+
+		if (beaconDef) then
+			beaconDefsByTeleporterDef[unitDefID] = beaconDef.id
+			isBeaconDef[beaconDef.id] = true
+		end
+	end
+end
+
 if (gadgetHandler:IsSyncedCode()) then
 
 -------------------------------------------------------------------------------------
@@ -63,8 +77,6 @@ local spTestMoveOrder = Spring.TestMoveOrder
 
 -------------------------------------------------------------------------------------
 -------------------------------------------------------------------------------------
-
-local beaconDef = UnitDefNames["tele_beacon"].id
 
 local offset = {
 	[0] = {x = 1, z = 0},
@@ -166,7 +178,8 @@ function tele_undeployTeleport(unitID)
 	Spring.SetUnitRulesParam(unitID, "deploy", 0)
 end
 
-function tele_createBeacon(unitID, x, z, beaconID)
+function tele_createBeacon(unitID, unitDefID, x, z, beaconID)
+	local beaconDef = beaconDefsByTeleporterDef[unitDefID]
 	local y = Spring.GetGroundHeight(x,z)
 	local place, feature = Spring.TestBuildOrder(beaconDef, x, y, z, 1)
 	changeSpeed(unitID, nil, 1)
@@ -332,6 +345,7 @@ function gadget:CommandFallback(unitID, unitDefID, teamID,    -- keeps getting
 			end
 			
 			if (inLos) then --if LOS: check for obstacle
+				local beaconDef = beaconDefsByTeleporterDef[unitDefID]
 				local place, feature = Spring.TestBuildOrder(beaconDef, cx, 0, cz, 1)
 				if not (place == 2 and feature == nil) then
 					return true, true -- command was used and remove it
@@ -694,7 +708,6 @@ local spGetLocalTeamID   = Spring.GetLocalTeamID
 local myTeam = spGetMyTeamID()
 local myAllyTeam = spGetMyAllyTeamID()
 
-local beaconDef = UnitDefNames["tele_beacon"].id
 local beacons = {}
 local beaconCount = 0
 
@@ -709,7 +722,7 @@ function gadget:Initialize()
 end
 
 function gadget:DefaultCommand(type, targetID)
-	if (type == 'unit') and beaconDef == spGetUnitDefID(targetID) then
+	if (type == 'unit') and isBeaconDef[ spGetUnitDefID(targetID) ] then
 		local targetTeam = spGetUnitTeam(targetID)
 		local selfTeam = spGetLocalTeamID()
 		if not (spAreTeamsAllied(targetTeam, selfTeam)) then
@@ -795,14 +808,14 @@ local function DrawFunc(u1, u2)
 end
 
 function gadget:UnitCreated(unitID, unitDefID)
-	if (unitDefID == beaconDef) then
+	if (isBeaconDef[unitDefID]) then
 		beacons[beaconCount + 1] = unitID
 		beaconCount = beaconCount + 1
 	end
 end
 
 function gadget:UnitDestroyed(unitID, unitDefID)
-	if (unitDefID == beaconDef) then
+	if (isBeaconDef[unitDefID]) then
 		for i=1, #beacons do
 			if beacons[i] == unitID then
 				beacons[i] = beacons[beaconCount]

--- a/LuaUI/Widgets/unit_teleport_ai_2.lua
+++ b/LuaUI/Widgets/unit_teleport_ai_2.lua
@@ -464,8 +464,8 @@ function widget:GameFrame(n)
 							--save exit coordinate:--
 							teleportedUnit[unitID] = { x = dx*50+ex ,y = ey, z = dz*50+ez } --(a coordinate of a command that we going to give)
 							--end fix
-							--method A: give GUARD order--
-							spGiveOrderArrayToUnitArray({unitID},{{CMD.INSERT, {0, CMD.GUARD, CMD.OPT_SHIFT, pathToFollow}, CMD.OPT_ALT},{CMD.INSERT, {1, CMD_RAW_MOVE, CMD.OPT_INTERNAL, dx*50+ex,ey,dz*50+ez}, CMD.OPT_ALT}})
+							--method A: give WAIT_AT_BEACON order--
+							spGiveOrderArrayToUnitArray({unitID},{{CMD.INSERT, {0, CMD_WAIT_AT_BEACON, CMD.OPT_SHIFT, pathToFollow}, CMD.OPT_ALT},{CMD.INSERT, {1, CMD_RAW_MOVE, CMD.OPT_INTERNAL, dx*50+ex,ey,dz*50+ez}, CMD.OPT_ALT}})
 							local defID = unitInfo["defID"]
 							local chargeTime = transportChargetime[unitID] or listOfMobile[defID][2]
 							beaconCurrentQueue[pathToFollow] = beaconCurrentQueue[pathToFollow] + chargeTime

--- a/LuaUI/Widgets/unit_teleport_ai_2.lua
+++ b/LuaUI/Widgets/unit_teleport_ai_2.lua
@@ -46,7 +46,19 @@ local groupBeaconFinish={}
 --end spread job stuff
 local IgnoreUnit = {} --list of uninteresting/irrelevant unit to be excluded until their command changes (an Optimization)
 local teleportedUnit = {}
-local beaconDefID = UnitDefNames["tele_beacon"].id
+
+local isBeaconDef = {}
+
+for _, ud in pairs(UnitDefs) do
+	if (ud.customParams.teleporter and ud.customParams.teleporter_beacon_unit) then
+		local beaconDef = UnitDefNames[ ud.customParams.teleporter_beacon_unit ]
+
+		if (beaconDef) then
+			isBeaconDef[beaconDef.id] = true
+		end
+	end
+end
+
 --Network lag hax stuff: (wait until unit receive command before processing 2nd time)
 local waitForNetworkDelay = {}
 local issuedOrderTo = {}
@@ -65,7 +77,7 @@ function widget:Initialize()
 		local unitID = units[i]
 		if Spring.IsUnitAllied(unitID) then
 			local unitDefID = Spring.GetUnitDefID(unitID)
-			if beaconDefID == unitDefID then
+			if isBeaconDef[unitDefID] then
 				local x,y,z = spGetUnitPosition(unitID)
 				listOfBeacon[unitID] = {x,y,z,nil,nil,nil,djinID=nil,prevIndex=nil,prevList=nil,nearbyBeacon=nil,becnQeuu=0,deployed=1}
 			end
@@ -79,7 +91,7 @@ function widget:Initialize()
 end
 
 function widget:UnitCreated(unitID, unitDefID, unitTeam, builderID)
-	if beaconDefID == unitDefID then
+	if isBeaconDef[unitDefID] then
 		local x,y,z = spGetUnitPosition(unitID)
 		listOfBeacon[unitID] = {x,y,z,nil,nil,nil,djinID=nil,prevIndex=nil,prevList=nil,nearbyBeacon=nil,becnQeuu=0,deployed=1}
 		local cluster, nonClustered = WG.OPTICS_cluster(listOfBeacon, detectionRange,1, myTeamID,detectionRange) --//find clusters with atleast 1 unit per cluster and with at least within 500-elmo from each other (this function is located in api_shared_function.lua)

--- a/scripts/amphtele.lua
+++ b/scripts/amphtele.lua
@@ -67,7 +67,7 @@ local function Create_Beacon_Thread(x,z)
 		end
 	end
 
-	GG.tele_createBeacon(unitID,x,z)
+	GG.tele_createBeacon(unitID,unitDefID,x,z)
 	
 	Spring.SetUnitRulesParam(unitID, "tele_creating_beacon_x", nil, PRIVATE)
 	Spring.SetUnitRulesParam(unitID, "tele_creating_beacon_z", nil, PRIVATE)

--- a/units/amphtele.lua
+++ b/units/amphtele.lua
@@ -23,6 +23,7 @@ return { amphtele = {
     teleporter = 1,
     teleporter_throughput = 150, -- mass per second
     teleporter_beacon_spawn_time = 8,
+    teleporter_beacon_unit = [[tele_beacon]],
   },
 
   explodeAs              = [[BIG_UNIT]],

--- a/units/tele_beacon.lua
+++ b/units/tele_beacon.lua
@@ -6,6 +6,7 @@ return { tele_beacon = {
   brakeRate                     = 0,
   buildCostMetal                = 100,
   builder                       = false,
+  buildPic                      = [[tele_beacon.png]],
   category                      = [[SINK UNARMED]],
 
   customParams                  = {


### PR DESCRIPTION
- Unhardcoded teleport beacon unitname in unit_teleporter.lua gadget and unit_teleport_ai_2.lua widget.
(this fixes point 6 from issue #4535)
- Improved canTeleport check in unit_teleporter.lua to only include factories that can build teleportable units.
(as the result AirPad, MissileSilo and pw_bomberfac can no longer be given WAIT_AT_BEACON command - it had no effect for them anyway)
- Make unit_teleport_ai_2.lua widget give WAIT_AT_BEACON command instead of GUARD command, so it actually works again. (GUARD command on beacon did nothing anymore)
- Add missing "buildPic" tag in tele_beacon unitDef file.
(engine was using a default internally, but in Lua UnitDefs it remained nil, which could cause potential problems in mods)
- Fix "attempt to compare number with string" error in unit_bomber_command.lua gadget. (Error in my previous PR, sorry :P)

All above changes are in separate commits for easier understanding.