### PR TITLE
Unhardcode some weaponnames hardcoded in gadgets

### DIFF
--- a/LuaRules/Gadgets/weapon_projectile_radar_homing.lua
+++ b/LuaRules/Gadgets/weapon_projectile_radar_homing.lua
@@ -22,15 +22,13 @@ local UNIT = string.byte('u')
 
 local projectiles = {}
 
-local projectileHomingDistance = {
-	[WeaponDefNames["shipcarrier_disarm_rocket"].id] = 600^2,
-	[WeaponDefNames["turretaaheavy_advsam"].id] = 1800^2,
-	[WeaponDefNames["amphraid_torpedo"].id] = 200^2,
-}
+local projectileHomingDistance = {}
 
 for wdid = 1, #WeaponDefs do
 	local wd = WeaponDefs[wdid]
-	if (not projectileHomingDistance[wdid]) and wd.tracks and
+	if (wd.customParams.radar_homing_distance) then
+		projectileHomingDistance[wdid] = tonumber(wd.customParams.radar_homing_distance)^2
+	elseif wd.tracks and
 			(wd.type == "TorpedoLauncher" or wd.type == "MissileLauncher" or wd.type == "StarburstLauncher") then
 		projectileHomingDistance[wdid] = (10 * wd.projectilespeed)^2
 	end

--- a/LuaRules/Gadgets/weapon_torpedo_stay_underwater.lua
+++ b/LuaRules/Gadgets/weapon_torpedo_stay_underwater.lua
@@ -15,13 +15,17 @@ function gadget:GetInfo()
   }
 end
 
-local projectileDefs = {
-	[WeaponDefNames["subraider_torpedo"].id] = true,
-	[WeaponDefNames["amphriot_torpedo"].id] = true,
-	[WeaponDefNames["amphraid_torpedo"].id] = true,
-	[WeaponDefNames["shiptorpraider_torpedo"].id] = true,
-	[WeaponDefNames["turrettorp_torpedo"].id] = true,
-}
+local tobool = Spring.Utilities.tobool
+
+local projectileDefs = {}
+
+for i = 1, #WeaponDefs do
+	local wd = WeaponDefs[i]
+
+	if tobool(wd.customParams.stays_underwater) then
+		projectileDefs[i] = true
+	end
+end
 
 -------------------------------------------------------------
 -------------------------------------------------------------

--- a/gamedata/unitdefs_checks.lua
+++ b/gamedata/unitdefs_checks.lua
@@ -20,10 +20,9 @@ local function round_to_frames(name, wd, key)
 	wd[key] = sanitized_value + 1E-5
 end
 
-local function print_bounce_warning(name, wd, key)
-	if (wd.numBounce or wd.bouncerebound or wd.bounceslip) and not (
-			name == "amphriot.torpedo" or name == "amphraid.torpedo" or
-			name == "shiptorpraider.torpedo" or name == "turrettorp.torpedo" or
+local function print_bounce_warning(name, wd)
+	if (wd.numbounce or wd.bouncerebound or wd.bounceslip) and not (
+			(wd.customparams and wd.customparams.stays_underwater == 1) or
 			name == "hoverdepthcharge.depthcharge" or name == "hoverdepthcharge.fake_depthcharge" or
 			wd.weapontype == "Cannon") then
 		Spring.Echo("===============================================================")
@@ -31,6 +30,7 @@ local function print_bounce_warning(name, wd, key)
 		Spring.Echo("Ground bounce detected for", name, wd.weapontype)
 		Spring.Echo("There is a risk of it falling through the ground indefinitely.")
 		Spring.Echo("Ensure appropriate hax is in place.")
+		Spring.Echo("For torpedoes use \"stays_underwater\" customParam.")
 		Spring.Echo("See LuaRules/Gadgets/weapon_torpedo_stay_underwater.lua.")
 		Spring.Echo("************************* END WARNING *************************")
 		Spring.Echo("===============================================================")
@@ -71,7 +71,7 @@ local function processWeapons(unitDefName, unitDef)
 		local fullWeaponName = unitDefName .. "." .. weaponDefName
 		round_to_frames(fullWeaponName, weaponDef, "reloadtime")
 		round_to_frames(fullWeaponName, weaponDef, "burstrate")
-		print_bounce_warning(fullWeaponName, weaponDef, "burstrate")
+		print_bounce_warning(fullWeaponName, weaponDef)
 		check_lasercannon_range(fullWeaponName, weaponDef)
 	end
 end

--- a/units/amphraid.lua
+++ b/units/amphraid.lua
@@ -127,6 +127,7 @@ return { amphraid = {
 
       customparams = {
         radar_homing_distance = 200,
+        stays_underwater = 1,
       },
 
       damage                  = {

--- a/units/amphraid.lua
+++ b/units/amphraid.lua
@@ -125,6 +125,10 @@ return { amphraid = {
       craterMult              = 2,
       cegTag                  = [[torpedo_trail]],
 
+      customparams = {
+        radar_homing_distance = 200,
+      },
+
       damage                  = {
         default = 130.01,
       },

--- a/units/amphriot.lua
+++ b/units/amphriot.lua
@@ -90,7 +90,11 @@ return { amphriot = {
       craterBoost             = 0,
       craterMult              = 0,
       cegTag                  = [[torpedo_trail]],
-   
+
+      customparams = {
+        stays_underwater = 1,
+      },
+
       damage                  = {
         default = 48.01,
       },

--- a/units/bomberprec.lua
+++ b/units/bomberprec.lua
@@ -217,6 +217,10 @@ return { bomberprec = {
       craterBoost             = 1,
       craterMult              = 2,
 
+      customparams = {
+        stays_underwater = 1,
+      },
+
       damage                  = {
         default = 800,
       },

--- a/units/shipcarrier.lua
+++ b/units/shipcarrier.lua
@@ -92,7 +92,8 @@ return { shipcarrier = {
         disarmDamageMult = 1.0,
         disarmDamageOnly = 1,
         disarmTimer      = 10, -- seconds
-        
+        radar_homing_distance = 600,
+
         light_color = [[1 1 1]],
       },
       

--- a/units/shiptorpraider.lua
+++ b/units/shiptorpraider.lua
@@ -76,11 +76,12 @@ return { shiptorpraider = {
       cegTag                  = [[torpedo_trail]],
 
       customParams = {
-          burst = Shared.BURST_RELIABLE,
+        burst = Shared.BURST_RELIABLE,
+
+        stays_underwater = 1,
       },
 
       damage                  = {
-
         default = 220.1,
       },
 

--- a/units/subraider.lua
+++ b/units/subraider.lua
@@ -83,6 +83,7 @@ return { subraider = {
         burst = Shared.BURST_RELIABLE,
 
         timeslow_damagefactor = 2,
+        stays_underwater = 1,
       },
 
       damage                  = {

--- a/units/turretaaheavy.lua
+++ b/units/turretaaheavy.lua
@@ -70,6 +70,7 @@ return { turretaaheavy = {
 
       customParams              = {
         isaa = [[1]],
+        radar_homing_distance = 1800,
 
         light_color = [[1.5 1.8 1.8]],
         light_radius = 600,

--- a/units/turrettorp.lua
+++ b/units/turrettorp.lua
@@ -69,6 +69,10 @@ return { turrettorp = {
       craterMult              = 0,
       cegTag                  = [[torpedo_trail]],
 
+      customparams = {
+        stays_underwater = 1,
+      },
+
       damage                  = {
         default = 190,
       },


### PR DESCRIPTION
- Unhardcode projectileHomingDistance table in weapon_projectile_radar_homing.lua gadget. (add customParam instead)
- Unhardcode projectileDefs table in weapon_torpedo_stay_underwater.lua gadget. (add customParam instead)
- Fix and update bounce warning check. (it didn't work previously because it looked for numBounce tag instead of lowercase numbounce)
- Add stays_underwater tag to bomberprec underwater weapon (caused warning after fixing above check).

This fixes points 10 and 12 from issue #4535.