### PR TITLE
Additional rmb command settings options

### DIFF
--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -131,6 +131,8 @@ local requiresAlt = {
 local overrideCmds = {
 	[CMD.GUARD] = CMD_RAW_MOVE,
 	[CMD_WAIT_AT_BEACON] = CMD_RAW_MOVE,
+	[CMD.ATTACK] = 20,
+	
 }
 
 -- What commands are issued at a position or unit/feature ID (Only used by GetUnitPosition)
@@ -518,10 +520,10 @@ function widget:MousePress(mx, my, mButton)
 	
 	-- Get command that would've been issued
 	local _, activeCmdID = spGetActiveCommand()
+	
 	if activeCmdID then
 		if mButton==3 and options.RMBLineFormation.value then
 			usingCmd = activeCmdID
-			--If the option to use RMB for fight and attack as well is on we fake the rmb not being used. Is this too janky?
 			usingContextCommand = false
 		else
 			if mButton ~= 1 then
@@ -543,6 +545,7 @@ function widget:MousePress(mx, my, mButton)
 		end
 		
 		local overrideCmdID = overrideCmds[defaultCmdID]
+		
 		if overrideCmdID then
 			local targType, targID = CulledTraceScreenRay(mx, my, false, inMinimap)
 			if targType == 'unit' then
@@ -566,6 +569,10 @@ function widget:MousePress(mx, my, mButton)
 		
 		usingContextCommand = true
 		usingRMB = true
+		Spring.Echo("usingContextCommand")
+		Spring.Echo(usingContextCommand)
+		Spring.Echo("usingRMB")
+		Spring.Echo(usingRMB)
 	end
 	
 	-- Without this, the unloads issued will use the area of the last area unload
@@ -589,7 +596,6 @@ function widget:MousePress(mx, my, mButton)
 	
 	-- Is this line a path candidate (We don't do a path off an overridden command)
 	pathCandidate = (not overriddenCmd) and (spGetSelectedUnitsCount()==1 or (alt and not requiresAlt[usingCmd]))
-	
 	-- We handled the mouse press
 	return true
 end

--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -549,7 +549,6 @@ function widget:MousePress(mx, my, mButton)
 	
 	-- Get command that would've been issued
 	local _, activeCmdID = spGetActiveCommand()
-	local alt, ctrl, meta, shift = GetModKeys()
 	if activeCmdID then
 		if mButton==3 and (fightRMBLineFormationToo[activeCmdID] or cmdRMBWorksAsALTLMB[activeCmdID]) then
 			usingCmd = activeCmdID

--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -22,11 +22,8 @@ local overrideCmdSingleUnit = {
 	[CMD.GUARD] = true,
 }
 
-local fightRMBLineFormationToo = {}
-local cmdRMBWorksAsALTLMB = {}
-
 options_path = 'Settings/Interface/Command Visibility'--/Formations'
-options_order = { 'drawmode_v2', 'linewidth', 'dotsize', 'overrideGuard','fightRMBLineFormation','rmbWorksAsALTLMB' }
+options_order = { 'drawmode_v2', 'linewidth', 'dotsize', 'overrideGuard','RMBLineFormation' }
 options = {
 	drawmode_v2 = {
 		name = 'Draw mode',
@@ -73,41 +70,12 @@ options = {
 			end
 		end,
 	},
-	fightRMBLineFormation = {
-		name = "RMB can line formation fight",
-		desc = "When enabled, after selecting fight you can also issue the line formation command with dragging rmb, clicking rmb without moving still cancels",
+	RMBLineFormation = {
+		name = "RMB can issue line formation",
+		desc = "When enabled you can also issue the line formation command with dragging rmb, clicking rmb without moving still cancels.",
 		type = "bool",
 		value = false,
 		path = 'Settings/Interface/Commands',
-		OnChange = function (self)
-			if self.value then
-				fightRMBLineFormationToo = {
-					
-					[CMD.FIGHT] = true,
-				}
-			else
-				fightRMBLineFormationToo = {}
-			end
-		end,
-	},
-	rmbWorksAsALTLMB = {
-		name = "RMB drag acts as alt ATK/TGT",
-		desc = "When enabled, after selecting attack or target, line drag will issue a formation line fire command",
-		type = "bool",
-		value = false,
-		path = 'Settings/Interface/Commands',
-		OnChange = function (self)
-			if self.value then
-				cmdRMBWorksAsALTLMB = {
-					
-					[CMD.ATTACK] = true,
-					[CMD_UNIT_SET_TARGET_CIRCLE] = true,
-					
-				}
-			else
-				cmdRMBWorksAsALTLMB = {}
-			end
-		end,
 	},
 }
 
@@ -550,7 +518,7 @@ function widget:MousePress(mx, my, mButton)
 	-- Get command that would've been issued
 	local _, activeCmdID = spGetActiveCommand()
 	if activeCmdID then
-		if mButton==3 and (fightRMBLineFormationToo[activeCmdID] or cmdRMBWorksAsALTLMB[activeCmdID]) then
+		if mButton==3 and options.RMBLineFormation.value then
 			usingCmd = activeCmdID
 			--If the option to use RMB for fight and attack as well is on we fake the rmb not being used. Is this too janky?
 			usingRMB = false
@@ -605,7 +573,7 @@ function widget:MousePress(mx, my, mButton)
 	-- Is this command eligible for a custom formation ?
 	local alt, ctrl, meta, shift = GetModKeys()
 	-- If its not ( command elegible for formation AND ((alt is being held or the command doesnt require alt) or (using rmb as alt command and rmb is pressed)))
-	if not (formationCmds[usingCmd] and (alt or not requiresAlt[usingCmd]) or (cmdRMBWorksAsALTLMB[usingCmd]) and mButton == 3) then
+	if not (formationCmds[usingCmd] and ((alt or not requiresAlt[usingCmd]) or (options.RMBLineFormation.value and mButton == 3))) then
 		return false
 	end
 	
@@ -706,7 +674,7 @@ function widget:MouseRelease(mx, my, mButton)
 	--copied from press to check activecmd
 	local _, activeCmdID = spGetActiveCommand()
 	-- If the right part involving rmb formations and mbutton 3, usingrmb will be false as it was passed like that on press
-	if (mButton == 1 or mButton == 3) and ((not usingRMB) == (mButton == 3) and (not ((fightRMBLineFormationToo[activeCmdID] or cmdRMBWorksAsALTLMB[activeCmdID])and mButton == 3))) then
+	if (mButton == 1 or mButton == 3) and ((not usingRMB) == (mButton == 3) and (not (options.RMBLineFormation.value and mButton == 3))) then
 		StopCommandAndRelinquishMouse()
 		return false
 	end

--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -671,8 +671,6 @@ local function StopCommandAndRelinquishMouse()
 end
 
 function widget:MouseRelease(mx, my, mButton)
-	--copied from press to check activecmd
-	local _, activeCmdID = spGetActiveCommand()
 	-- If the right part involving rmb formations and mbutton 3, usingrmb will be false as it was passed like that on press
 	if (mButton == 1 or mButton == 3) and ((not usingRMB) == (mButton == 3) and (not (options.RMBLineFormation.value and mButton == 3))) then
 		StopCommandAndRelinquishMouse()

--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -132,7 +132,6 @@ local overrideCmds = {
 	[CMD.GUARD] = CMD_RAW_MOVE,
 	[CMD_WAIT_AT_BEACON] = CMD_RAW_MOVE,
 	[CMD.ATTACK] = 20,
-	
 }
 
 -- What commands are issued at a position or unit/feature ID (Only used by GetUnitPosition)
@@ -520,7 +519,6 @@ function widget:MousePress(mx, my, mButton)
 	
 	-- Get command that would've been issued
 	local _, activeCmdID = spGetActiveCommand()
-	
 	if activeCmdID then
 		if mButton==3 and options.RMBLineFormation.value then
 			usingCmd = activeCmdID
@@ -545,7 +543,6 @@ function widget:MousePress(mx, my, mButton)
 		end
 		
 		local overrideCmdID = overrideCmds[defaultCmdID]
-		
 		if overrideCmdID then
 			local targType, targID = CulledTraceScreenRay(mx, my, false, inMinimap)
 			if targType == 'unit' then
@@ -569,10 +566,6 @@ function widget:MousePress(mx, my, mButton)
 		
 		usingContextCommand = true
 		usingRMB = true
-		Spring.Echo("usingContextCommand")
-		Spring.Echo(usingContextCommand)
-		Spring.Echo("usingRMB")
-		Spring.Echo(usingRMB)
 	end
 	
 	-- Without this, the unloads issued will use the area of the last area unload

--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -131,7 +131,6 @@ local requiresAlt = {
 local overrideCmds = {
 	[CMD.GUARD] = CMD_RAW_MOVE,
 	[CMD_WAIT_AT_BEACON] = CMD_RAW_MOVE,
-	[CMD.ATTACK] = 20,
 }
 
 -- What commands are issued at a position or unit/feature ID (Only used by GetUnitPosition)
@@ -576,7 +575,7 @@ function widget:MousePress(mx, my, mButton)
 	-- Is this command eligible for a custom formation ?
 	local alt, ctrl, meta, shift = GetModKeys()
 	-- If its not ( command elegible for formation AND ((alt is being held or the command doesnt require alt) or (using rmb as alt command and rmb is pressed)))
-	if not (formationCmds[usingCmd] and ((alt or not requiresAlt[usingCmd]) or (options.RMBLineFormation.value and mButton == 3))) then
+	if not (formationCmds[usingCmd] and ((alt or not requiresAlt[usingCmd]) or (options.RMBLineFormation.value and mButton == 3 and not usingContextCommand))) then
 		return false
 	end
 	


### PR DESCRIPTION
Adds settings for issuing target and attack as if it had alt pressed with rmb drag.  Also adds the ability to also issue line formation fight with the rmb drag. 