### PR TITLE
fixes for apm stats crash

### DIFF
--- a/LuaUI/Widgets/gui_chili_apm_stats.lua
+++ b/LuaUI/Widgets/gui_chili_apm_stats.lua
@@ -50,11 +50,10 @@ local function SendMyPlayerStats()
 	local MP, MC, KP, NC, NUC = spGetPlayerStatistics(myPlayerID, true)
 	local playerStats = {
 		teamID = myTeamID,
-		MP = MP,
-		MC = MC,
-		KP = KP,
-		NC = NC,
-		NUC = NUC
+		MPS = round(MP/activeTime),
+		MCM = round(MC*60/activeTime),
+		KPM = round(KP*60/activeTime),
+		APM = round(NC*60/activeTime),
 	}
 	WG.apmStats[myPlayerID] = playerStats
 	MP = VFS.PackU16(MP)
@@ -111,7 +110,7 @@ function widget:Initialize()
 end
 
 function widget:RecvLuaMsg(msg, playerID)
-	if playerID == myPLayerID then
+	if playerID == myPlayerID then
 		return true
 	end
 	if (msg:sub(1,6)=="pStats") then

--- a/LuaUI/Widgets/gui_chili_endgamewindow.lua
+++ b/LuaUI/Widgets/gui_chili_endgamewindow.lua
@@ -66,6 +66,7 @@ local endgame_fontcolor
 local gameEnded
 local showEndgameWindowTimer
 local myPlayerID = Spring.GetMyPlayerID()
+local updateFlag = true
 
 -- Constants and parameters
 local endgameWindowDelay = 2
@@ -626,32 +627,36 @@ function widget:GameOver(winners)
 end
 
 function widget:Update(dt)
-	showEndgameWindowTimer = showEndgameWindowTimer - dt
-	if showEndgameWindowTimer > 0 then
-		return
+	if updateFlag then
+		showEndgameWindowTimer = showEndgameWindowTimer - dt
+		if showEndgameWindowTimer > 0 then
+			return
+		end
+		local screenWidth, screenHeight = Spring.GetViewGeometry()
+		window_endgame:SetPos(screenWidth*0.2,screenHeight*0.2,screenWidth*0.6,screenHeight*0.6)
+		statsPanel:SetPosRelative(10, 50, -(10+10), -(50+10))
+		statsSubPanel.graphButtons[1].OnClick[1](statsSubPanel.graphButtons[1])
+		awardButton:Show()
+		statsButton:Show()
+		apmButton:Show()
+		exitButton:Show()
+
+		window_endgame.tooltip = ""
+		window_endgame.caption = endgame_caption
+		window_endgame.font.color = endgame_fontcolor
+
+		if WG.awardList then
+			ShowAwards()
+		else
+			ShowStats()
+		end
+		ToggleStatsGraph(true)
+
+		updateFlag = false
 	end
-	local screenWidth, screenHeight = Spring.GetViewGeometry()
-	window_endgame:SetPos(screenWidth*0.2,screenHeight*0.2,screenWidth*0.6,screenHeight*0.6)
-	statsPanel:SetPosRelative(10, 50, -(10+10), -(50+10))
-	statsSubPanel.graphButtons[1].OnClick[1](statsSubPanel.graphButtons[1])
-	awardButton:Show()
-	statsButton:Show()
-	apmButton:Show()
-	exitButton:Show()
-
-	window_endgame.tooltip = ""
-	window_endgame.caption = endgame_caption
-	window_endgame.font.color = endgame_fontcolor
-
-	if WG.awardList then
-		ShowAwards()
-	else
-		ShowStats()
+	if gameEnded then
+		PopulateAPMPanel()
 	end
-	ToggleStatsGraph(true)
-
-	PopulateAPMPanel()
-	widgetHandler:RemoveCallIn("Update")
 end
 
 function widget:GameFrame(f)


### PR DESCRIPTION
Most likely cause was that player was logging incorrect stats for themselves (logging raw stats like Mouse Pixels instead of final stats like MPS).  Also, adjusted endgamewindow so it would keep calling update after gameEnd and window setup, only for apmstats, in case their is a delay in sending.