### PR TITLE
Overheating quill proposal

### DIFF
--- a/LuaRules/Gadgets/unit_attributes.lua
+++ b/LuaRules/Gadgets/unit_attributes.lua
@@ -406,12 +406,12 @@ function UpdateUnitAttributes(unitID, frame)
 	-- Increased reload from CAPTURE --
 	local selfReloadSpeedChange = spGetUnitRulesParam(unitID,"selfReloadSpeedChange")
 	
-	local disarmed = spGetUnitRulesParam(unitID,"disarmed") or 0
-	local completeDisable = (spGetUnitRulesParam(unitID,"morphDisable") or 0)
-	if spGetUnitRulesParam(unitID,"planetwarsDisable") == 1 then
+	local disarmed = spGetUnitRulesParam(unitID, "disarmed") or 0
+	local completeDisable = (spGetUnitRulesParam(unitID, "morphDisable") or 0)
+	if spGetUnitRulesParam(unitID, "planetwarsDisable") == 1 then
 		completeDisable = 1
 	end
-	local crashing = spGetUnitRulesParam(unitID,"crashing") or 0
+	local crashing = spGetUnitRulesParam(unitID, "crashing") or 0
 	
 	-- Unit speed change (like sprint) --
 	local upgradesSpeedMult   = spGetUnitRulesParam(unitID, "upgradesSpeedMult")
@@ -419,13 +419,14 @@ function UpdateUnitAttributes(unitID, frame)
 	local selfTurnSpeedChange = spGetUnitRulesParam(unitID, "selfTurnSpeedChange")
 	local selfIncomeChange = (spGetUnitRulesParam(unitID, "selfIncomeChange") or 1) * (GG.unit_handicap[unitID] or 1)
 	local selfMaxAccelerationChange = spGetUnitRulesParam(unitID, "selfMaxAccelerationChange") --only exist in airplane??
+	local selfBuildChange = spGetUnitRulesParam(unitID, "selfBuildChange")
 	
 	-- SLOW --
 	local slowState = spGetUnitRulesParam(unitID,"slowState")
 	if slowState and slowState > 0.5 then
 		slowState = 0.5 -- Maximum slow
 	end
-	local zombieSpeedMult = spGetUnitRulesParam(unitID,"zombieSpeedMult")
+	local zombieSpeedMult = spGetUnitRulesParam(unitID, "zombieSpeedMult")
 	local buildpowerMult = spGetUnitRulesParam(unitID, "buildpower_mult")
 	
 	-- Disable
@@ -450,7 +451,7 @@ function UpdateUnitAttributes(unitID, frame)
 		local baseSpeedMult   = (1 - (slowState or 0))*(zombieSpeedMult or 1)
 		
 		local econMult   = (baseSpeedMult)*(1 - disarmed)*(1 - completeDisable)*(selfIncomeChange or 1)
-		local buildMult  = (baseSpeedMult)*(1 - disarmed)*(1 - completeDisable)*(selfIncomeChange or 1)*(buildpowerMult or 1)
+		local buildMult  = (baseSpeedMult)*(selfBuildChange or 1)*(1 - disarmed)*(1 - completeDisable)*(selfIncomeChange or 1)*(buildpowerMult or 1)
 		local moveMult   = (baseSpeedMult)*(selfMoveSpeedChange or 1)*(1 - completeDisable)*(upgradesSpeedMult or 1)
 		local turnMult   = (baseSpeedMult)*(selfMoveSpeedChange or 1)*(selfTurnSpeedChange or 1)*(1 - completeDisable)
 		local reloadMult = (baseSpeedMult)*(selfReloadSpeedChange or 1)*(1 - disarmed)*(1 - completeDisable)

--- a/units/hovercon.lua
+++ b/units/hovercon.lua
@@ -26,6 +26,10 @@ return { hovercon = {
     modelradius    = [[25]],
     selection_scale = 1.2,
     turnatfullspeed_hover = [[1]],
+    heat_per_shot  = 0.02, -- Heat is always a number between 0 and 1
+    heat_decay     = 1/6, -- Per second
+    heat_max_slow  = 0.5,
+    heat_initial   = 1,
   },
 
   energyUse           = 0,
@@ -34,7 +38,7 @@ return { hovercon = {
   footprintX          = 2,
   footprintZ          = 2,
   iconType            = [[builder]],
-  maxDamage           = 960,
+  maxDamage           = 940,
   maxSlope            = 36,
   maxVelocity         = 2.9,
   movementClass       = [[HOVER2]],
@@ -56,7 +60,7 @@ return { hovercon = {
   sonarDistance       = 300,
   turninplace         = 0,
   turnRate            = 1100,
-  workerTime          = 5,
+  workerTime          = 10,
 
   featureDefs         = {
 


### PR DESCRIPTION
Adds heat to quill like stardust. Roughly gives Quill a second of free work over the first 3 seconds of working, while reducing hp slightly to compensate. This ability cools down after 6 seconds. This makes quill slightly better at smaller tasks that require traveling for at-least 6 seconds.

A mod with this change has been uploaded. Try it out: !game Over heating Quill v1 