### PR TITLE
Fix #4641

### DIFF
--- a/LuaRules/Gadgets/unit_ward_fire.lua
+++ b/LuaRules/Gadgets/unit_ward_fire.lua
@@ -299,7 +299,8 @@ end
 local function StateToggleCommand(unitID, cmdParams, cmdOptions, cmdID)
 	local unitData = IterableMap.Get(wardUnits, unitID)
 	local mexData = IterableMap.Get(mexUnits, unitID)
-	if (unitData or mexData) and unitData.def.wardFireCmdID == cmdID then
+	local def = (unitData and unitData.def) or (mexData and mexData.def)
+	if def and (def.wardFireCmdID or CMD_FIRE_AT_SHIELD) == cmdID then
 		local state = cmdParams[1]
 		local cmdDescID = spFindUnitCmdDesc(unitID, cmdID)
 		


### PR DESCRIPTION
Units such as pyro and Crabe can cause lua errors when someone toggles the fire at shield state (literally nobody does this apparently so this has gone under the radar for some time).

There's probably a better way to do this.