### PR TITLE
Added a gadget to unstick caretakers

### DIFF
--- a/LuaRules/Gadgets/unit_unstick_staticcon.lua
+++ b/LuaRules/Gadgets/unit_unstick_staticcon.lua
@@ -100,7 +100,7 @@ OR (after finding a feature)
 [5] = radius
 ]]
 
-local function HandleUnit(unitID, f)
+local function HandleUnit(unitID)
 	if not spValidUnitID(unitID) then
 		return
 	end

--- a/LuaRules/Gadgets/unit_unstick_staticcon.lua
+++ b/LuaRules/Gadgets/unit_unstick_staticcon.lua
@@ -45,18 +45,8 @@ local spGetUnitDefID = Spring.GetUnitDefID
 local spGetFeaturePosition = Spring.GetFeaturePosition
 --local EMPTY = {}
 
-local function DebugEcho(str, arg1, arg2, arg3, arg4)
-	if arg4 then
-		spEcho("[unit_unstick_staticcon]: " .. str, arg1, arg2, arg3, arg4)
-	elseif arg3 then
-		spEcho("[unit_unstick_staticcon]: " .. str, arg1, arg2, arg3)
-	elseif arg2 then
-		spEcho("[unit_unstick_staticcon]: " .. str, arg1, arg2)
-	elseif arg1 then
-		spEcho("[unit_unstick_staticcon]: " .. str, arg1)
-	else
-		spEcho("[unit_unstick_staticcon]: " .. str)
-	end
+local function DebugEcho(...)
+	spEcho("[unit_staticcon_unsticker]", unpack(arg))
 end
 
 local function GetDistance(unitID, targetID, isReclaim)
@@ -75,7 +65,7 @@ local function GetDistance(unitID, targetID, isReclaim)
 		if debug then DebugEcho("Target doesn't exist?") end
 		return 9999
 	end
-	return ((x2 - x) * (x2 - x)) + ((z2 - z) * (z2 - z))
+	return (x2 - x)^2 + (z2 - z)^2
 end
 
 local function IsObjectCloseEnough(unitID, targetID, cmd) -- Note: build ranges are 2D usually.
@@ -120,7 +110,7 @@ local function HandleUnit(unitID, f)
 	if cmdParam1 and spValidFeatureID(cmdParam1 - Game.maxUnits) then
 		cmdParam1 = cmdParam1 - Game.maxUnits
 	end
-	if debug then DebugEcho(unitID .. ": " .. tostring(cmdID) .. ", " .. tostring(cmdParam1) .. ", " .. tostring(cmdParam2)) end
+	if debug then DebugEcho(unitID .. ": ", cmdID, cmdParam1, cmdParam2) end
 	if cmdID and cmdParam1 and (spValidFeatureID(cmdParam1) or spValidUnitID(cmdParam1)) then
 		if debug then DebugEcho(unitID .. ": Valid command, checking distance.") end
 		if not IsObjectCloseEnough(unitID, cmdParam1, cmdID) then

--- a/LuaRules/Gadgets/unit_unstick_staticcon.lua
+++ b/LuaRules/Gadgets/unit_unstick_staticcon.lua
@@ -127,9 +127,7 @@ end
 function gadget:GameFrame(f)
 	if f%delay == 0 then
 		for id, _ in pairs(IterableMap.Iterator(handled)) do
-			if spValidUnitID(id) then
-				HandleUnit(id)
-			end
+			HandleUnit(id)
 		end
 	end
 end

--- a/LuaRules/Gadgets/unit_unstick_staticcon.lua
+++ b/LuaRules/Gadgets/unit_unstick_staticcon.lua
@@ -1,0 +1,142 @@
+function gadget:GetInfo()
+	return {
+		name      = "Static Con Unsticker",
+		desc      = "Implements Caretaker / rejuvenator unstick.",
+		author    = "Shaman",
+		date      = "4-20-2022",
+		license   = "PD",
+		layer     = 0,
+		enabled   = true,
+	}
+end
+
+if not (gadgetHandler:IsSyncedCode()) then
+	return
+end
+
+local delay = 15
+local debug = false
+
+local handled = {} -- [f] = {[1] = unitID}
+local buildRanges = {} -- [unitDefID] = buildDistance
+
+for i = 1, #UnitDefs do
+	local def = UnitDefs[i]
+	if def.isBuilder and def.customParams.like_structure then
+		buildRanges[i] = def.buildDistance
+	end
+end
+
+--[[local buildRanges = {
+	[UnitDefNames["staticrepair"].id] = UnitDefNames["staticrepair"].buildDistance,
+	[UnitDefNames["staticcon"].id] = UnitDefNames["staticcon"].buildDistance,
+	[UnitDefNames["striderhub"].id] = UnitDefNames["striderhub"].buildDistance,
+}]]
+
+-- Speedups --
+local CMD_INSERT = CMD.INSERT
+local CMD_REPAIR = CMD.REPAIR
+local CMD_RECLAIM = CMD.RECLAIM
+local CMD_RESURRECT = CMD.RESURRECT
+local CMD_REMOVE = CMD.REMOVE
+local spEcho = Spring.Echo
+local spGiveOrderToUnit = Spring.GiveOrderToUnit
+local spValidUnitID = Spring.ValidUnitID
+local spGetGameFrame = Spring.GetGameFrame
+local spGetUnitIsStunned = Spring.GetUnitIsStunned
+local spGetUnitCurrentCommand = Spring.GetUnitCurrentCommand
+local spValidFeatureID = Spring.ValidFeatureID
+local spGetUnitPosition = Spring.GetUnitPosition
+local spGetUnitDefID = Spring.GetUnitDefID
+local spGetFeaturePosition = Spring.GetFeaturePosition
+--local EMPTY = {}
+
+local function DebugEcho(str)
+	spEcho("[unit_staticcon_unsticker]: " .. str)
+end
+
+local function GetDistance(unitID, targetID, isReclaim)
+	local x, _, z = spGetUnitPosition(unitID)
+	local x2, z2
+	if isReclaim then
+		if spValidFeatureID(targetID) then
+			x2, _, z2 = spGetFeaturePosition(targetID)
+		elseif spValidUnitID(targetID) then -- live reclaim
+			x2, _, z2 = spGetUnitPosition(targetID)
+		end
+	else
+		x2, _, z2 = spGetUnitPosition(targetID)
+	end
+	if not x2 then
+		if debug then DebugEcho("Target doesn't exist?") end
+		return 9999
+	end
+	return math.sqrt(((x2 - x) * (x2 - x)) + ((z2 - z) * (z2 - z)))
+end
+
+local function IsObjectCloseEnough(unitID, targetID, cmd) -- Note: build ranges are 2D usually.
+	if cmd == CMD_REPAIR and spValidUnitID(targetID) then
+		local dist = GetDistance(unitID, targetID, false)
+		if debug then
+			DebugEcho(unitID .. ": Distance: " .. dist .. " (Build Range: " .. buildRanges[spGetUnitDefID(unitID)] .. ")")
+		end
+		return dist <= buildRanges[spGetUnitDefID(unitID)]
+	elseif (cmd == CMD_RECLAIM or cmd == CMD_RESURRECT) and spValidFeatureID(targetID) then
+		local dist = GetDistance(unitID, targetID, true)
+		if debug then
+			DebugEcho(unitID .. ": Distance: " .. dist .. " (Build Range: " .. buildRanges[spGetUnitDefID(unitID)] .. ")")
+		end
+		return dist <= buildRanges[spGetUnitDefID(unitID)]
+	else
+		return false
+	end
+end
+
+local function HandleUnit(unitID, f)
+	if spValidUnitID(unitID) then
+		local _, _, unbuilt = spGetUnitIsStunned(unitID)
+		if not unbuilt then -- if caretaker is reversed built, UnitFinished should retrigger to readd it, though nobody really unbuilds caretakers.
+			local cmdID, _, cmdTag, cmdParam1, cmdParam2, cmdParam3, cmdParam4, cmdParam5 = spGetUnitCurrentCommand(unitID)
+			if cmdParam1 and spValidFeatureID(cmdParam1 - Game.maxUnits) then
+				cmdParam1 = cmdParam1 - Game.maxUnits
+			end
+			if debug then DebugEcho(unitID .. ": " .. tostring(cmdID) .. ", " .. tostring(cmdParam1) .. ", " .. tostring(cmdParam2)) end
+			if cmdID and cmdParam1 and (spValidFeatureID(cmdParam1) or spValidUnitID(cmdParam1)) then
+				if debug then DebugEcho(unitID .. ": Valid command, checking distance.") end
+				if not IsObjectCloseEnough(unitID, cmdParam1, cmdID) then
+					if debug then DebugEcho(unitID .. ": Command dropped (Out of Range)") end
+					spGiveOrderToUnit(unitID, CMD_REMOVE, cmdTag, 0)
+					if cmdParam5 and cmdParam5 ~= buildRanges[spGetUnitDefID(unitID)] then -- this was an area command added by the user.
+						if debug then DebugEcho("Readding area command: " .. tostring(cmdParam2) .. ", " .. tostring(cmdParam3) .. ", " .. tostring(cmdParam4) .. ", " .. tostring(cmdParam5)) end
+						spGiveOrderToUnit(unitID, CMD_INSERT, {0, cmdID, CMD.OPT_SHIFT, cmdParam2, cmdParam3, cmdParam4, cmdParam5}, CMD.OPT_ALT) -- reissue the command (just in case)
+					end
+				end
+			elseif debug then
+				DebugEcho("Invalid command handled for " .. unitID)
+			end
+			handled[f + delay] = handled[f + delay] or {} -- check back in 15 frames.
+			handled[f + delay][#handled[f + delay] + 1] = unitID
+		elseif debug then 
+			DebugEcho(unitID .. ": Exited drop (Reverse Built)")
+		end
+	end
+end
+
+function gadget:GameFrame(f)
+	if handled[f] then
+		for i = 1, #handled[f] do
+			if debug then DebugEcho("Check " .. handled[f][i]) end
+			HandleUnit(handled[f][i], f)
+		end
+		handled[f] = nil
+	end
+end
+
+function gadget:UnitFinished(unitID, unitDefID, unitTeam)
+	if buildRanges[unitDefID] then
+		if debug then DebugEcho(unitID .. ": Added to check loop.") end
+		local f = spGetGameFrame() + delay
+		handled[f] = handled[f] or {}
+		handled[f][#handled[f] + 1] = unitID
+	end
+end

--- a/LuaRules/Gadgets/unit_unstick_staticcon.lua
+++ b/LuaRules/Gadgets/unit_unstick_staticcon.lua
@@ -45,8 +45,18 @@ local spGetUnitDefID = Spring.GetUnitDefID
 local spGetFeaturePosition = Spring.GetFeaturePosition
 --local EMPTY = {}
 
-local function DebugEcho(str)
-	spEcho("[unit_unstick_staticcon]: " .. str)
+local function DebugEcho(str, arg1, arg2, arg3, arg4)
+	if arg4 then
+		spEcho("[unit_unstick_staticcon]: " .. str, arg1, arg2, arg3, arg4)
+	elseif arg3 then
+		spEcho("[unit_unstick_staticcon]: " .. str, arg1, arg2, arg3)
+	elseif arg2 then
+		spEcho("[unit_unstick_staticcon]: " .. str, arg1, arg2)
+	elseif arg1 then
+		spEcho("[unit_unstick_staticcon]: " .. str, arg1)
+	else
+		spEcho("[unit_unstick_staticcon]: " .. str)
+	end
 end
 
 local function GetDistance(unitID, targetID, isReclaim)

--- a/LuaRules/Gadgets/unit_unstick_staticcon.lua
+++ b/LuaRules/Gadgets/unit_unstick_staticcon.lua
@@ -1,37 +1,31 @@
+if not (gadgetHandler:IsSyncedCode()) then
+	return
+end
+
 function gadget:GetInfo()
 	return {
 		name      = "Static Con Unsticker",
-		desc      = "Implements Caretaker / rejuvenator unstick.",
+		desc      = "Ensures static constructors do not get stuck on tasks outside their build range",
 		author    = "Shaman",
-		date      = "4-20-2022",
+		date      = "2022-04-20",
 		license   = "PD",
 		layer     = 0,
 		enabled   = true,
 	}
 end
 
-if not (gadgetHandler:IsSyncedCode()) then
-	return
-end
-
 local delay = 15
 local debug = false
 
 local handled = {} -- [f] = {[1] = unitID}
-local buildRanges = {} -- [unitDefID] = buildDistance
+local buildRangesSq = {} -- [unitDefID] = buildDistance
 
 for i = 1, #UnitDefs do
 	local def = UnitDefs[i]
 	if def.isBuilder and def.customParams.like_structure then
-		buildRanges[i] = def.buildDistance
+		buildRangesSq[i] = def.buildDistance^2
 	end
 end
-
---[[local buildRanges = {
-	[UnitDefNames["staticrepair"].id] = UnitDefNames["staticrepair"].buildDistance,
-	[UnitDefNames["staticcon"].id] = UnitDefNames["staticcon"].buildDistance,
-	[UnitDefNames["striderhub"].id] = UnitDefNames["striderhub"].buildDistance,
-}]]
 
 -- Speedups --
 local CMD_INSERT = CMD.INSERT
@@ -52,7 +46,7 @@ local spGetFeaturePosition = Spring.GetFeaturePosition
 --local EMPTY = {}
 
 local function DebugEcho(str)
-	spEcho("[unit_staticcon_unsticker]: " .. str)
+	spEcho("[unit_unstick_staticcon]: " .. str)
 end
 
 local function GetDistance(unitID, targetID, isReclaim)
@@ -71,55 +65,67 @@ local function GetDistance(unitID, targetID, isReclaim)
 		if debug then DebugEcho("Target doesn't exist?") end
 		return 9999
 	end
-	return math.sqrt(((x2 - x) * (x2 - x)) + ((z2 - z) * (z2 - z)))
+	return ((x2 - x) * (x2 - x)) + ((z2 - z) * (z2 - z))
 end
 
 local function IsObjectCloseEnough(unitID, targetID, cmd) -- Note: build ranges are 2D usually.
-	if cmd == CMD_REPAIR and spValidUnitID(targetID) then
-		local dist = GetDistance(unitID, targetID, false)
-		if debug then
-			DebugEcho(unitID .. ": Distance: " .. dist .. " (Build Range: " .. buildRanges[spGetUnitDefID(unitID)] .. ")")
-		end
-		return dist <= buildRanges[spGetUnitDefID(unitID)]
-	elseif (cmd == CMD_RECLAIM or cmd == CMD_RESURRECT) and spValidFeatureID(targetID) then
-		local dist = GetDistance(unitID, targetID, true)
-		if debug then
-			DebugEcho(unitID .. ": Distance: " .. dist .. " (Build Range: " .. buildRanges[spGetUnitDefID(unitID)] .. ")")
-		end
-		return dist <= buildRanges[spGetUnitDefID(unitID)]
-	else
-		return false
+	local isReclaim = (cmd == CMD_RECLAIM or cmd == CMD_RESURRECT)
+	local dist = GetDistance(unitID, targetID, isReclaim)
+	local buildRange = buildRangesSq[spGetUnitDefID(unitID)]
+	if debug then
+		DebugEcho(unitID, ": Distance: ", dist, " (Build Range: ", buildRange, ")")
 	end
+	return dist <= buildRange
 end
 
+--[[Some documentation with regards to this HandleUnit function:
+When patrol orders for cons encounters reclaim or repair, it sends the following cmd params:
+[1] = unitID / featureID
+[2] = the patroler's X position
+[3] = the patroler's Y position
+[4] = the patroler's Z position
+[5] = the patroler's buildrange
+
+A normal user added single unit reclaim would have only look like this:
+[1] = Unit / FeatureID
+
+OR (after finding a feature)
+[1] = unitID / featureID
+[2] = center X
+[3] = center Y
+[4] = center Z
+[5] = radius
+]]
+
 local function HandleUnit(unitID, f)
-	if spValidUnitID(unitID) then
-		local _, _, unbuilt = spGetUnitIsStunned(unitID)
-		if not unbuilt then -- if caretaker is reversed built, UnitFinished should retrigger to readd it, though nobody really unbuilds caretakers.
-			local cmdID, _, cmdTag, cmdParam1, cmdParam2, cmdParam3, cmdParam4, cmdParam5 = spGetUnitCurrentCommand(unitID)
-			if cmdParam1 and spValidFeatureID(cmdParam1 - Game.maxUnits) then
-				cmdParam1 = cmdParam1 - Game.maxUnits
-			end
-			if debug then DebugEcho(unitID .. ": " .. tostring(cmdID) .. ", " .. tostring(cmdParam1) .. ", " .. tostring(cmdParam2)) end
-			if cmdID and cmdParam1 and (spValidFeatureID(cmdParam1) or spValidUnitID(cmdParam1)) then
-				if debug then DebugEcho(unitID .. ": Valid command, checking distance.") end
-				if not IsObjectCloseEnough(unitID, cmdParam1, cmdID) then
-					if debug then DebugEcho(unitID .. ": Command dropped (Out of Range)") end
-					spGiveOrderToUnit(unitID, CMD_REMOVE, cmdTag, 0)
-					if cmdParam5 and cmdParam5 ~= buildRanges[spGetUnitDefID(unitID)] then -- this was an area command added by the user.
-						if debug then DebugEcho("Readding area command: " .. tostring(cmdParam2) .. ", " .. tostring(cmdParam3) .. ", " .. tostring(cmdParam4) .. ", " .. tostring(cmdParam5)) end
-						spGiveOrderToUnit(unitID, CMD_INSERT, {0, cmdID, CMD.OPT_SHIFT, cmdParam2, cmdParam3, cmdParam4, cmdParam5}, CMD.OPT_ALT) -- reissue the command (just in case)
-					end
-				end
-			elseif debug then
-				DebugEcho("Invalid command handled for " .. unitID)
-			end
-			handled[f + delay] = handled[f + delay] or {} -- check back in 15 frames.
-			handled[f + delay][#handled[f + delay] + 1] = unitID
-		elseif debug then 
-			DebugEcho(unitID .. ": Exited drop (Reverse Built)")
-		end
+	if not spValidUnitID(unitID) then
+		return
 	end
+	local _, _, unbuilt = spGetUnitIsStunned(unitID)
+	if unbuilt then -- if caretaker is reversed built, UnitFinished should retrigger to readd it, though nobody really unbuilds caretakers.
+		if debug then DebugEcho(unitID .. ": Exited drop (Reverse Built)") end
+		return
+	end
+	local cmdID, _, cmdTag, cmdParam1, cmdParam2, cmdParam3, cmdParam4, cmdParam5 = spGetUnitCurrentCommand(unitID)
+	if cmdParam1 and spValidFeatureID(cmdParam1 - Game.maxUnits) then
+		cmdParam1 = cmdParam1 - Game.maxUnits
+	end
+	if debug then DebugEcho(unitID .. ": " .. tostring(cmdID) .. ", " .. tostring(cmdParam1) .. ", " .. tostring(cmdParam2)) end
+	if cmdID and cmdParam1 and (spValidFeatureID(cmdParam1) or spValidUnitID(cmdParam1)) then
+		if debug then DebugEcho(unitID .. ": Valid command, checking distance.") end
+		if not IsObjectCloseEnough(unitID, cmdParam1, cmdID) then
+			if debug then DebugEcho(unitID .. ": Command dropped (Out of Range)") end
+			spGiveOrderToUnit(unitID, CMD_REMOVE, cmdTag, 0)
+			if cmdParam5 and cmdParam5 ~= buildRangesSq[spGetUnitDefID(unitID)] then -- this was an area command added by the user.
+				if debug then DebugEcho(unitID, cmdID, cmdParam1, cmdParam2) end
+				spGiveOrderToUnit(unitID, CMD_INSERT, {0, cmdID, CMD.OPT_SHIFT, cmdParam2, cmdParam3, cmdParam4, cmdParam5}, CMD.OPT_ALT) -- reissue the command (just in case)
+			end
+		end
+	elseif debug then
+		DebugEcho("Invalid command handled for " .. unitID)
+	end
+	handled[f + delay] = handled[f + delay] or {} -- check back in 15 frames.
+	handled[f + delay][#handled[f + delay] + 1] = unitID
 end
 
 function gadget:GameFrame(f)
@@ -133,7 +139,7 @@ function gadget:GameFrame(f)
 end
 
 function gadget:UnitFinished(unitID, unitDefID, unitTeam)
-	if buildRanges[unitDefID] then
+	if buildRangesSq[unitDefID] then
 		if debug then DebugEcho(unitID .. ": Added to check loop.") end
 		local f = spGetGameFrame() + delay
 		handled[f] = handled[f] or {}


### PR DESCRIPTION
Caretakers occasionally will get stuck reclaiming (typically when they catch onto a flying wreck) something out of range. This gadget introduces a 2hz check for if a feature (or unit) is range of a caretaker.

Fixes #4640.