### PR TITLE
Fix custom formations error caused by selecting and giving orders to units in fog

### DIFF
--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -990,7 +990,7 @@ function widget:CommandsChanged()
 		local unitDefID = Spring.GetUnitDefID(unitID)
 		local ud = UnitDefs[unitDefID]
 
-		if ud.canMove and not ud.isFactory and not (ud.springCategories.fixedwing) then
+		if ud and ud.canMove and not ud.isFactory and not (ud.springCategories.fixedwing) then
 			local rank = formationRank[unitID] or defaultRank[unitDefID] or 2
 			local customCommands = widgetHandler.customCommands
 			formationRankCmdDesc.params[1] = rank


### PR DESCRIPTION
This is more developer QoL than anything and is a pretty simple fix anyways, so thought I'd pr it.