### PR TITLE
Hotfix: Disable proximity targetting on Starlight, DRP, Bertha.

### DIFF
--- a/units/mahlazer.lua
+++ b/units/mahlazer.lua
@@ -22,7 +22,7 @@ return { mahlazer = {
     midposoffset   = [[0 0 0]],
     select_no_rotate   = [[1]], -- tells selection widgets to treat the unit as if it has no rotation.
     bait_level_default = 0,
-	want_precise_proximity_targetting = 1,
+	-- want_precise_proximity_targetting = 1, --hotfix 31/05/22
     draw_blueprint_facing = 1,
 
     keeptooltip    = [[any string I want]],

--- a/units/raveparty.lua
+++ b/units/raveparty.lua
@@ -19,7 +19,7 @@ return { raveparty = {
     modelradius    = [[35]],
     bait_level_default = 0,
     draw_blueprint_facing = 1,
-    want_proximity_targetting = 1,
+    --want_proximity_targetting = 1, --hotfix 31/05/22
     speed_bar = 1,
 
     keeptooltip    = [[any string I want]],

--- a/units/staticheavyarty.lua
+++ b/units/staticheavyarty.lua
@@ -17,7 +17,7 @@ return { staticheavyarty = {
 
   customParams                  = {
     bait_level_default = 1,
-    want_proximity_targetting = 1,
+    --want_proximity_targetting = 1, --hotfix 31/05/22
     aimposoffset = [[0 50 -7]],
     modelradius    = [[35]],
     selectionscalemult = 1,


### PR DESCRIPTION
I don't have time to understand and fix the widget right now, but the game shouldn't be left in this state.