### PR TITLE
Add widow to unit marker

### DIFF
--- a/LuaUI/Configs/unit_marker.lua
+++ b/LuaUI/Configs/unit_marker.lua
@@ -7,6 +7,7 @@ local unitlistNames = {
 	cloaksnipe = MARK_EACH,
 	cloakheavyraid = MARK_EACH,
 	cloakjammer = MARK_EACH,
+	spiderantiheavy = MARK_EACH,
 
 	energyheavygeo = DEFAULT,
 	energyfusion = DEFAULT,


### PR DESCRIPTION
What the title says.
As an aside, would setting the cloaked striders like ultimatum and scorp to "MARK_EACH" be a worthwhile change too? Only marking them once could be annoying if you've already marked them once before, but they showed up again somewhere you weren't paying attention to.