### PR TITLE
Commanders

### DIFF
--- a/scripts/dynassault.lua
+++ b/scripts/dynassault.lua
@@ -236,9 +236,14 @@ function script.AimWeapon(num, heading, pitch)
 		Signal(SIG_LASER)
 		SetSignalMask(SIG_LASER)
 		isLasering = true
-		Turn(rarm, x_axis, math.rad(0) -pitch, ARM_SPEED_PITCH)
+		if pitch > math.rad(-45) then
+			Turn(rarm, x_axis, -pitch, ARM_SPEED_PITCH)
+			Turn(rhand, x_axis, math.rad(0), ARM_SPEED_PITCH)
+		else
+			Turn(rarm, x_axis, -math.rad(18), ARM_SPEED_PITCH)
+			Turn(rhand, x_axis, math.rad(18) -pitch, ARM_SPEED_PITCH)
+		end
 		Turn(torso, y_axis, heading, TORSO_SPEED_YAW)
-		Turn(rhand, x_axis, math.rad(0), ARM_SPEED_PITCH)
 		WaitForTurn(torso, y_axis)
 		WaitForTurn(rarm, x_axis)
 		StartThread(RestoreLaser)
@@ -250,11 +255,18 @@ function script.AimWeapon(num, heading, pitch)
 		Signal(SIG_DGUN)
 		SetSignalMask(SIG_DGUN)
 		isDgunning = true
-		Turn(larm, x_axis, math.rad(0) -pitch, ARM_SPEED_PITCH)
+		if pitch > math.rad(-45) then
+			Turn(larm, x_axis, -pitch, ARM_SPEED_PITCH)
+			Turn(lnanohand, x_axis, math.rad(0), ARM_SPEED_PITCH)
+		else
+			Turn(larm, x_axis, -math.rad(18), ARM_SPEED_PITCH)
+			Turn(lnanohand, x_axis, math.rad(18) -pitch, ARM_SPEED_PITCH)
+		end
+		--Turn(larm, x_axis, math.min(math.rad(-18), -pitch), ARM_SPEED_PITCH)
+		--Turn(lnanohand, x_axis, math.max(0, math.rad(18) -pitch), ARM_SPEED_PITCH)
 		Turn(torso, y_axis, heading, TORSO_SPEED_YAW)
-		Turn(lnanohand, x_axis, math.rad(0), ARM_SPEED_PITCH)
 		WaitForTurn(torso, y_axis)
-		WaitForTurn(rarm, x_axis)
+		WaitForTurn(lnanohand, x_axis)
 		StartThread(RestoreDGun)
 		return true
 	elseif weaponNum == 3 then

--- a/scripts/dynrecon.lua
+++ b/scripts/dynrecon.lua
@@ -375,7 +375,7 @@ function script.StopMoving()
 end
 
 function script.AimFromWeapon(num)
-	return pelvis
+	return head
 end
 
 local function AimRifle(heading, pitch, isDgun)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8924181/176038819-2903deae-9f09-4ebe-bb52-b38b28302b99.png)
a change to recon comander, hopefully to stop it from aiming it's beamlazer above other comander's heads in a cqc duel(will aim at enemy midpoint from head instead of midpoint to midpoint, causing sometimes a nasty case of https://github.com/ZeroK-RTS/Zero-K/issues/4310)

A change to guardian com that should only change it's behavior when it aims down a slope or sheer cliff(kill teradowned mexes, an unasked for change)