### PR TITLE
Added a gadget to fix broken geos

### DIFF
--- a/LuaRules/Gadgets/feature_geofixer.lua
+++ b/LuaRules/Gadgets/feature_geofixer.lua
@@ -17,8 +17,8 @@ end
 local geoDef = FeatureDefNames["geovent"].id
 local geos = {}
 
-function gadget:GameStart()
-	if #geos > 0 then
+function gadget:GameStart() -- Note: Geos need to be movectrl'd after game starts 
+	if #geos > 0 then -- (I don't know why, but when testing in FeatureCreated, it would not apply the fix)
 		for i = 1, #geos do
 			local featureID = geos[i]
 			local x, _, z = Spring.GetFeaturePosition(featureID)

--- a/LuaRules/Gadgets/feature_geofixer.lua
+++ b/LuaRules/Gadgets/feature_geofixer.lua
@@ -1,0 +1,41 @@
+if not gadgetHandler:IsSyncedCode() then
+	return
+end
+
+function gadget:GetInfo()
+	return {
+		name      = "Geo fixer",
+		desc      = "Fixes geothermals",
+		author    = "Shaman",
+		date      = "30 July, 2022",
+		license   = "CC-0",
+		layer     = -1000, -- low enough to catch any geo creation.
+		enabled   = true,
+	}
+end
+
+local geoDef = FeatureDefNames["geovent"].id
+local geos = {}
+
+function gadget:GameStart()
+	if #geos > 0 then
+		for i = 1, #geos do
+			local featureID = geos[i]
+			local x, _, z = Spring.GetFeaturePosition(featureID)
+			local gy = Spring.GetGroundHeight(x, z)
+			--Spring.Echo("[geofixer]: Setting up for " .. featureID)
+			Spring.SetFeatureMoveCtrl(featureID, true)
+			Spring.SetFeaturePosition(featureID, x, gy, z, true)
+			Spring.SetFeatureMoveCtrl(featureID, false, 0, 1, 0, 0, 1, 0, 0, 1, 0) -- unlock y axis movement, so geo can move with terrain
+		end
+	end
+	gadgetHandler:RemoveGadget()
+end
+
+function gadget:FeatureCreated(featureID, allyTeamID)
+	local defID = Spring.GetFeatureDefID(featureID)
+	--Spring.Echo("FeatureCreated: " .. FeatureDefs[defID].name)
+	if defID == geoDef then -- this is a geo.
+		geos[#geos + 1] = featureID
+	end
+end


### PR DESCRIPTION
Currently some maps with featureplacer have their geos stuck. This code fixes this by allowing geos to move on the y axis with terrain. Does not trigger on maps with pre-placed features (which is nice). An improvement could be to have it only trigger on maps that need it.

Notes:
Tested on https://zero-k.info/Maps/Detail/59707 and https://zero-k.info/Maps/Detail/58911 . See: #ZKMap.