### PR TITLE
⚙️ Change report string delimiter to `;`

### DIFF
--- a/LuaUI/Widgets/gui_chili_share.lua
+++ b/LuaUI/Widgets/gui_chili_share.lua
@@ -633,7 +633,7 @@ local function ReportPlayer(subject)
 	local seconds = math.floor(Spring.GetGameFrame()/30)
 	local minutes = math.floor(seconds/60)
 	extraText = extraText .. " at " .. string.format("%d:%02d", minutes, seconds - 60*minutes)
-	Spring.SendLuaMenuMsg("reportUser_" .. subject.name .. "_" .. extraText)
+	Spring.SendLuaMenuMsg("reportUser;" .. subject.name .. ";" .. extraText)
 end
 
 local function GiveUnit(target)


### PR DESCRIPTION
People and maps can have `_` in their names.