### PR TITLE
📝 Fix #4504, less plain kamikaze award name

### DIFF
--- a/LuaRules/Configs/award_names.lua
+++ b/LuaRules/Configs/award_names.lua
@@ -16,7 +16,7 @@ return {
 	rezz    = 'Vile Necromancer',
 	vet     = 'Decorated Veteran',
 	ouch    = 'Big Purple Heart',
-	kam     = 'Kamikaze Award',
+	kam     = 'Blaze of Glory',
 	comm    = 'Master and Commander',
 	mex     = 'Mineral Prospector',
 	mexkill = 'Loot & Pillage',


### PR DESCRIPTION
Kamikaze Award → Blaze of Glory. Fixes #4504