### PR TITLE
amph factory not as targetable when underwater

### DIFF
--- a/units/factoryamph.lua
+++ b/units/factoryamph.lua
@@ -38,7 +38,7 @@ return { factoryamph = {
 
   customParams     = {
     ploppable = 1,
-    modelradius    = [[60]],
+    modelradius    = [[42]],
     aimposoffset   = [[0 0 -26]],
     midposoffset   = [[0 0 -10]],
     sortName = [[8]],


### PR DESCRIPTION
amph factory targetable at/above y=-48. Some direct fire units will fire but not hit the factory when at a narrow angle to the xz plane, but less egregiously than before. Other units like Crusader will promote needless player micro attacking the water surface above the factory.

in responce to https://github.com/ZeroK-RTS/Zero-K/issues/4746