### PR TITLE
Fix Pyro's flamethrower

### DIFF
--- a/scripts/jumpraid.lua
+++ b/scripts/jumpraid.lua
@@ -319,6 +319,7 @@ local function RestoreAfterDelay()
 	Turn(low_head, y_axis, 0, math.rad(200))
 	Turn(low_head, x_axis, 0, math.rad(45))
 	Move(up_head, y_axis, 0, LINEAR_SPEED/3)
+	Move(low_head, y_axis, 0, LINEAR_SPEED/3)
 	firing = false
 end
 
@@ -330,7 +331,8 @@ function script.AimWeapon(num, heading, pitch)
 	--turn head, open mouth/limbs
 	Turn(low_head, y_axis, heading, math.rad(650)) -- left-right
 	Turn(low_head, x_axis, -pitch, math.rad(200)) --up-down
-	Move(up_head, y_axis, 1, LINEAR_SPEED/2)
+	Move(up_head, y_axis, 2.1895, LINEAR_SPEED/2)
+	Move(low_head, y_axis, -2, LINEAR_SPEED/2)
 	WaitForTurn(low_head, y_axis)
 	WaitForTurn(low_head, x_axis)
 	StartThread(RestoreAfterDelay)


### PR DESCRIPTION
Pyro's flamethrower animation doesn't fully reveal the flamethrower on the model. This PR fixes this by adjusting the position of the lower head and upper head to reveal that sweet flamethrower underneath.

![image](https://user-images.githubusercontent.com/48730089/186888119-507bed8e-e004-4425-98eb-f84f87c298e8.png)
