### PR TITLE
Fix caretaker guard orders

### DIFF
--- a/LuaRules/Gadgets/unit_unstick_staticcon.lua
+++ b/LuaRules/Gadgets/unit_unstick_staticcon.lua
@@ -111,7 +111,7 @@ local function HandleUnit(unitID)
 	if debugMode then
 		Spring.Echo(unitID .. ": ", cmdID, cmdParam1, cmdParam2)
 	end
-	if cmdID and cmdParam1 and (spValidFeatureID(cmdParam1) or spValidUnitID(cmdParam1)) then
+	if cmdID and (cmdID == CMD_RECLAIM or cmdID == CMD_RESURRECT) and cmdParam1 and (spValidFeatureID(cmdParam1) or spValidUnitID(cmdParam1)) then
 		if debugMode then
 			Spring.Echo(unitID .. ": Valid command, checking distance.")
 		end


### PR DESCRIPTION
The caretaker unsticker gadget assumes all commands are reclaim or resurrect.

I haven't tested this in the wild via FW yet, but lab testing shows caretakers no longer drop guard commands after https://github.com/Arch-Shaman/ZK-Futurewars-Mod/commit/6f94610f25c60d3fe09808e4b666bc7937cd12af