### PR TITLE
✨ Krow lasers now look like Redback

### DIFF
--- a/scripts/gunshipkrow.lua
+++ b/scripts/gunshipkrow.lua
@@ -111,7 +111,7 @@ local function DeathAnim()
 				EmitSfx(jets[i], 258)
 			end
 			if count % 18 == 0 then
-				EmitSfx(jets[index], 1025)
+				EmitSfx(jets[index], 1024)
 				index = index + 1
 				if index > #jets then
 					index = 1
@@ -318,13 +318,6 @@ function script.AimWeapon(num, heading, pitch)
 	StartThread(RestoreAfterDelay)
 	return true
 end
-
-function script.FireWeapon(num)
-	if num ~= 3 then
-		EmitSfx(gunpoints[num].fire, 1024)
-	end
-end
-
 
 function script.Killed(recentDamage, maxHealth)
 	local severity = recentDamage/maxHealth

--- a/units/gunshipkrow.lua
+++ b/units/gunshipkrow.lua
@@ -46,7 +46,6 @@ return { gunshipkrow = {
   sfxtypes               = {
 
     explosiongenerators = {
-      [[custom:BEAMWEAPON_MUZZLE_BIG_RED]],
       [[custom:DOT_Pillager_Explo]],
     },
 
@@ -95,43 +94,44 @@ return { gunshipkrow = {
   weaponDefs             = {
 
     KROWLASER  = {
-      name                    = [[Laserbeam]],
+      name                    = [[Auto Particle Beam]],
       areaOfEffect            = 8,
       avoidFeature            = false,
       canattackground         = true,
       collideFriendly         = false,
+      beamDecay               = 0.85,
+      beamTime                = 1/30,
+      beamttl                 = 45,
       coreThickness           = 0.5,
       craterBoost             = 0,
       craterMult              = 0,
 
-      customParams        = {
-        light_camera_height = 1800,
-        light_radius = 160,
+      customParams            = {
+        light_color = [[0.9 0.22 0.22]],
+        light_radius = 80,
       },
 
       damage                  = {
-        default = 45,
+        default = 67.5,
       },
 
-      duration                = 0.02,
-      explosionGenerator      = [[custom:BEAMWEAPON_HIT_RED]],
+      explosionGenerator      = [[custom:flash1red]],
       fireStarter             = 50,
       impactOnly              = true,
       impulseBoost            = 0,
-      impulseFactor           = 0.4,
+      impulseFactor           = 0,
       interceptedByShieldType = 1,
+      laserFlareSize          = 7,
+      minIntensity            = 1,
       range                   = 395,
-      reloadtime              = 0.2,
+      reloadtime              = 0.3,
       rgbColor                = [[1 0 0]],
-      soundHit                = [[weapon/laser/lasercannon_hit]],
-      soundStart              = [[weapon/laser/heavylaser_fire2]],
-      soundStartVolume        = 0.7,
-      soundTrigger            = true,
-      thickness               = 3.25,
+      soundStart              = [[weapon/laser/mini_laser]],
+      soundStartVolume        = 6,
+      thickness               = 5,
       tolerance               = 10000,
       turret                  = true,
-      weaponType              = [[LaserCannon]],
-      weaponVelocity          = 2370,
+      weaponType              = [[BeamLaser]],
     },
 
     CLUSTERBOMB = {


### PR DESCRIPTION
How about this? After the recent buffs it now has laser closer (in power, role, range, damage) to somewhere between Mace and Commander, but it still uses the red pew visuals, which is used for weapons with roles all over the place (Bandit's low intensity pew, Razor's AA pew, Krow's powerful pew). It's also somewhat hard to see where the shots are going given how fast they move.

Sad effects:
 * loses unique pew sound. On the other hand hearing Mace is also (already) a "shit's melting, yo" audio cue so maybe it's fine?
 * minor balance change, probably mostly vs Swifts or Fleas. Probably doesn't matter at this weight.
 * balance change was already stabled so it's a bit late.

![image](https://user-images.githubusercontent.com/2573076/203184489-04dbcce6-7000-4291-a0d3-1dd871018b80.png)

