### PR TITLE
Add support for MiniMapCanFlip

### DIFF
--- a/LuaUI/Headers/minimap_utilities.lua
+++ b/LuaUI/Headers/minimap_utilities.lua
@@ -1,0 +1,12 @@
+local function getMiniMapFlipped()
+	if ((not Spring.GetMiniMapRotation) or
+	    (Spring.GetConfigInt("MiniMapCanFlip", 0) == 0)) then
+		return false
+	end
+
+	local rot = Spring.GetMiniMapRotation()
+
+	return rot > math.pi/2 and rot <= 3 * math.pi/2;
+end
+
+return { getMiniMapFlipped = getMiniMapFlipped }

--- a/LuaUI/Widgets/api_set_springsettings.lua
+++ b/LuaUI/Widgets/api_set_springsettings.lua
@@ -12,6 +12,7 @@ function widget:GetInfo()
 end
 
 function widget:Initialize()
+	Spring.SetConfigInt("MiniMapCanFlip", 1)
 	Spring.SetConfigInt("RotateLogFiles", 1)
 	Spring.SendCommands("maxviewrange 100000")
 	Spring.SendCommands("minviewrange 0")

--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -14,6 +14,8 @@ end
 
 VFS.Include("LuaRules/Configs/customcmds.h.lua")
 
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
+
 local formationRank = {}
 local defaultRank = {}
 
@@ -1190,8 +1192,14 @@ function widget:DrawInMiniMap()
 
 	glPushMatrix()
 		glLoadIdentity()
-		glTranslate(0, 1, 0)
-		glScale(1 / mapSizeX, -1 / mapSizeZ, 1)
+
+		if GetMiniMapFlipped() then
+			glTranslate(1, 0, 0)
+			glScale(-1 / mapSizeX, 1 / mapSizeZ, 1)
+		else
+			glTranslate(0, 1, 0)
+			glScale(1 / mapSizeX, -1 / mapSizeZ, 1)
+		end
 
 		DrawFormationLines(tVertsMinimap, 1)
 	glPopMatrix()

--- a/LuaUI/Widgets/cmd_factory_plate_placer.lua
+++ b/LuaUI/Widgets/cmd_factory_plate_placer.lua
@@ -19,6 +19,7 @@ end
 
 include("keysym.lua")
 VFS.Include("LuaRules/Utilities/glVolumes.lua")
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
 include("LuaRules/Configs/customcmds.h.lua")
 
 local spGetActiveCommand = Spring.GetActiveCommand
@@ -455,8 +456,13 @@ function widget:DrawInMiniMap(minimapX, minimapY)
 		mx, mz = SnapBuildToGrid(mx, mz, buildPlateDefID)
 	end
 	
-	glTranslate(0,minimapY,0)
-	glScale(minimapX/mapX, -minimapY/mapZ, 1)
+	if GetMiniMapFlipped() then
+		glTranslate(minimapY, 0, 0)
+		glScale(-minimapX/mapX, minimapY/mapZ, 1)
+	else
+		glTranslate(0, minimapY, 0)
+		glScale(minimapX/mapX, -minimapY/mapZ, 1)
+	end
 	
 	local drawn = false
 	for unitID, data in IterableMap.Iterator(factories) do

--- a/LuaUI/Widgets/cmd_mex_placement.lua
+++ b/LuaUI/Widgets/cmd_mex_placement.lua
@@ -16,6 +16,7 @@ end
 
 VFS.Include("LuaRules/Configs/customcmds.h.lua")
 local _, _, GetAllyTeamOctant = VFS.Include("LuaUI/Headers/startbox_utilities.lua")
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
 include("keysym.lua")
 
 ------------------------------------------------------------
@@ -1344,8 +1345,15 @@ function widget:DrawInMiniMap(minimapX, minimapY)
 	end
 	if drawMexSpots or WG.showeco_always_mexes then
 		glPushMatrix()
-		glTranslate(0,minimapY,0)
-		glScale(minimapX/mapX, -minimapY/mapZ, 1)
+
+		if GetMiniMapFlipped() then
+			glTranslate(minimapY, 0, 0)
+			glScale(-minimapX/mapX, minimapY/mapZ, 1)
+		else
+			glTranslate(0, minimapY, 0)
+			glScale(minimapX/mapX, -minimapY/mapZ, 1)
+		end
+
 		glLighting(false)
 
 		glCallList(minimapDrawList)

--- a/LuaUI/Widgets/gui_antinuke_coverage.lua
+++ b/LuaUI/Widgets/gui_antinuke_coverage.lua
@@ -39,6 +39,7 @@ end
 --------------------------------------------------------------------------------
 
 local GetNukeIntercepted = VFS.Include("LuaRules/Gadgets/Include/GetNukeIntercepted.lua", nil, VFS.GAME)
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
 
 local enemyInt = {}
 local enemyNuke = {}
@@ -513,28 +514,28 @@ end
 
 
 local function DrawMinimap(minimapX, minimapY)
-	if drawNuke then
-		glPushMatrix()
-		glTranslate(0,minimapY,0)
+	if not (drawNuke or drawAnti) then return end
+
+	glPushMatrix()
+
+	if GetMiniMapFlipped() then
+		glTranslate(minimapY, 0, 0)
+		glScale(-minimapX/mapX, minimapY/mapZ, 1)
+	else
+		glTranslate(0, minimapY, 0)
 		glScale(minimapX/mapX, -minimapY/mapZ, 1)
-		
-		DrawEnemyInterceptors(true)
-		
-		glLineWidth(1)
-		glColor(1, 1, 1, 1)
-		
-		glPopMatrix()
-	elseif drawAnti then
-		glPushMatrix()
-		glTranslate(0,minimapY,0)
-		glScale(minimapX/mapX, -minimapY/mapZ, 1)
-		
-		DrawAllyInterceptors(true)
-		glLineWidth(1)
-		glColor(1, 1, 1, 1)
-		
-		glPopMatrix()
 	end
+
+	if drawNuke then
+		DrawEnemyInterceptors(true)
+	elseif drawAnti then
+		DrawAllyInterceptors(true)
+	end
+
+	glLineWidth(1)
+	glColor(1, 1, 1, 1)
+
+	glPopMatrix()
 end
 
 function widget:DrawInMiniMap(minimapX, minimapY)

--- a/LuaUI/Widgets/gui_custom_markers.lua
+++ b/LuaUI/Widgets/gui_custom_markers.lua
@@ -92,6 +92,8 @@ for name, color in pairs(colorPresets) do
 	end
 end
 
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
+
 ----------------------------------------------------------------
 --speedups
 ----------------------------------------------------------------
@@ -546,6 +548,12 @@ function widget:DrawInMiniMap(sx, sy)
 		else
 			local x = point.x * ratioX
 			local y = sy - point.z * ratioY
+
+			if GetMiniMapFlipped() then
+				x = sx - x
+				y = sy - y
+			end
+
 			glColor(point.color[1], point.color[2], point.color[3], alpha * point.color[4])
 			local vertices = {
 					{v = {x, y - minimapHighlightLineMin, 0}},

--- a/LuaUI/Widgets/gui_highlight_geos.lua
+++ b/LuaUI/Widgets/gui_highlight_geos.lua
@@ -12,6 +12,8 @@ function widget:GetInfo()
 	}
 end
 
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
+
 ----------------------------------------------------------------
 -- Globals
 ----------------------------------------------------------------
@@ -139,8 +141,13 @@ function widget:DrawInMiniMap()
 	if drawGeos then
 		gl.PushMatrix()
 		gl.LoadIdentity()
-		gl.Translate(0,1,0)
-		gl.Scale(mapXinv , -mapZinv, 1)
+		if GetMiniMapFlipped() then
+			gl.Translate(1, 0, 0)
+			gl.Scale(-mapXinv , mapZinv, 1)
+		else
+			gl.Translate(0, 1, 0)
+			gl.Scale(mapXinv , -mapZinv, 1)
+		end
 		gl.LineWidth(2)
 		gl.Lighting(false)
 		gl.Color(1,1,0,0.7)

--- a/LuaUI/Widgets/gui_point_tracker.lua
+++ b/LuaUI/Widgets/gui_point_tracker.lua
@@ -13,6 +13,8 @@ function widget:GetInfo()
   }
 end
 
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
+
 ----------------------------------------------------------------
 --config
 ----------------------------------------------------------------
@@ -313,6 +315,12 @@ function widget:DrawInMiniMap(sx, sy)
 		local curr = mapPoints[i]
 		local x = curr[2] * ratioX
 		local y = sy - curr[4] * ratioY
+
+		if GetMiniMapFlipped() then
+			x = sx - x
+			y = sy - y
+		end
+
 		local alpha = maxAlpha * (curr[6] - timeNow) / ttl
 		if (alpha <= 0) then
 			mapPoints[i] = mapPoints[mapPointCount]

--- a/LuaUI/Widgets/minimap_events.lua
+++ b/LuaUI/Widgets/minimap_events.lua
@@ -24,6 +24,7 @@ function widget:GetInfo()
   }
 end
 
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
@@ -466,8 +467,14 @@ function widget:DrawInMiniMap(xSize, ySize)
   glPushMatrix()
 
   glLoadIdentity()
-  glTranslate(0, 1, 0)
-  glScale(1 / xMapSize, -1 / yMapSize,1)
+
+  if GetMiniMapFlipped() then
+    glTranslate(1, 0, 0)
+    glScale(-1 / xMapSize, 1 / yMapSize,1)
+  else
+    glTranslate(0, 1, 0)
+    glScale(1 / xMapSize, -1 / yMapSize,1)
+  end
   
   -- draw damages before events
   for _,damage in pairs(damageMap) do

--- a/LuaUI/Widgets/minimap_startbox_new.lua
+++ b/LuaUI/Widgets/minimap_startbox_new.lua
@@ -10,6 +10,7 @@ function widget:GetInfo() return {
 
 local mapX = Game.mapSizeX
 local mapZ = Game.mapSizeZ
+local flipped
 
 local GetRawBoxes, GetParsedBoxes = VFS.Include("LuaUI/Headers/startbox_utilities.lua")
 local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
@@ -185,6 +186,7 @@ local function drawBoxesMinimap()
 		gl.Color (allyStartBoxColor)
 		for i = 1, #allyStartBox do
 			local x1, z1, x2, z2, x3, z3 = unpack(allyStartBox[i])
+
 			gl.Shape (GL.TRIANGLES, {
 				{ v = {x1, z1, 0} },
 				{ v = {x2, z2, 0} },
@@ -207,6 +209,17 @@ local function drawBoxesMinimap()
 	end
 end
 
+local function xForm()
+		gl.LoadIdentity()
+		if flipped then
+			gl.Translate(1, 0, 0)
+			gl.Scale(-1 / Game.mapSizeX, 1 / Game.mapSizeZ, 1)
+		else
+			gl.Translate(0, 1, 0)
+			gl.Scale(1 / Game.mapSizeX, -1 / Game.mapSizeZ, 1)
+		end
+end
+
 function widget:Initialize()
 	-- only show at the beginning
 	if (Spring.GetGameFrame() > 1) or (Game.startPosType ~= 2) or (Spring.GetModOptions().fixedstartpos == "1") then
@@ -214,12 +227,10 @@ function widget:Initialize()
 		return
 	end
 
+	flipped = GetMiniMapFlipped()
+
 	-- flip and scale (using x & y for gl.Rect())
-	xformList = gl.CreateList(function()
-		gl.LoadIdentity()
-		gl.Translate(0, 1, 0)
-		gl.Scale(1 / Game.mapSizeX, -1 / Game.mapSizeZ, 1)
-	end)
+	xformList = gl.CreateList(xForm)
 
 	-- cone list for world start positions
 	coneList = gl.CreateList(function()
@@ -325,7 +336,7 @@ function widget:DrawWorld()
 		end
 		gl.PolygonMode(GL.FRONT_AND_BACK, GL.FILL)
 	end
-	
+
 	for _, teamID in ipairs(Spring.GetTeamList()) do
 		local x, y, z = Spring.GetTeamStartPosition(teamID)
 		if ValidStartpos(x,y,z) then
@@ -391,10 +402,18 @@ function widget:DrawScreenEffects()
 	gl.Fog(true)
 end
 
-local boxes_loaded_minimap = false
 function widget:DrawInMiniMap(minimapX, minimapY)
+	local newFlipped = GetMiniMapFlipped()
 
 	gl.PushMatrix()
+
+	if flipped ~= newFlipped then
+		flipped = newFlipped
+
+		gl.DeleteList(xformList)
+		xformList = gl.CreateList(xForm)
+	end
+
 	gl.CallList(xformList)
 	gl.LineWidth(1.49)
 	gl.PolygonMode(GL.FRONT_AND_BACK, GL.FILL)
@@ -409,14 +428,9 @@ function widget:DrawInMiniMap(minimapX, minimapY)
 	gl.PushMatrix()
 	gl.LineWidth(3)
 
-	if GetMiniMapFlipped() then
-		gl.Translate(minimapY, 0, 0)
-		gl.Scale(-minimapX/mapX, minimapY/mapZ, 1)
-	else
-		gl.Translate(0, minimapY, 0)
-		gl.Scale(minimapX/mapX, -minimapY/mapZ, 1)
-	end
-	
+	gl.Translate(0, minimapY, 0)
+	gl.Scale(minimapX/mapX, -minimapY/mapZ, 1)
+
 	for _, teamID in ipairs(Spring.GetTeamList()) do
 		local x, y, z = Spring.GetTeamStartPosition(teamID)
 		if ValidStartpos(x, y, z) then

--- a/LuaUI/Widgets/minimap_startbox_new.lua
+++ b/LuaUI/Widgets/minimap_startbox_new.lua
@@ -12,6 +12,7 @@ local mapX = Game.mapSizeX
 local mapZ = Game.mapSizeZ
 
 local GetRawBoxes, GetParsedBoxes = VFS.Include("LuaUI/Headers/startbox_utilities.lua")
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
 local startboxConfig = GetParsedBoxes()
 
 local rawBoxes = GetRawBoxes()
@@ -407,8 +408,14 @@ function widget:DrawInMiniMap(minimapX, minimapY)
 	local dotSize = math.max(minimapX, minimapY) * 0.3
 	gl.PushMatrix()
 	gl.LineWidth(3)
-	gl.Translate(0, minimapY, 0)
-	gl.Scale(minimapX/mapX, -minimapY/mapZ, 1)
+
+	if GetMiniMapFlipped() then
+		gl.Translate(minimapY, 0, 0)
+		gl.Scale(-minimapX/mapX, minimapY/mapZ, 1)
+	else
+		gl.Translate(0, minimapY, 0)
+		gl.Scale(minimapX/mapX, -minimapY/mapZ, 1)
+	end
 	
 	for _, teamID in ipairs(Spring.GetTeamList()) do
 		local x, y, z = Spring.GetTeamStartPosition(teamID)

--- a/LuaUI/Widgets/missilesilo_range.lua
+++ b/LuaUI/Widgets/missilesilo_range.lua
@@ -84,6 +84,7 @@ local circleDivs = 64
 -- Speedup
 
 VFS.Include("LuaRules/Utilities/glVolumes.lua")
+local GetMiniMapFlipped = VFS.Include("LuaUI/Headers/minimap_utilities.lua").getMiniMapFlipped
 
 local spGetActiveCommand = Spring.GetActiveCommand
 local spTraceScreenRay   = Spring.TraceScreenRay
@@ -187,8 +188,13 @@ local function DrawActiveCommandRangesMinimap(minimapX, minimapY)
 	
 	local height = spGetGroundHeight(mouseX,mouseZ)
 	
-	glTranslate(0,minimapY,0)
-	glScale(minimapX/mapX, -minimapY/mapZ, 1)
+	if GetMiniMapFlipped() then
+		glTranslate(minimapY, 0, 0)
+		glScale(-minimapX/mapX, minimapY/mapZ, 1)
+	else
+		glTranslate(0, minimapY, 0)
+		glScale(minimapX/mapX, -minimapY/mapZ, 1)
+	end
 	
 	for i = 1, (options.missile_silo_advanced.value and 5 or 2) do
 		local radius = drawRadius[i]


### PR DESCRIPTION
Remarks:

- `Gadgets/unit_cloak_shield.lua` callin for `DrawInMiniMap` seems to be noop. Disabling the gadget does not change anything, the range is still drawn correctly, flipped or not.

Untested widgets:

- `Widgets/minimap_events.lua`

These should be safe when minimap cant flip or is not flipped, otherwise they follow same structure for drawing as other tested ones.

All changes, unless stated otherwise above, were tested.
