### PR TITLE
Gunships no longer teleport units after crashing

### DIFF
--- a/LuaRules/Gadgets/unit_aircraft_crash.lua
+++ b/LuaRules/Gadgets/unit_aircraft_crash.lua
@@ -25,7 +25,6 @@ local spGetUnitIsStunned	= Spring.GetUnitIsStunned
 local spGetUnitHealth		= Spring.GetUnitHealth
 
 local aircraftDefIDs = {}
-local emptyTable = {}
 
 function gadget:Initialize()
 	for i=1,#UnitDefs do

--- a/LuaRules/Gadgets/unit_aircraft_crash.lua
+++ b/LuaRules/Gadgets/unit_aircraft_crash.lua
@@ -55,10 +55,13 @@ function gadget:GameFrame(n)
 	end
 end
 
-local spUnitScript = Spring.UnitScript -- CallAsUnit can't be localized directly because a later-layered gadget modifies it
-local function CallAsUnitIfExists(unitID, func, ...)
-	if func then
-		spUnitScript.CallAsUnit(unitID, func, ...)
+local function CallAsUnitIfExists(unitID, funcName)
+	local env = Spring.UnitScript.GetScriptEnv(unitID)
+	if not env then
+		return
+	end
+	if env and env[funcName] then
+		Spring.UnitScript.CallAsUnit(unitID, env[funcName])
 	end
 end
 
@@ -81,8 +84,7 @@ function gadget:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weap
 		local maxHealth = aircraftDefIDs[unitDefID]
 		local severity = rDam/maxHealth
 		if severity < 0.5 then
-			local env = Spring.UnitScript.GetScriptEnv(unitID) or emptyTable
-			CallAsUnitIfExists(unitID, env.OnStartingCrash) -- tell the LUS that we're crashing (mostly for transports)
+			CallAsUnitIfExists(unitID, "OnStartingCrash") -- tell the LUS that we're crashing (mostly for transports)
 			Spring.SetUnitCrashing(unitID, true)
 			Spring.SetUnitNoSelect(unitID, true)
 			Spring.SetUnitSensorRadius(unitID, "los", 0)

--- a/scripts/gunshipheavytrans.lua
+++ b/scripts/gunshipheavytrans.lua
@@ -259,10 +259,7 @@ function ForceDropUnit()
 	StartThread(script.EndTransport) --formalize unit drop (finish animation, clear tag, ect)
 end
 
-local function CrashWatcher()
-	while GetUnitValue(COB.CRASHING) ~= 1 do
-		Sleep(33)
-	end
+function OnStartingCrash()
 	ForceDropUnit()
 end
 
@@ -465,7 +462,6 @@ function script.Create()
 	Turn(dust2, x_axis, math.rad(90))
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 	StartThread(PickupAndDropFixer)
-	StartThread(CrashWatcher)
 	--StartThread(DustLoop)	-- looks stupid
 	
 	Spring.MoveCtrl.SetGunshipMoveTypeData(unitID,"bankingAllowed",false)

--- a/scripts/gunshipheavytrans.lua
+++ b/scripts/gunshipheavytrans.lua
@@ -259,6 +259,13 @@ function ForceDropUnit()
 	StartThread(script.EndTransport) --formalize unit drop (finish animation, clear tag, ect)
 end
 
+local function CrashWatcher()
+	while GetUnitValue(COB.CRASHING) ~= 1 do
+		Sleep(33)
+	end
+	ForceDropUnit()
+end
+
 --fetch unit id of passenger (from the load command)
 function getPassengerId()
 	local cmd=Spring.GetCommandQueue(unitID, 1)
@@ -458,6 +465,7 @@ function script.Create()
 	Turn(dust2, x_axis, math.rad(90))
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 	StartThread(PickupAndDropFixer)
+	StartThread(CrashWatcher)
 	--StartThread(DustLoop)	-- looks stupid
 	
 	Spring.MoveCtrl.SetGunshipMoveTypeData(unitID,"bankingAllowed",false)

--- a/scripts/gunshiptrans.lua
+++ b/scripts/gunshiptrans.lua
@@ -82,10 +82,7 @@ function ForceDropUnit()
 	StartThread(script.EndTransport) --formalize unit drop (finish animation, clear tag, ect)
 end
 
-local function CrashWatcher()
-	while GetUnitValue(COB.CRASHING) ~= 1 do
-		Sleep(33)
-	end
+function OnStartingCrash()
 	ForceDropUnit()
 end
 
@@ -244,7 +241,6 @@ end
 function script.Create()
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 	StartThread(PickupAndDropFixer)
-	StartThread(CrashWatcher)
 end
 
 function script.Activate()

--- a/scripts/gunshiptrans.lua
+++ b/scripts/gunshiptrans.lua
@@ -82,6 +82,13 @@ function ForceDropUnit()
 	StartThread(script.EndTransport) --formalize unit drop (finish animation, clear tag, ect)
 end
 
+local function CrashWatcher()
+	while GetUnitValue(COB.CRASHING) ~= 1 do
+		Sleep(33)
+	end
+	ForceDropUnit()
+end
+
 --fetch unit id of passenger (from the load command)
 function getPassengerId()
 	local cmd = Spring.GetCommandQueue(unitID, 1)
@@ -237,6 +244,7 @@ end
 function script.Create()
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 	StartThread(PickupAndDropFixer)
+	StartThread(CrashWatcher)
 end
 
 function script.Activate()


### PR DESCRIPTION
Fixes #4784

Gunships that are in the "crashing" state do not call their "killed" callin until they smack the ground. This causes the transportee to teleport.

Tested via [Future Wars 242eaa2](https://github.com/Arch-Shaman/ZK-Futurewars-Mod/commit/242eaa29c65967f717f39af87fe83115e5895e1f) using a special unitdef to cause the gunship to crash reliably by dealing low damage. (You can test this by creating a razor with a laser weapon and deals around 1 damage every 1/30 second.)