### PR TITLE
Fix xray shader [BLIND FIX]

### DIFF
--- a/LuaUI/Widgets/gfx_xray_shader.lua
+++ b/LuaUI/Widgets/gfx_xray_shader.lua
@@ -147,7 +147,7 @@ function widget:Initialize()
         color = gl_Color.rgb;
               
         gl_Position = gl_ProjectionMatrix * P;
-        position = gl_Position;
+        position = gl_Position.xyz;
       }
     ]],
  


### PR DESCRIPTION
[t=00:00:54.905729][f=-000001] Loaded widget: Unit Marker Zero-K <unit_marker.lua>
[t=00:00:54.907094][f=-000001] Xray shader compilation failed. [t=00:00:54.907074][f=-000001] [XrayShader] Error: ERROR: 0:21: 'assign' : cannot convert from ' gl_Position 4-component vector of float Position' to ' smooth out 3-component vector of float' ERROR: 0:21: '' : compilation terminated
ERROR: 2 compilation errors. No code generated.


[t=00:00:54.907739][f=-000001] [cawidgets.lua] Error: Error in Initialize(): [string "LuaUI/Widgets/gfx_xray_shader.lua"]:182: bad argument #1 to 'GetUniformLocation' (number expected, got nil)
[t=00:00:54.907754][f=-000001] [cawidgets.lua] Error: Removed widget: XrayShader