### PR TITLE
Fix unit xp not being updated after morphing

### DIFF
--- a/LuaRules/Gadgets/unit_morph.lua
+++ b/LuaRules/Gadgets/unit_morph.lua
@@ -507,7 +507,7 @@ local function FinishMorph(unitID, morphData)
 	Spring.SetUnitHealth(newUnit, {health = newHealth, build = buildProgress, paralyze = newPara, capture = captureProgress })
 	
 	--//transfer experience
-	newXp = newXp * (oldBuildTime / Spring.Utilities.GetUnitCost(unitID, morphData.def.into))
+	newXp = newXp * (oldBuildTime / Spring.Utilities.GetUnitCost(newUnit, morphData.def.into))
 	Spring.SetUnitExperience(newUnit, newXp)
 	--// transfer shield power
 	if oldShieldState then


### PR DESCRIPTION
The XP setting calculation took the old cost over the old cost, probably because of a typo or something.

![image](https://user-images.githubusercontent.com/48730089/208628466-5b444c65-559b-440c-ab97-1a9c6f910d99.png)
Here we can see the morph is using the old commander cost, and not the new commander cost. This effectively just set the morphed unit's xp to the current xp.