### PR TITLE
Healthbars: Fixed a bug where the "shield" text was not rendered

### DIFF
--- a/LuaUI/Widgets/unit_healthbars.lua
+++ b/LuaUI/Widgets/unit_healthbars.lua
@@ -656,14 +656,14 @@ do
 					local shieldOn, shieldPower = GetUnitShieldState(unitID, GetUnitRulesParam(unitID, "comm_shield_num"))
 					if (shieldOn)and(build == 1)and(shieldPower < commShield) then
 						shieldPower = shieldPower / commShield
-						barDrawer.AddBar(addTitle and messages.shield, shieldPower, "shield", (addPercent and floor(shieldPower*100) .. '%'))
+						barDrawer.AddBar(addTitle and messages.shield_bar, shieldPower, "shield", (addPercent and floor(shieldPower*100) .. '%'))
 					end
 				end
 			else
 				local shieldOn, shieldPower = GetUnitShieldState(unitID)
 				if (shieldOn)and(build == 1)and(shieldPower < ci.maxShield) then
 					shieldPower = shieldPower / ci.maxShield
-					barDrawer.AddBar(addTitle and messages.shield, shieldPower, "shield", (addPercent and floor(shieldPower*100) .. '%'))
+					barDrawer.AddBar(addTitle and messages.shield_bar, shieldPower, "shield", (addPercent and floor(shieldPower*100) .. '%'))
 				end
 			end
 		end


### PR DESCRIPTION
50be39ee introduced the bug, apparently by changing "shield" to "shield_bar", but never updating the reference in the widget.