### PR TITLE
⚖️ Fix #2774, transportable heavy ships

### DIFF
--- a/units/chickenbroodqueen.lua
+++ b/units/chickenbroodqueen.lua
@@ -40,7 +40,6 @@ return { chickenbroodqueen = {
   canMove             = true,
   canPatrol           = true,
   canSubmerge         = true,
-  cantBeTransported   = true,
   category            = [[LAND]],
 
   customParams        = {

--- a/units/neebcomm.lua
+++ b/units/neebcomm.lua
@@ -16,7 +16,6 @@ return { neebcomm = {
   canMove             = true,
   canPatrol           = true,
   canSubmerge         = true,
-  cantBeTransported   = true,
   category            = [[LAND UNARMED]],
 
   customParams        = {

--- a/units/shipcarrier.lua
+++ b/units/shipcarrier.lua
@@ -10,7 +10,6 @@ return { shipcarrier = {
   buildPic               = [[shipcarrier.png]],
   canMove                = true,
   canManualFire          = true,
-  cantBeTransported      = true,
   category               = [[SHIP]],
   CollisionSphereScale   = 0.6,
   collisionVolumeOffsets = [[10 -10 0]],

--- a/units/shipheavyarty.lua
+++ b/units/shipheavyarty.lua
@@ -11,7 +11,6 @@ return { shipheavyarty = {
   canGuard               = true,
   canMove                = true,
   canPatrol              = true,
-  cantBeTransported      = true,
   category               = [[SHIP]],
   collisionVolumeOffsets = [[0 5 0]],
   collisionVolumeScales  = [[45 45 260]],


### PR DESCRIPTION
Reef and Shogun are now transportable, they could already be moved via Lobster anyway.

Reef might be somewhat problematic since its drones can still act, but maybe that's based and protosspilled.