### PR TITLE
Fix #4838 & Preventative maintenance for Commshare forceresign

### DIFF
--- a/LuaRules/Gadgets/game_share_mode.lua
+++ b/LuaRules/Gadgets/game_share_mode.lua
@@ -738,4 +738,5 @@ end
 
 function gadget:Initialize()
 	gadgetHandler:AddChatAction("debugcommshare", ToggleDebug, "Toggles Commshare debugMode echos.")
+	GG.UnmergePlayerFromCommshare = UnmergePlayer
 end


### PR DESCRIPTION
Spectators are team 0 so team 0 gets forced resigned. Commshare teams are also potentially impacted because resigning a member or a squad leader will return the teamID anyways, killing the entire squad.

Fixes #4838