### PR TITLE
QoL improvement: Hosts can directly /luarules resignteam

### DIFF
--- a/LuaRules/Gadgets/game_resign.lua
+++ b/LuaRules/Gadgets/game_resign.lua
@@ -58,7 +58,7 @@ function gadget:GotChatMsg (msg, senderID)
 			allowed = true
 		else
 			local playerkeys = select (10, spGetPlayerInfo(senderID))
-			if (playerkeys and playerkeys.admin and (playerkeys.admin == "1")) then
+			if playerkeys and ((playerkeys.admin and playerkeys.admin == "1") or (playerkeys.room_boss and playerkeys.room_boss == "1")) then
 				allowed = true
 			end
 		end


### PR DESCRIPTION
Separated from #4839 in case you want to debate this change. Essentially hosts can already do !hostsay /luarules resignteam x to force a resign, This just cuts down the 9 extra characters for it.