### PR TITLE
compatibility fix for latest versions of  raaar maps

### DIFF
--- a/LuaRules/Gadgets/mex_spot_finder.lua
+++ b/LuaRules/Gadgets/mex_spot_finder.lua
@@ -21,6 +21,7 @@ if (gadgetHandler:IsSyncedCode()) then
 -- Config
 ------------------------------------------------------------
 local MAPSIDE_METALMAP = "mapconfig/map_metal_layout.lua"
+local ALT_MAPSIDE_METALMAP = "mapconfig/map_resource_spot_layout.lua"
 local GAMESIDE_METALMAP = "LuaRules/Configs/MetalSpots/" .. (Game.mapName or "") .. ".lua"
 
 local DEFAULT_MEX_INCOME = 2
@@ -439,7 +440,9 @@ function gadget:Initialize()
 	Spring.Log(gadget:GetInfo().name, LOG.INFO, "Mex Spot Finder Initialising")
 	local gameConfig = VFS.FileExists(GAMESIDE_METALMAP) and VFS.Include(GAMESIDE_METALMAP) or false
 	local mapConfig = VFS.FileExists(MAPSIDE_METALMAP) and VFS.Include(MAPSIDE_METALMAP) or false
-	
+	if not mapConfig then
+		mapConfig = VFS.FileExists(ALT_MAPSIDE_METALMAP) and VFS.Include(ALT_MAPSIDE_METALMAP) or false
+	end
 	local metalSpots, fromEngineMetalmap = GetSpots(gameConfig, mapConfig)
 	local metalSpotsByPos = false
 	


### PR DESCRIPTION
without this fix, area-mex command is broken on those maps:

Highway 95 v7		https://springrts.com/phpbb/viewtopic.php?t=36689
Highway 95 West v2.1	https://springrts.com/phpbb/viewtopic.php?t=42994
Highway 95 East v2	https://springrts.com/phpbb/viewtopic.php?t=42877
Hexian Arena v3		https://springrts.com/phpbb/viewtopic.php?t=41642
High Forts v3		https://springrts.com/phpbb/viewtopic.php?t=44537
Scorched Crossing v2	https://springrts.com/phpbb/viewtopic.php?t=41558
The Hole v5			https://springrts.com/phpbb/viewtopic.php?t=36637
Sky Fortress Sigma v6	https://springrts.com/phpbb/viewtopic.php?t=36851
Dockside v2			https://springrts.com/phpbb/viewtopic.php?t=40964
River Of Flame v4.1	https://springrts.com/phpbb/viewtopic.php?t=39333
Halean Ruins v2		https://springrts.com/phpbb/viewtopic.php?t=43052
Icy Crater v4		https://springrts.com/phpbb/viewtopic.php?t=40235
Crucible v3.1		https://springrts.com/phpbb/viewtopic.php?t=39953


