### PR TITLE
TTS: Replays ignore messages for commander select

### DIFF
--- a/LuaUI/Widgets/snd_text_to_speech.lua
+++ b/LuaUI/Widgets/snd_text_to_speech.lua
@@ -94,6 +94,10 @@ function widget:AddConsoleMessage(msg)
 	if not (msg and msg.msgtype == "player_to_allies" and msg.playername ~= myPlayerName) then
 		return
 	end
+	local comselect = "I choose:"
+	if Spring.IsReplay() and msg and msg.argument:sub(1, #comselect) == comselect then
+		return
+	end
 	Spring.SendLuaMenuMsg("textToSpeechSay_" .. (msg.playername or "unknown") .. " " .. (msg.argument or ""))
 end
 


### PR DESCRIPTION
Optimization: Prevent backlog of selection messages from being spoken at start of replays