### PR TITLE
Add optional huge nuke warning

### DIFF
--- a/LuaUI/Widgets/gui_chili_nuke_warning.lua
+++ b/LuaUI/Widgets/gui_chili_nuke_warning.lua
@@ -236,7 +236,7 @@ options = {
 	nukeWarningOpacity = {
 		name = "Nuclear launch warning opacity",
 		type = "number",
-		value = 60,
+		value = 100,
 		min = 1, max = 100, step = 1,
 		advanced = true,
 		OnChange = UpdateFlashStateDefs

--- a/LuaUI/Widgets/gui_chili_nuke_warning.lua
+++ b/LuaUI/Widgets/gui_chili_nuke_warning.lua
@@ -34,22 +34,32 @@ local flashTime = 0
 
 local FLASH_PERIOD = 0.4
 
-local flashStateDefs = {
-	{
-		color = {1,0.2,0,1},
-		outlinecolor = {0.3,0.1,0,1},
-	},
-	{
-		color = {0.9,0.6,0.1,1},
-		outlinecolor = {0.25,0.15,0,1},
-	},
-}
+local flashStateDefs
+
+local UpdateFont
+
+local function UpdateFlashStateDefs()
+	local opacity = options and options.nukeWarningOpacity and (options.nukeWarningOpacity.value / 100.0) or 0.6
+
+	flashStateDefs = {
+		{
+			color = {1,0.2,0,opacity},
+			outlinecolor = {0.3,0.1,0,opacity},
+		},
+		{
+			color = {0.9,0.6,0.1,opacity},
+			outlinecolor = {0.25,0.15,0,opacity},
+		}
+	}
+
+	if currentlyShown then UpdateFont(flashState) end
+end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Update Text
 
-local function UpdateFont(state)
+function UpdateFont(state)
 	local c = flashStateDefs[state].color
 	local o = flashStateDefs[state].outlinecolor
 	mainWindow.label.font:SetColor(c[1],c[2],c[3], c[4])
@@ -66,10 +76,15 @@ end
 local function CreateWindow()
 	local data = {}
 	
-	local screenWidth = Spring.GetViewGeometry()
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
 	local screenHorizCentre = screenWidth / 2
-	local windowWidth = 500
 	local resourcePanelHeight = 100
+
+	local isHuge = options and options.nukeWarningIsHuge and options.nukeWarningIsHuge.value
+
+	local windowWidth = isHuge and (screenWidth - 10) or 500
+	local windowHeight = isHuge and (screenHeight - 2*resourcePanelHeight) or 50
+	local fontSize = isHuge and 200 or 32
 
 	data.window = Chili.Window:New{
 		parent = screen0,
@@ -80,7 +95,7 @@ local function CreateWindow()
 		x = screenHorizCentre - windowWidth/2,
 		y = resourcePanelHeight,
 		clientWidth  = windowWidth,
-		clientHeight = 50,
+		clientHeight = windowHeight,
 		dockable = false,
 		draggable = false,
 		resizable = false,
@@ -100,7 +115,7 @@ local function CreateWindow()
 		align  = "center",
 		autosize = false,
 		font   = {
-			size = 32,
+			size = fontSize,
 			outline = true,
 			outlineWidth = 6,
 			outlineWeight = 6,
@@ -161,6 +176,7 @@ function widget:Initialize()
 		return
 	end
 	WG.InitializeTranslation (languageChanged, GetInfo().name)
+	UpdateFlashStateDefs()
 end
 
 function widget:Update(dt)
@@ -194,3 +210,35 @@ end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+
+options_path = "Settings/Accessibility"
+options_order = { "mainlabel", "nukeWarningIsHuge", "nukeWarningOpacity" }
+
+options = {
+	mainlabel = {name='Nuclear launch warning', type='label'},
+	nukeWarningIsHuge = {
+		name = "Full-screen nuclear launch warning",
+		type = "bool",
+		value = false,
+		noHotkey = true,
+		OnChange = function (self)
+			if mainWindow and mainWindow.window then
+				mainWindow.window:Dispose()
+				mainWindow = nil
+				currentlyShown = false
+			end
+
+			if wantedShown then
+				ShowWindow()
+			end
+		end
+	},
+	nukeWarningOpacity = {
+		name = "Nuclear launch warning opacity",
+		type = "number",
+		value = 60,
+		min = 1, max = 100, step = 1,
+		advanced = true,
+		OnChange = UpdateFlashStateDefs
+	},
+}


### PR DESCRIPTION
This is for people who tend to tunnel-vision on a different part of the screen and miss the nuke warning completely :)

Haven't found a way to put this below the color blindness options instead of above.