### PR TITLE
Fixing advanced geo aimpoint to be above the ground

### DIFF
--- a/units/energyheavygeo.lua
+++ b/units/energyheavygeo.lua
@@ -17,7 +17,7 @@ return { energyheavygeo = {
     pylonrange     = 150,
     removewait     = 1,
     removestop     = 1,
-	aimposoffset = [[0 30 0]],
+    aimposoffset = [[0 30 0]],
 
     stats_show_death_explosion = 1,
   },

--- a/units/energyheavygeo.lua
+++ b/units/energyheavygeo.lua
@@ -17,6 +17,7 @@ return { energyheavygeo = {
     pylonrange     = 150,
     removewait     = 1,
     removestop     = 1,
+	aimposoffset = [[0 30 0]],
 
     stats_show_death_explosion = 1,
   },


### PR DESCRIPTION
Adv geo currently has an aimpoint at its base, this causes targeting issues if there's a very slight ridge (e.g. caused by the automatic building flatting that happens when making the advanced geo):
![image](https://github.com/ZeroK-RTS/Zero-K/assets/6192259/458ce2fc-d279-4f56-9a55-e79f2b2f37ba)

Highered aimpoint looks like this:
![image](https://github.com/ZeroK-RTS/Zero-K/assets/6192259/6f32c6ad-2185-4ff5-8c37-8407f18a54a1)
