### PR TITLE
⚙️ Impalator and tacnukes HEAVILY prefer targeting statics

### DIFF
--- a/LuaRules/Configs/target_priority_defs.lua
+++ b/LuaRules/Configs/target_priority_defs.lua
@@ -9,6 +9,7 @@ local DISARM_ADD = 0.2
 local DISARM_ADD_TIME = 10*30 -- frames
 
 local weaponBadCats_fixedwing = {}
+local weaponBadCats_mobile = {}
 local weaponBadCats_gunship = {}
 local weaponBadCats_ground = {}
 local weaponBadCats_heavy = {}
@@ -52,9 +53,11 @@ end
 local unitIsGunship = {}
 local unitIsFixedwing = {}
 local unitIsGround = {}
+local unitIsMobile = {}
 local getMovetype = Spring.Utilities.getMovetype
 for i = 1, udCount do
 	local ud = UnitDefs[i]
+	unitIsMobile[i] = not ud.isImmobile
 	local unitType = getMovetype(ud) --1 gunship, 0 fixedplane, 2 ground/sea, false everything-else
 	if unitType == 1 then
 		unitIsGunship[i] = true
@@ -115,6 +118,15 @@ local unitIsHeavyHitter = {
 	[UnitDefNames["hoverskirm"].id] = true,
 	[UnitDefNames["striderbantha"].id] = true,
 	[UnitDefNames["bomberheavy"].id] = true,
+}
+
+-- Hardcore things that are bad vs mobiles
+local unitIsBadVsMobiles = {
+	[UnitDefNames["vehheavyarty"].id] = true,
+	[UnitDefNames["tacnuke"].id] = true,
+	[UnitDefNames["empmissile"].id] = true,
+	[UnitDefNames["napalmmissile"].id] = true,
+	-- Sling (cloakarty)? Is okay vs mobiles but should probably still prefer buildings
 }
 
 local unitIsCheap = {
@@ -274,6 +286,13 @@ for i = 1, udCount do
 			local realWD = wd.weaponDef
 			weaponBadCats_heavy[realWD] = true
 		end
+	elseif unitIsBadVsMobiles[i] then
+		local weapons = weaponsCache[i]
+		for j = 1, #weapons do
+			local wd = weapons[j]
+			local realWD = wd.weaponDef
+			weaponBadCats_mobile[realWD] = true
+		end
 	end
 end
 
@@ -340,6 +359,8 @@ local function GetPriority(uid, wid)
 			targetTable[uid][wid] = priority + 10
 		elseif (unitIsBomber[uid] and weaponIsAA[wid]) or (weaponBadCats_heavy[wid] and unitIsHeavy[uid]) then
 			targetTable[uid][wid] = priority*0.3
+		elseif weaponBadCats_mobile[wid] and unitIsMobile[uid] then
+			targetTable[uid][wid] = priority + 100
 		else
 			targetTable[uid][wid] = priority
 		end

--- a/gamedata/unitdefs_post.lua
+++ b/gamedata/unitdefs_post.lua
@@ -611,7 +611,7 @@ end
 -- Avoid firing at unarmed
 --
 for name, ud in pairs(UnitDefs) do
-	if (ud.weapons and not ud.canfly) then
+	if ud.weapons and not ud.canfly and not ud.target_stupid_targets then
 		for wName, wDef in pairs(ud.weapons) do
 			if wDef.badtargetcategory then
 				wDef.badtargetcategory = wDef.badtargetcategory .. " STUPIDTARGET"

--- a/units/empmissile.lua
+++ b/units/empmissile.lua
@@ -44,7 +44,7 @@ return { empmissile = {
 
     {
       def                = [[EMP_WEAPON]],
-      badTargetCategory  = [[SWIM LAND SHIP HOVER]],
+      badTargetCategory  = [[MOBILE]],
       onlyTargetCategory = [[SWIM LAND SINK TURRET FLOAT SHIP HOVER FIXEDWING GUNSHIP SUB]],
     },
 

--- a/units/napalmmissile.lua
+++ b/units/napalmmissile.lua
@@ -48,7 +48,7 @@ return { napalmmissile = {
 
     {
       def                = [[WEAPON]],
-      badTargetCategory  = [[SWIM LAND SHIP HOVER]],
+      badTargetCategory  = [[MOBILE]],
       onlyTargetCategory = [[SWIM LAND SINK TURRET FLOAT SHIP HOVER GUNSHIP]],
     },
 

--- a/units/tacnuke.lua
+++ b/units/tacnuke.lua
@@ -48,7 +48,7 @@ return { tacnuke = {
 
     {
       def                = [[WEAPON]],
-      badTargetCategory  = [[SWIM LAND SHIP HOVER]],
+      badTargetCategory  = [[MOBILE]],
       onlyTargetCategory = [[SWIM LAND SINK TURRET FLOAT SHIP HOVER GUNSHIP]],
     },
 

--- a/units/vehheavyarty.lua
+++ b/units/vehheavyarty.lua
@@ -14,6 +14,9 @@ return { vehheavyarty = {
   corpse              = [[DEAD]],
 
   customParams        = {
+    chase_everything = 1, -- don't ignore solars. Doesn't chase mobiles anyway
+    target_stupid_targets = 1, -- ditto, don't deprioritize solars (mobile stupid targets already deprioritized)
+
     bait_level_default = 2,
     dontfireatradarcommand = '0',
   },
@@ -28,7 +31,7 @@ return { vehheavyarty = {
   maxVelocity         = 2.0,
   metalCost           = 700,
   movementClass       = [[TANK3]],
-  noChaseCategory     = [[TERRAFORM FIXEDWING GUNSHIP]],
+  noChaseCategory     = [[TERRAFORM FIXEDWING GUNSHIP MOBILE]],
   objectName          = [[core_diplomat.s3o]],
   script              = [[vehheavyarty.lua]],
   selfDestructAs      = [[BIG_UNITEX_MERL]],
@@ -54,7 +57,7 @@ return { vehheavyarty = {
 
     {
       def                = [[CORTRUCK_ROCKET]],
-      badTargetCategory  = [[SWIM LAND SHIP HOVER]],
+      badTargetCategory  = [[MOBILE]],
       onlyTargetCategory = [[SWIM LAND SINK TURRET FLOAT SHIP HOVER]],
     },
 


### PR DESCRIPTION
An Impaler with Unit AI will still get stuck avoiding the first mobile, but if you turn off unit AI it will level every single building before targeting units.

To also consider: Sling, Similar "fire and forget" style where you just fight-move it into porc, but not so terrible vs mobiles.

For tacnukes this is currently not too useful due to the lack of OKP (which is not in the scope of this patch). With OKP, tacnukes could reasonably be built by AI and just put on fire at will.