### PR TITLE
Default fonts to autoOutlineColor = false

### DIFF
--- a/LuaUI/Widgets/api_font_cache.lua
+++ b/LuaUI/Widgets/api_font_cache.lua
@@ -34,7 +34,7 @@ function WG.GetFont(size)
 			outlineWeight = 3,
 			color         = {1, 1, 1, 1},
 			outlineColor  = {0, 0, 0, 1},
-			autoOutlineColor = true,
+			autoOutlineColor = false,
 		}
 	end
 	return font[size]
@@ -46,7 +46,7 @@ function WG.GetSpecialFont(size, name, data)
 		specialFont[size] = {}
 	end
 	if (not specialFont[size][name]) or DISABLE then
-		local shadows, outline, autoOutlineColor = true, false, true
+		local shadows, outline, autoOutlineColor = true, false, false
 		if data.shadows ~= nil then
 			shadows = data.shadows
 		end

--- a/LuaUI/Widgets/chili/Controls/font.lua
+++ b/LuaUI/Widgets/chili/Controls/font.lua
@@ -25,7 +25,7 @@ Font = Object:Inherit{
 	outline       = false,
 	color         = {1, 1, 1, 1},
 	outlineColor  = {0, 0, 0, 1},
-	autoOutlineColor = true,
+	autoOutlineColor = false,
 
 	uiScale = 1
 }

--- a/LuaUI/Widgets/gui_chili_proconsole_test.lua
+++ b/LuaUI/Widgets/gui_chili_proconsole_test.lua
@@ -931,8 +931,9 @@ local function formatMessage(msg)
 		-- we get all the usernames by iterating it and just ignoring the #[aehos] control codes
 		for name, colour in pairs(incolors) do
 			if name:sub(1,1) ~= '#' then
-				local pattern = '[^%w]' .. name .. '[^%w]'
-				formatted_arg, _ = formatted_arg:gsub(pattern, function(parameter) return parameter:sub(1,1) .. colour .. parameter:sub(2,-1) .. message_colour end)
+				local pattern = '([^%w_])(' .. name .. ')([^%w_])'
+				local sub = '%1'..colour..'%2'..message_colour..'%3'
+				formatted_arg, _ = formatted_arg:gsub(pattern, sub)
 			end
 		end
 		msg.argument = formatted_arg:sub(2, -2)  -- strip added spaces


### PR DESCRIPTION
Removes the behaviour of "dark" font colours having white outlines.
Should fix #4954.
Additional small refactor on chat widget following up from comments on #4953.