### PR TITLE
Update unit_auto_reclaim_heal_assist.lua

### DIFF
--- a/LuaUI/Widgets/unit_auto_reclaim_heal_assist.lua
+++ b/LuaUI/Widgets/unit_auto_reclaim_heal_assist.lua
@@ -43,7 +43,7 @@ local ConController = {
 	handle=function(self)
 		local cmdQueue = Spring.GetUnitCommands(self.unitID, 3);
 		if (#cmdQueue == 0) then
-			if (not Spring.IsUnitSelected(self.unitID)) then              --if unit is not selected
+			if ((not Spring.IsUnitSelected(self.unitID) and (not Spring.GetUnitStates(self.unitID)["cloak"]))) then  --if unit is not selected and not cloaked
 				self.cmdPos = {GetUnitPosition(self.unitID)}
 				Spring.GiveOrderToUnit(self.unitID, CMD.FIGHT, self.cmdPos, {})   --command unit to reclaim
 				-- printThing("order", Spring.GetUnitCommands(self.unitID, 2), "")


### PR DESCRIPTION
Excludes cloaked units. This is helpful because without it even cloaked stealth bots try to reclaim