### PR TITLE
Propagate attacker info to widgets for UnitDamaged callin.

### DIFF
--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -2348,9 +2348,9 @@ end
 
 function widgetHandler:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 	for _, w in r_ipairs(self.UnitDamagedList) do
-		-- The engine only provides attacker information when visible. However weapon information is always passed - arguably
-		-- the weapon is always visible - but we don't want widgets to be able to infer the attacker when it is not visible.
-		w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, nil, nil, attackerID, attackerDefID, attackerTeam)
+		-- The engine only provides attackerID etc if the attacker is visible.
+		-- OTOH weaponDefID and projectileID are always provided - elide projectileID so that widgets can't aquire projectile vector and locate the attacker.
+		w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, nil, attackerID, attackerDefID, attackerTeam)
 	end
 end
 

--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -2346,9 +2346,9 @@ function widgetHandler:UnitCmdDone(unitID, unitDefID, unitTeam, cmdID, cmdParams
 end
 
 
-function widgetHandler:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer)
+function widgetHandler:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 	for _, w in r_ipairs(self.UnitDamagedList) do
-		w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer)
+		w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 	end
 end
 

--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -2348,7 +2348,9 @@ end
 
 function widgetHandler:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
 	for _, w in r_ipairs(self.UnitDamagedList) do
-		w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
+		-- The engine only provides attacker information when visible. However weapon information is always passed - arguably
+		-- the weapon is always visible - but we don't want widgets to be able to infer the attacker when it is not visible.
+		w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, nil, nil, attackerID, attackerDefID, attackerTeam)
 	end
 end
 

--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -17,6 +17,7 @@
 local ignorelist = {count = 0, ignorees = {} } -- Ignore workaround for WG table.
 local playerstate = {} -- for PlayerChangedTeam, PlayerResigned
 local resetWidgetDetailLevel = false -- has widget detail level changed
+local myPlayerID = Spring.GetLocalPlayerID()
 
 local ORDER_VERSION = 8 --- change this to reset enabled/disabled widgets
 local DATA_VERSION = 9 -- change this to reset widget settings
@@ -2347,13 +2348,17 @@ end
 
 
 function widgetHandler:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
+	local spectating = playerstate[myPlayerID].spectator
 	for _, w in r_ipairs(self.UnitDamagedList) do
 		-- The engine only provides attackerID etc if the attacker is visible.
 		-- OTOH weaponDefID and projectileID are always provided - elide projectileID so that widgets can't aquire projectile vector and locate the attacker.
-		w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, nil, attackerID, attackerDefID, attackerTeam)
+		if spectating then
+			w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, projectileID, attackerID, attackerDefID, attackerTeam)
+		else
+			w:UnitDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, attackerID and weaponDefID, nil, attackerID, attackerDefID, attackerTeam)
+		end
 	end
 end
-
 function widgetHandler:UnitStunned(unitID, unitDefID, unitTeam, stunned)
 	for _, w in r_ipairs(self.UnitStunnedList) do
 		w:UnitStunned(unitID, unitDefID, unitTeam, stunned)


### PR DESCRIPTION
This should be safe to do since https://github.com/beyond-all-reason/spring/issues/391 was fixed in the engine.

As player I get the callin info when I have line of sight, but not when I don't - I think this is OK?

<img width="366" alt="image" src="https://github.com/ZeroK-RTS/Zero-K/assets/1387874/216d1d35-80f3-40db-93dd-452e2735519c">
<img width="382" alt="image" src="https://github.com/ZeroK-RTS/Zero-K/assets/1387874/e35f9124-ebbf-410e-992d-93bb20c4b9f0">
