### PR TITLE
Fixing desolator colvol to be less abhorent

### DIFF
--- a/units/turretheavy.lua
+++ b/units/turretheavy.lua
@@ -179,6 +179,9 @@ return { turretheavy = {
       footprintX       = 3,
       footprintZ       = 3,
       object           = [[ddm_dead.s3o]],
+      collisionVolumeOffsets        = [[0 -5 10]],
+      collisionVolumeScales         = [[100 80 55]],
+      collisionVolumeType           = [[ellipsoid]],
     },
 
 


### PR DESCRIPTION
Old:
![image](https://github.com/ZeroK-RTS/Zero-K/assets/6192259/44f59aab-65b9-42ed-9c9a-ef79de66c7c1)
New:
![image](https://github.com/ZeroK-RTS/Zero-K/assets/6192259/8a4321cd-91c5-4cfe-aded-1c666e24ce1d)
![image](https://github.com/ZeroK-RTS/Zero-K/assets/6192259/9620791e-9ea9-4322-9e70-9f27c00a37f5)
![image](https://github.com/ZeroK-RTS/Zero-K/assets/6192259/d6703533-4f21-4f49-ae46-0f3999c3676b)

It's not covering the sticky-out bit but there's no way to do that without worse side effects with our current colvol technology and its sufficiently low down that most units won't fire through that space.