### PR TITLE
Commanders no longer spawn on top of each other

### DIFF
--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -302,7 +302,7 @@ local function CanUnitDropHere(unitDefID, x, y, z, facing, checkFeature)
 	end
 end
 
-local function GetAdjustedDropPosition(unitDefID, facing, x, z)
+local function GetClosestValidSpawnSpot(unitDefID, facing, x, z)
 	local radius = 16 -- FIXME: take the actual unit footprint size, perhaps also facing for nota style comms
 	local y = Spring.GetGroundHeight(x, z)
 	local canDropHere = CanUnitDropHere(unitDefID, x, y, z, facing, false)
@@ -367,7 +367,7 @@ local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartO
 		
 		-- get facing direction
 		local facing = GetFacingDirection(x, z, teamID)
-		x, y, z = GetAdjustedDropPosition(startUnit, facing, x, z) -- adjust for new location.
+		x, y, z = GetClosestValidSpawnSpot(startUnit, facing, x, z) -- adjust for new location.
 
 		if CAMPAIGN_SPAWN_DEBUG then
 			local _, aiName = Spring.GetAIInfo(teamID)

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -305,6 +305,7 @@ local function GetClosestValidSpawnSpot(teamID, unitDefID, facing, x, z)
 	local dir = 1 -- 1: right, 2: up, 3: left, 4 down
 	local nx, ny, nz
 	local offsetX, offsetZ = 0, 0
+	local aborted = false
 	repeat -- 1 right, 1 up, 2 left, 2 down, 3 right, 3 up
 		nx = x + offsetX
 		nz = z + offsetZ
@@ -319,7 +320,7 @@ local function GetClosestValidSpawnSpot(teamID, unitDefID, facing, x, z)
 				movesLeft = mag
 				dir = dir%4 + 1
 			elseif mag == 8 and movesLeft == 0 and dir == 4 then -- abort
-				canDropHere = true 
+				aborted = true 
 			else -- move to the next offset
 				if dir == 1 then
 					offsetX = offsetX + radius
@@ -333,8 +334,12 @@ local function GetClosestValidSpawnSpot(teamID, unitDefID, facing, x, z)
 				movesLeft = movesLeft - 1
 			end
 		end
-	until canDropHere
-	return nx, ny, nz
+	until canDropHere or aborted
+	if canDropHere then
+		return nx, ny, nz
+	else -- aborted: give original position back.
+		return x, Spring.GetGroundHeight(x, z), z
+	end
 end
 	
 local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartOfTheGame)

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -303,7 +303,7 @@ local function CanUnitDropHere(unitDefID, x, y, z, facing, checkFeature)
 end
 
 local function GetAdjustedDropPosition(unitDefID, facing, x, z)
-	local radius = 16
+	local radius = 16 -- FIXME: take the actual unit footprint size, perhaps also facing for nota style comms
 	local y = Spring.GetGroundHeight(x, z)
 	local canDropHere = CanUnitDropHere(unitDefID, x, y, z, facing, false)
 	if canDropHere then return x, y, z end

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -380,7 +380,7 @@ local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartO
 		
 		-- get facing direction
 		local facing = GetFacingDirection(x, z, teamID)
-		x, y, z = GetClosestValidSpawnSpot(startUnit, facing, x, z) -- adjust for new location.
+		x, y, z = GetClosestValidSpawnSpot(teamID, startUnit, facing, x, z) -- adjust for new location.
 
 		if CAMPAIGN_SPAWN_DEBUG then
 			local _, aiName = Spring.GetAIInfo(teamID)

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -282,6 +282,50 @@ local function GetStartPos(teamID, teamInfo, isAI)
 	return x, y, z
 end
 
+local offsetGrid = {
+	[1] = {-1, 0},
+	[2] = {-1, -1},
+	[3] = {0, -1},
+	[4] = {1, -1},
+	[5] = {1, 0},
+	[6] = {1, 1},
+	[7] = {0, 1},
+	[8] = {-1, 1},
+}
+
+local function CanUnitDropHere(unitDefID, x, y, z, facing, checkFeature)
+	local blocking, feature = Spring.TestBuildOrder(unitDefID, x, y, z, facing)
+	if checkFeature then
+		return blocking == 3 -- Recoil engine now has 3 for "free", 2 for "blocked by feature"
+	else
+		return blocking > 1
+	end
+end
+
+local function GetAdjustedDropPosition(unitDefID, facing, x, z)
+	local radius = 16
+	local y = Spring.GetGroundHeight(x, z)
+	local canDropHere = CanUnitDropHere(unitDefID, x, y, z, facing, false)
+	if canDropHere then return x, y, z end
+	local mag = 1
+	local index = 1
+	local nx, ny, nz
+	repeat
+		nx = x + (offsetGrid[index][1] * radius * mag)
+		nz = z + (offsetGrid[index][2] * radius * mag)
+		ny = Spring.GetGroundHeight(nx, nz)
+		canDropHere = CanUnitDropHere(unitDefID, nx, ny, nz, facing, false)
+		if not canDropHere then 
+			index = index + 1
+			if index == 9 then
+				index = 1
+				mag = mag + 1
+			end
+		end
+	until canDropHere
+	return nx, ny, nz
+end
+	
 local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartOfTheGame)
 	if not teamID then
 		return
@@ -323,6 +367,7 @@ local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartO
 		
 		-- get facing direction
 		local facing = GetFacingDirection(x, z, teamID)
+		x, y, z = GetAdjustedDropPosition(startUnit, facing, x, z) -- adjust for new location.
 
 		if CAMPAIGN_SPAWN_DEBUG then
 			local _, aiName = Spring.GetAIInfo(teamID)

--- a/LuaRules/Gadgets/start_unit_setup.lua
+++ b/LuaRules/Gadgets/start_unit_setup.lua
@@ -311,35 +311,32 @@ local function GetClosestValidSpawnSpot(teamID, unitDefID, facing, x, z)
 		nz = z + offsetZ
 		ny = Spring.GetGroundHeight(nx, nz)
 		canDropHere = CanUnitDropHere(startBoxID, unitDefID, nx, ny, nz, facing, false, true)
-		if not canDropHere then 
-			if movesLeft == 0 and not (mag == 8 and movesLeft == 0 and dir == 4) then 
-				spiralChangeNumber = spiralChangeNumber + 1
-				if spiralChangeNumber%3 == 0 then 
-					mag = mag + 1
-				end
-				movesLeft = mag
-				dir = dir%4 + 1
-			elseif mag == 8 and movesLeft == 0 and dir == 4 then -- abort
-				aborted = true 
-			else -- move to the next offset
-				if dir == 1 then
-					offsetX = offsetX + radius
-				elseif dir == 2 then
-					offsetZ = offsetZ + radius
-				elseif dir == 3 then
-					offsetX = offsetX - radius
-				elseif dir == 4 then
-					offsetZ = offsetZ - radius
-				end
-				movesLeft = movesLeft - 1
+		if canDropHere then
+			return nx, ny, nz
+		end
+		if movesLeft == 0 and not (mag == 8 and movesLeft == 0 and dir == 4) then 
+			spiralChangeNumber = spiralChangeNumber + 1
+			if spiralChangeNumber%3 == 0 then 
+				mag = mag + 1
 			end
+			movesLeft = mag
+			dir = dir%4 + 1
+		elseif mag == 8 and movesLeft == 0 and dir == 4 then -- abort
+			aborted = true 
+		else -- move to the next offset
+			if dir == 1 then
+				offsetX = offsetX + radius
+			elseif dir == 2 then
+				offsetZ = offsetZ + radius
+			elseif dir == 3 then
+				offsetX = offsetX - radius
+			elseif dir == 4 then
+				offsetZ = offsetZ - radius
+			end
+			movesLeft = movesLeft - 1
 		end
 	until canDropHere or aborted
-	if canDropHere then
-		return nx, ny, nz
-	else -- aborted: give original position back.
-		return x, Spring.GetGroundHeight(x, z), z
-	end
+	return x, Spring.GetGroundHeight(x, z), z -- aborted, return original position.
 end
 	
 local function SpawnStartUnit(teamID, playerID, isAI, bonusSpawn, notAtTheStartOfTheGame)


### PR DESCRIPTION
This is an enhancement added in FW v0.38.22 to help players understand that they have multiple comms. Comms that spawn on top of each other will also (very) slowly float away due to impulse sliding, which is just silly.