### PR TITLE
fix: Make the first ally color a bit whiter overall, as it doesn't contrast well with the dark outline

### DIFF
--- a/LuaUI/Configs/TeamColorConfig.lua
+++ b/LuaUI/Configs/TeamColorConfig.lua
@@ -7,14 +7,13 @@ end
 
 local colors = {
 	myColor		= Range({ 050, 250, 050 }),	-- can only be 1 color
---	myColor		= Range({ 008, 192, 016 }),
 	gaiaColor	= Range({ 200, 200, 200 }),	-- can only be 1 color
 	
 	allyColors = {
 	  -- the first three ally colours are shades of blue
 	  -- this is so that in a MM game (4v4 or less) you are the only one green
 	  -- this is effectively soft simplecolors without the main disadvantage
-	  Range({ 010, 080, 255 }),
+	  Range({ 050, 110, 255 }),
 	  Range({ 010, 250, 250 }),
 	  Range({ 150, 150, 255 }),
 
@@ -50,7 +49,6 @@ local colors = {
 
 local colorsTeal = {
 	myColor		= Range({ 013, 245, 243 }),	-- can only be 1 color
---	myColor		= Range({ 008, 192, 016 }),
 	gaiaColor	= Range({ 200, 200, 200 }),	-- can only be 1 color
 	
 	allyColors = {
@@ -130,13 +128,6 @@ local simpleColors = {
 	allyColors = {colors.allyColors[1]},
 	enemyColors = {colors.enemyColors[1]},
 	enemyByTeamColors = colors.enemyColors,
-}
-
-local simpleColorsTeams = {
-	myColor = colors.myColor,
-	gaiaColor = colors.gaiaColor,
-	allyColors = {colors.allyColors[1]},
-	enemyColors = colors.enemyColors,
 }
 
 local simpleColorblind = {

--- a/LuaUI/Widgets/gui_local_colors.lua
+++ b/LuaUI/Widgets/gui_local_colors.lua
@@ -18,18 +18,6 @@ local campaignBattleID = Spring.GetModOptions().singleplayercampaignbattleid
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 
-local function GetColorConfig()
-	if VFS.FileExists("LuaUI/Configs/LocalColors.lua", VFS.RAW_FIRST) then -- user override
-		Spring.Echo("Loaded local team color config.")
-		return VFS.Include("LuaUI/Configs/LocalColors.lua", nil, VFS.RAW_FIRST)
-	elseif VFS.FileExists("LuaUI/Configs/ZKTeamColors.lua") then
-		return VFS.Include("LuaUI/Configs/ZKTeamColors.lua")
-	else
-		error("missing file: LuaUI/Configs/LocalColors.lua")
-	end
-	return {}
-end
-
 local function FixRanges(colors)
 	if colors.myColor[1] <= 1 and colors.myColor[2] <= 1 and colors.myColor[3] < 1 and
 			colors.gaiaColor[1] <= 1 and colors.gaiaColor[2] <= 1 and colors.gaiaColor[3] < 1 then


### PR DESCRIPTION
Plus some cleanup of unused code.

As discussed in Discord the first ally blue isn't very readable next to the other colors. Tried to tweak it a little without losing too much of the blueness.

Before:

![image](https://github.com/ZeroK-RTS/Zero-K/assets/1387874/90af142c-42e7-4f6c-baaa-90aec83476ef)

After:

![image](https://github.com/ZeroK-RTS/Zero-K/assets/1387874/2581904e-72b3-4c71-ab0b-61edda5c8de7)
