### PR TITLE
BAR selection widget 

### DIFF
--- a/LuaUI/Widgets/Include/DrawPrimitiveAtUnit.lua
+++ b/LuaUI/Widgets/Include/DrawPrimitiveAtUnit.lua
@@ -1,0 +1,98 @@
+-------------------------------------------------
+-- An API wrapper to draw simple graphical primitives at units extremely efficiently
+-- License: Lua code GPL V2, GLSL shader code: (c) Beherith (mysterme@gmail.com)
+-------------------------------------------------
+
+local DrawPrimitiveAtUnit = {}
+
+local shaderConfig = {
+	TRANSPARENCY = 0.2, -- transparency of the stuff drawn
+	HEIGHTOFFSET = 1, -- Additional height added to everything
+	ANIMATION = 1, -- set to 0 if you dont want animation
+	INITIALSIZE = 0.66, -- What size the stuff starts off at when spawned
+	GROWTHRATE = 4, -- How fast it grows to full size
+	BREATHERATE = 30.0, -- how fast it periodicly grows
+	BREATHESIZE = 0.05, -- how much it periodicly grows
+	TEAMCOLORIZATION = 1.0, -- not used yet
+	CLIPTOLERANCE = 1.1, -- At 1.0 it wont draw at units just outside of view (may pop in), 1.1 is a good safe amount
+	USETEXTURE = 1, -- 1 if you want to use textures (atlasses too!) , 0 if not
+	BILLBOARD = 0, -- 1 if you want camera facing billboards, 0 is flat on ground
+	POST_ANIM = " ", -- what you want to do in the animation post function (glsl snippet, see shader source)
+	POST_VERTEX = "v_color = v_color;", -- noop
+	POST_GEOMETRY = "gl_Position.z = (gl_Position.z) - 256.0 / (gl_Position.w);",	--"g_uv.zw = dataIn[0].v_parameters.xy;", -- noop
+	POST_SHADING = "fragColor.rgba = fragColor.rgba;", -- noop
+	MAXVERTICES = 64, -- The max number of vertices we can emit, make sure this is consistent with what you are trying to draw (tris 3, quads 4, corneredrect 8, circle 64
+	USE_CIRCLES = 1, -- set to nil if you dont want circles
+	USE_CORNERRECT = 1, -- set to nil if you dont want cornerrect
+	USE_TRIANGLES = 1, -- set to nil if you dont want to use tris
+	USE_QUADS = 1, -- set to nil if you dont want to use quads
+	FULL_ROTATION = 0, -- the primitive is fully rotated in the units plane
+	DISCARD = 0, -- Enable alpha threshold to discard fragments below 0.01
+	ROTATE_CIRCLES = 1, -- Set to 0 if you dont want circles to be rotated
+	PRE_OFFSET = "",
+}
+
+---- GL4 Backend Stuff----
+local DrawPrimitiveAtUnitVBO = nil
+local DrawPrimitiveAtUnitShader = nil
+
+local luaShaderDir = "LuaUI/Widgets/Include/"
+local LuaShader = VFS.Include(luaShaderDir.."LuaShader.lua")
+VFS.Include(luaShaderDir.."instancevbotable.lua")
+
+local vsSrcPath = "LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl"
+local gsSrcPath = "LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl"
+local fsSrcPath = "LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.frag.glsl"
+
+local shaderSourceCache = {
+		vssrcpath = vsSrcPath,
+		fssrcpath = fsSrcPath,
+		gssrcpath = gsSrcPath,
+		shaderName = "DrawPrimitiveAtUnit",
+		uniformInt = {},
+		uniformFloat = {
+			addRadius = 0.0,
+			iconDistance = 20000.0,
+		  },
+		shaderConfig = shaderConfig,
+	}
+
+local function InitDrawPrimitiveAtUnit(shaderConfig, DPATname)
+	if shaderConfig.USETEXTURE then 
+		shaderSourceCache.uniformInt = {DrawPrimitiveAtUnitTexture = 0,}
+	end
+	
+	shaderSourceCache.shaderName = DPATname .. "Shader GL4"
+	
+	DrawPrimitiveAtUnitShader =  LuaShader.CheckShaderUpdates(shaderSourceCache)
+
+	if not DrawPrimitiveAtUnitShader then 
+		Spring.Echo("Failed to compile shader for ", DPATname)
+		return nil
+	end
+
+	DrawPrimitiveAtUnitVBO = makeInstanceVBOTable(
+		{
+			{id = 0, name = 'lengthwidthcorner', size = 4},
+			{id = 1, name = 'teamID', size = 1, type = GL.UNSIGNED_INT},
+			{id = 2, name = 'numvertices', size = 1, type = GL.UNSIGNED_INT},
+			{id = 3, name = 'parameters', size = 4},
+			{id = 4, name = 'uvoffsets', size = 4},
+			{id = 5, name = 'instData', size = 4, type = GL.UNSIGNED_INT},
+		},
+		64, -- maxelements
+		DPATname .. "VBO", -- name
+		5  -- unitIDattribID (instData)
+	)
+	if DrawPrimitiveAtUnitVBO == nil then 
+		Spring.Echo("Failed to create DrawPrimitiveAtUnitVBO for ", DPATname) 
+		return nil
+	end
+
+	local DrawPrimitiveAtUnitVAO = gl.GetVAO()
+	DrawPrimitiveAtUnitVAO:AttachVertexBuffer(DrawPrimitiveAtUnitVBO.instanceVBO)
+	DrawPrimitiveAtUnitVBO.VAO = DrawPrimitiveAtUnitVAO
+	return  DrawPrimitiveAtUnitVBO, DrawPrimitiveAtUnitShader
+end
+
+return {InitDrawPrimitiveAtUnit = InitDrawPrimitiveAtUnit, shaderConfig = shaderConfig}

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.frag.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.frag.glsl
@@ -1,0 +1,33 @@
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+
+// This shader is (c) Beherith (mysterme@gmail.com)
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+
+#line 30000
+uniform float addRadius = 0.0;
+uniform float iconDistance = 20000.0;
+in DataGS {
+	vec4 g_color;
+	vec4 g_uv;
+};
+
+uniform sampler2D DrawPrimitiveAtUnitTexture;
+out vec4 fragColor;
+
+void main(void)
+{
+	vec4 texcolor = vec4(1.0);
+	#if (USETEXTURE == 1)
+		texcolor = texture(DrawPrimitiveAtUnitTexture, g_uv.xy);
+	#endif
+	fragColor.rgba = vec4(g_color.rgb * texcolor.rgb + addRadius, texcolor.a * TRANSPARENCY + addRadius);
+	POST_SHADING
+	//fragColor.rgba = vec4(1.0);
+	#if (DISCARD == 1)
+		if (fragColor.a < 0.01) discard;
+	#endif
+}

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
@@ -1,0 +1,137 @@
+#version 330
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+
+// This shader is (c) Beherith (mysterme@gmail.com)
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+layout(points) in;
+layout(triangle_strip, max_vertices = MAXVERTICES) out;
+#line 20000
+
+uniform float addRadius = 0.0;
+uniform float iconDistance = 20000.0;
+
+in DataVS {
+	uint v_numvertices;
+	float v_rotationY;
+	vec4 v_color;
+	vec4 v_lengthwidthcornerheight;
+	vec4 v_centerpos;
+	vec4 v_uvoffsets;
+	vec4 v_parameters;
+	#if (FULL_ROTATION == 1)
+		mat3 v_fullrotation;
+	#endif
+} dataIn[];
+
+out DataGS {
+	vec4 g_color;
+	vec4 g_uv;
+};
+
+mat3 rotY;
+vec4 centerpos;
+vec4 uvoffsets;
+
+// This function takes in a set of UV coordinates [0,1] and tranforms it to correspond to the correct UV slice of an atlassed texture
+vec2 transformUV(float u, float v){// this is needed for atlassing
+	//return vec2(uvoffsets.p * u + uvoffsets.q, uvoffsets.s * v + uvoffsets.t); old
+	float a = uvoffsets.t - uvoffsets.s;
+	float b = uvoffsets.q - uvoffsets.p;
+	return vec2(uvoffsets.s + a * u, uvoffsets.p + b * v);
+}
+
+void offsetVertex4( float x, float y, float z, float u, float v){
+	g_uv.xy = transformUV(u,v);
+	vec3 primitiveCoords = vec3(x,y,z);
+	vec3 vecnorm = normalize(primitiveCoords);
+	PRE_OFFSET
+	gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * ( addRadius * vecnorm + primitiveCoords ), 1.0);
+	g_uv.zw = dataIn[0].v_parameters.zw;
+	POST_GEOMETRY
+	EmitVertex();
+}
+#line 22000
+void main(){
+	uint numVertices = dataIn[0].v_numvertices;
+	centerpos = dataIn[0].v_centerpos;
+	#if (BILLBOARD == 1 )
+		rotY = mat3(cameraViewInv[0].xyz,cameraViewInv[2].xyz, cameraViewInv[1].xyz); // swizzle cause we use xz
+	#else
+		#if (FULL_ROTATION == 1)
+			rotY = dataIn[0].v_fullrotation; // Use the units true rotation
+		#else
+			#if (ROTATE_CIRCLES == 1)
+				rotY = rotation3dY(-1*dataIn[0].v_rotationY); // Create a rotation matrix around Y from the unit's rotation
+			#else
+				if (numVertices > uint(5)) rotY = mat3(1.0) ;
+				else rotY = rotation3dY(-1*dataIn[0].v_rotationY);
+			#endif
+		#endif
+	#endif
+
+	g_color = dataIn[0].v_color;
+
+	uvoffsets = dataIn[0].v_uvoffsets; // if an atlas is used, then use this, otherwise dont
+
+	float length = dataIn[0].v_lengthwidthcornerheight.x;
+	float width = dataIn[0].v_lengthwidthcornerheight.y;
+	float cs = dataIn[0].v_lengthwidthcornerheight.z;
+	float height = dataIn[0].v_lengthwidthcornerheight.w;
+	
+	#ifdef USE_TRIANGLES
+		if (numVertices == uint(3)){ // triangle pointing "forward"
+			offsetVertex4(0.0, 0.0, length, 0.5, 1.0); // xyz uv
+			offsetVertex4(-0.866 * width, 0.0, -0.5 * length, 0.0, 0.0);
+			offsetVertex4(0.866* width, 0.0, -0.5 * length, 1.0, 0.0);
+			EndPrimitive();
+		}
+	#endif
+	
+	#ifdef USE_QUADS
+		if (numVertices == uint(4)){ // A quad
+			offsetVertex4( width * 0.5, 0.0,  length * 0.5, 0.0, 1.0);
+			offsetVertex4( width * 0.5, 0.0, -length * 0.5, 0.0, 0.0);
+			offsetVertex4(-width * 0.5, 0.0,  length * 0.5, 1.0, 1.0);
+			offsetVertex4(-width * 0.5, 0.0, -length * 0.5, 1.0, 0.0);
+			EndPrimitive();
+		}
+	#endif
+	
+	#ifdef USE_CORNERRECT
+		if (numVertices == uint(2)){ // A quad with chopped off corners
+			float csuv = (cs / (length + width))*2.0;
+			offsetVertex4( - width * 0.5 , 0.0,  - length * 0.5 + cs, 0, csuv); // bottom left
+			offsetVertex4( - width * 0.5 , 0.0,  + length * 0.5 - cs, 0, 1.0 - csuv); // top left
+			offsetVertex4( - width * 0.5 + cs, 0.0,  - length * 0.5 , csuv, 0); // bottom left
+			offsetVertex4( - width * 0.5 + cs, 0.0,  + length * 0.5, csuv, 1.0); // top left
+			offsetVertex4( + width * 0.5 - cs, 0.0,  - length * 0.5 , 1.0 - csuv, 0.0); // bottom right
+			offsetVertex4( + width * 0.5 - cs, 0.0,  + length * 0.5 ,1.0 - csuv, 1.0 ); // top right
+			offsetVertex4( + width * 0.5 , 0.0,  - length * 0.5 + cs , 1.0 , csuv ); // bottom right
+			offsetVertex4( + width * 0.5 , 0.0,  + length * 0.5 - cs , 1.0 -csuv , 1.0 ); // top right
+			EndPrimitive();
+		}
+	#endif
+	
+	#ifdef USE_CIRCLES
+		if (numVertices > uint(5)) { //A circle with even subdivisions
+			numVertices = min(numVertices,62u); // to make sure that we dont emit more than 64 vertices
+			//left most vertex
+			offsetVertex4(- width * 0.5, 0.0,  0, 0.0, 0.5);
+			int numSides = int(numVertices) / 2;
+			//for each phi in (-PI/2, Pi/2) omit the first and last one
+			for (int i = 1; i < numSides; i++){
+				float phi = ((i * 3.141592) / numSides) -  1.5707963;
+				float sinphi = sin(phi);
+				float cosphi = cos(phi);
+				offsetVertex4( width * 0.5 * sinphi, 0.0,  length * 0.5 * cosphi, sinphi*0.5 + 0.5, cosphi * 0.5 + 0.5);
+				offsetVertex4( width * 0.5 * sinphi, 0.0,  -length * 0.5 * cosphi, sinphi*0.5 + 0.5, cosphi *(-0.5) + 0.5);
+			}
+			// add right most vertex
+			offsetVertex4(width * 0.5, 0.0,  0, 1.0, 0.5);
+			EndPrimitive();
+		}
+	#endif
+}

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
@@ -43,12 +43,12 @@ vec2 transformUV(float u, float v){// this is needed for atlassing
 	return vec2(uvoffsets.s + a * u, uvoffsets.p + b * v);
 }
 
-void offsetVertex4( float x, float y, float z, float u, float v){
+void offsetVertex4(float x, float y, float z, float u, float v, float addRadiusCorr){
 	g_uv.xy = transformUV(u,v);
 	vec3 primitiveCoords = vec3(x,y,z);
 	vec3 vecnorm = normalize(primitiveCoords);
 	PRE_OFFSET
-	gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * ( addRadius * vecnorm + primitiveCoords ), 1.0);
+	gl_Position = cameraViewProj * vec4(centerpos.xyz + rotY * (addRadius * addRadiusCorr * vecnorm + primitiveCoords ), 1.0);
 	g_uv.zw = dataIn[0].v_parameters.zw;
 	POST_GEOMETRY
 	EmitVertex();
@@ -82,55 +82,42 @@ void main(){
 	float height = dataIn[0].v_lengthwidthcornerheight.w;
 	
 	#ifdef USE_TRIANGLES
-		if (numVertices == uint(3)){ // triangle pointing "forward"
-			offsetVertex4(0.0, 0.0, length, 0.5, 1.0); // xyz uv
-			offsetVertex4(-0.866 * width, 0.0, -0.5 * length, 0.0, 0.0);
-			offsetVertex4(0.866* width, 0.0, -0.5 * length, 1.0, 0.0);
+		if (numVertices == 3u){ // triangle pointing "forward"
+			offsetVertex4(0.0, 0.0, length, 0.5, 1.0, 2.000); // xyz uv
+			offsetVertex4(-0.866 * width, 0.0, -0.5 * length, 0.0, 0.0, 2.000);
+			offsetVertex4(0.866* width, 0.0, -0.5 * length, 1.0, 0.0, 2.000);
 			EndPrimitive();
 		}
 	#endif
 	
 	#ifdef USE_QUADS
-		if (numVertices == uint(4)){ // A quad
-			offsetVertex4( width * 0.5, 0.0,  length * 0.5, 0.0, 1.0);
-			offsetVertex4( width * 0.5, 0.0, -length * 0.5, 0.0, 0.0);
-			offsetVertex4(-width * 0.5, 0.0,  length * 0.5, 1.0, 1.0);
-			offsetVertex4(-width * 0.5, 0.0, -length * 0.5, 1.0, 0.0);
-			EndPrimitive();
-		}
-	#endif
-	
-	#ifdef USE_CORNERRECT
-		if (numVertices == uint(2)){ // A quad with chopped off corners
-			float csuv = (cs / (length + width))*2.0;
-			offsetVertex4( - width * 0.5 , 0.0,  - length * 0.5 + cs, 0, csuv); // bottom left
-			offsetVertex4( - width * 0.5 , 0.0,  + length * 0.5 - cs, 0, 1.0 - csuv); // top left
-			offsetVertex4( - width * 0.5 + cs, 0.0,  - length * 0.5 , csuv, 0); // bottom left
-			offsetVertex4( - width * 0.5 + cs, 0.0,  + length * 0.5, csuv, 1.0); // top left
-			offsetVertex4( + width * 0.5 - cs, 0.0,  - length * 0.5 , 1.0 - csuv, 0.0); // bottom right
-			offsetVertex4( + width * 0.5 - cs, 0.0,  + length * 0.5 ,1.0 - csuv, 1.0 ); // top right
-			offsetVertex4( + width * 0.5 , 0.0,  - length * 0.5 + cs , 1.0 , csuv ); // bottom right
-			offsetVertex4( + width * 0.5 , 0.0,  + length * 0.5 - cs , 1.0 -csuv , 1.0 ); // top right
+		if (numVertices == 4u){ // A quad
+			offsetVertex4( width * 0.5, 0.0,  length * 0.5, 0.0, 1.0, 1.414);
+			offsetVertex4( width * 0.5, 0.0, -length * 0.5, 0.0, 0.0, 1.414);
+			offsetVertex4(-width * 0.5, 0.0,  length * 0.5, 1.0, 1.0, 1.414);
+			offsetVertex4(-width * 0.5, 0.0, -length * 0.5, 1.0, 0.0, 1.414);
 			EndPrimitive();
 		}
 	#endif
 	
 	#ifdef USE_CIRCLES
-		if (numVertices > uint(5)) { //A circle with even subdivisions
+		if (numVertices > 5u){ // A circle with even subdivisions
 			numVertices = min(numVertices,62u); // to make sure that we dont emit more than 64 vertices
+			float internalAngle = float(numVertices) * radians(180.0) / float(numVertices);
+			float addRadiusCorr = 1 / sin(internalAngle / 2.0);
 			//left most vertex
-			offsetVertex4(- width * 0.5, 0.0,  0, 0.0, 0.5);
+			offsetVertex4(- width * 0.5, 0.0,  0, 0.0, 0.5, addRadiusCorr);
 			int numSides = int(numVertices) / 2;
 			//for each phi in (-PI/2, Pi/2) omit the first and last one
 			for (int i = 1; i < numSides; i++){
 				float phi = ((i * 3.141592) / numSides) -  1.5707963;
 				float sinphi = sin(phi);
 				float cosphi = cos(phi);
-				offsetVertex4( width * 0.5 * sinphi, 0.0,  length * 0.5 * cosphi, sinphi*0.5 + 0.5, cosphi * 0.5 + 0.5);
-				offsetVertex4( width * 0.5 * sinphi, 0.0,  -length * 0.5 * cosphi, sinphi*0.5 + 0.5, cosphi *(-0.5) + 0.5);
+				offsetVertex4( width * 0.5 * sinphi, 0.0,  length * 0.5 * cosphi, sinphi*0.5 + 0.5, cosphi * 0.5 + 0.5, addRadiusCorr);
+				offsetVertex4( width * 0.5 * sinphi, 0.0,  -length * 0.5 * cosphi, sinphi*0.5 + 0.5, cosphi *(-0.5) + 0.5, addRadiusCorr);
 			}
 			// add right most vertex
-			offsetVertex4(width * 0.5, 0.0,  0, 1.0, 0.5);
+			offsetVertex4(width * 0.5, 0.0,  0, 1.0, 0.5, addRadiusCorr);
 			EndPrimitive();
 		}
 	#endif

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
@@ -103,7 +103,6 @@ void main(){
 	#ifdef USE_CIRCLES
 		if (numVertices > 5u){ // A circle with even subdivisions
 			numVertices = min(numVertices,62u); // to make sure that we dont emit more than 64 vertices
-			// FIXME: Test whether this has any effect on performance. Could just use one and/or hardcode some more cases.
 			float internalAngle = float(numVertices) * radians(180.0) / float(numVertices);
 			float addRadiusCorr = 1 / sin(internalAngle / 2.0);
 			//left most vertex

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
@@ -102,8 +102,8 @@ void main(){
 	
 	#ifdef USE_CIRCLES
 		if (numVertices > 5u){ // A circle with even subdivisions
-			numVertices = min(numVertices,62u); // to make sure that we dont emit more than 64 vertices
-			float internalAngle = float(numVertices) * radians(180.0) / float(numVertices);
+			numVertices = min(numVertices,64u); // to make sure that we dont emit more than 64 vertices
+			float internalAngle = float(numVertices - 2u) * radians(180.0) / float(numVertices);
 			float addRadiusCorr = 1 / sin(internalAngle / 2.0);
 			//left most vertex
 			offsetVertex4(- width * 0.5, 0.0,  0, 0.0, 0.5, addRadiusCorr);

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.geom.glsl
@@ -103,6 +103,7 @@ void main(){
 	#ifdef USE_CIRCLES
 		if (numVertices > 5u){ // A circle with even subdivisions
 			numVertices = min(numVertices,62u); // to make sure that we dont emit more than 64 vertices
+			// FIXME: Test whether this has any effect on performance. Could just use one and/or hardcode some more cases.
 			float internalAngle = float(numVertices) * radians(180.0) / float(numVertices);
 			float addRadiusCorr = 1 / sin(internalAngle / 2.0);
 			//left most vertex

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
@@ -1,0 +1,105 @@
+#version 420
+#extension GL_ARB_uniform_buffer_object : require
+#extension GL_ARB_shader_storage_buffer_object : require
+#extension GL_ARB_shading_language_420pack: require
+// This shader is (c) Beherith (mysterme@gmail.com)
+
+#line 5000
+
+layout (location = 0) in vec4 lengthwidthcornerheight;
+layout (location = 1) in uint teamID;
+layout (location = 2) in uint numvertices;
+layout (location = 3) in vec4 parameters; // lifestart, ismine
+layout (location = 4) in vec4 uvoffsets; // this is optional, for using an Atlas
+layout (location = 5) in uvec4 instData;
+
+//__ENGINEUNIFORMBUFFERDEFS__
+//__DEFINES__
+
+struct SUniformsBuffer {
+    uint composite; //     u8 drawFlag; u8 unused1; u16 id;
+    
+    uint unused2;
+    uint unused3;
+    uint unused4;
+
+    float maxHealth;
+    float health;
+    float unused5;
+    float unused6;
+    
+    vec4 drawPos;
+    vec4 speed;
+    vec4[4] userDefined; //can't use float[16] because float in arrays occupies 4 * float space
+};
+
+layout(std140, binding=1) readonly buffer UniformsBuffer {
+    SUniformsBuffer uni[];
+}; 
+
+#define UNITID (uni[instData.y].composite >> 16)
+
+#line 10000
+
+uniform float addRadius = 0.0;
+uniform float iconDistance = 20000.0;
+
+out DataVS {
+	uint v_numvertices;
+	float v_rotationY;
+	vec4 v_color;
+	vec4 v_lengthwidthcornerheight;
+	vec4 v_centerpos;
+	vec4 v_uvoffsets;
+	vec4 v_parameters;
+	#if (FULL_ROTATION == 1)
+		mat3 v_fullrotation;
+	#endif
+};
+
+layout(std140, binding=0) readonly buffer MatrixBuffer {
+	mat4 UnitPieces[];
+};
+
+
+bool vertexClipped(vec4 clipspace, float tolerance) {
+  return any(lessThan(clipspace.xyz, -clipspace.www * tolerance)) ||
+         any(greaterThan(clipspace.xyz, clipspace.www * tolerance));
+}
+
+void main()
+{
+	uint baseIndex = instData.x; // this tells us which unit matrix to find
+	mat4 modelMatrix = UnitPieces[baseIndex]; // This gives us the models  world pos and rot matrix
+
+	gl_Position = cameraViewProj * vec4(modelMatrix[3].xyz, 1.0); // We transform this vertex into the center of the model
+	v_rotationY = atan(modelMatrix[0][2], modelMatrix[0][0]); // we can get the euler Y rot of the model from the model matrix
+	v_uvoffsets = uvoffsets;
+	v_parameters = parameters;
+	v_color = teamColor[teamID];  // We can lookup the teamcolor right here
+	v_centerpos = vec4( modelMatrix[3].xyz, 1.0); // We are going to pass the centerpoint to the GS
+	v_lengthwidthcornerheight = lengthwidthcornerheight;
+	#if (ANIMATION == 1)
+		float animation = clamp(((timeInfo.x + timeInfo.w) - parameters.x)/GROWTHRATE + INITIALSIZE, INITIALSIZE, 1.0) + sin((timeInfo.x)/BREATHERATE)*BREATHESIZE;
+		v_lengthwidthcornerheight.xy *= animation; // modulate it with animation factor
+	#endif
+	POST_ANIM
+	v_numvertices = numvertices;
+	if (vertexClipped(gl_Position, CLIPTOLERANCE)) v_numvertices = 0; // Make no primitives on stuff outside of screen
+	// TODO: take into account size of primitive before clipping
+
+	// this sets the num prims to 0 for units further from cam than iconDistance
+	float cameraDistance = length((cameraViewInv[3]).xyz - v_centerpos.xyz);
+	if (cameraDistance > iconDistance) v_numvertices = 0;
+
+	if (dot(v_centerpos.xyz, v_centerpos.xyz) < 1.0) v_numvertices = 0; // if the center pos is at (0,0,0) then we probably dont have the matrix yet for this unit, because it entered LOS but has not been drawn yet.
+
+	v_centerpos.y += HEIGHTOFFSET; // Add some height to ensure above groundness
+	v_centerpos.y += lengthwidthcornerheight.w; // Add per-instance height offset
+	#if (FULL_ROTATION == 1)
+		v_fullrotation = mat3(modelMatrix);
+	#endif
+	if ((uni[instData.y].composite & 0x00000003u) < 1u ) v_numvertices = 0u; // this checks the drawFlag of wether the unit is actually being drawn (this is ==1 when then unit is both visible and drawn as a full model (not icon)) 
+	// TODO: allow overriding this check, to draw things even if unit (like a building) is not drawn
+	POST_VERTEX
+}

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
@@ -80,7 +80,8 @@ void main()
 	v_centerpos = vec4( modelMatrix[3].xyz, 1.0); // We are going to pass the centerpoint to the GS
 	v_lengthwidthcornerheight = lengthwidthcornerheight;
 	#if (ANIMATION == 1)
-		float animation = clamp(((timeInfo.x + timeInfo.w) - parameters.x)/GROWTHRATE + INITIALSIZE, INITIALSIZE, 1.0) + sin((timeInfo.x)/BREATHERATE)*BREATHESIZE;
+	    // parameters.y is 0 for normal selections and 1 for preselections
+		float animation = clamp(((timeInfo.x + timeInfo.w) - parameters.x)/GROWTHRATE + INITIALSIZE, max(INITIALSIZE, float(1 - parameters.y)), 1.0) + sin((timeInfo.x)/BREATHERATE)*BREATHESIZE*parameters.y;
 		v_lengthwidthcornerheight.xy *= animation; // modulate it with animation factor
 	#endif
 	POST_ANIM

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
@@ -82,8 +82,10 @@ void main()
 	v_lengthwidthcornerheight = lengthwidthcornerheight;
 	#if (ANIMATION == 1)
 	    // No animation when parameters.y is 0
-		float animation = clamp(((timeInfo.x + timeInfo.w) - parameters.x)/GROWTHRATE + INITIALSIZE, max(INITIALSIZE, float(1 - parameters.y)), 1.0) + sin((timeInfo.x)/BREATHERATE)*BREATHESIZE*parameters.y;
-		v_lengthwidthcornerheight.xy *= animation; // modulate it with animation factor
+		float initial = clamp(((timeInfo.x + timeInfo.w) - parameters.x)/GROWTHRATE + INITIALSIZE, max(INITIALSIZE, float(1 - parameters.y)), 1.0);
+		float breathe = 64.0 * (BREATHESIZE + sin((timeInfo.x)/BREATHERATE)*BREATHESIZE*parameters.y);
+		v_lengthwidthcornerheight.xy *= initial;
+		v_lengthwidthcornerheight.xy += breathe;
 	#endif
 	POST_ANIM
 	v_numvertices = numvertices;

--- a/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
+++ b/LuaUI/Widgets/Shaders/DrawPrimitiveAtUnit.vert.glsl
@@ -9,7 +9,7 @@
 layout (location = 0) in vec4 lengthwidthcornerheight;
 layout (location = 1) in uint teamID;
 layout (location = 2) in uint numvertices;
-layout (location = 3) in vec4 parameters; // lifestart, ismine
+layout (location = 3) in vec4 parameters; // time start, animate, unused, unused
 layout (location = 4) in vec4 uvoffsets; // this is optional, for using an Atlas
 layout (location = 5) in uvec4 instData;
 
@@ -76,11 +76,12 @@ void main()
 	v_rotationY = atan(modelMatrix[0][2], modelMatrix[0][0]); // we can get the euler Y rot of the model from the model matrix
 	v_uvoffsets = uvoffsets;
 	v_parameters = parameters;
-	v_color = teamColor[teamID];  // We can lookup the teamcolor right here
+	// teamID 255 is used for local selection color
+	v_color = teamID == 255 ? vec4(0.1, 1.0, 0.2, 1.0) : teamColor[teamID];
 	v_centerpos = vec4( modelMatrix[3].xyz, 1.0); // We are going to pass the centerpoint to the GS
 	v_lengthwidthcornerheight = lengthwidthcornerheight;
 	#if (ANIMATION == 1)
-	    // parameters.y is 0 for normal selections and 1 for preselections
+	    // No animation when parameters.y is 0
 		float animation = clamp(((timeInfo.x + timeInfo.w) - parameters.x)/GROWTHRATE + INITIALSIZE, max(INITIALSIZE, float(1 - parameters.y)), 1.0) + sin((timeInfo.x)/BREATHERATE)*BREATHESIZE*parameters.y;
 		v_lengthwidthcornerheight.xy *= animation; // modulate it with animation factor
 	#endif

--- a/LuaUI/Widgets/gui_selectedunits_gl4.lua
+++ b/LuaUI/Widgets/gui_selectedunits_gl4.lua
@@ -1,0 +1,272 @@
+function widget:GetInfo()
+	return {
+		name = "Selected Units GL4",
+		desc = "Draw geometric pritives at any unit",
+		author = "Beherith, Floris",
+		date = "2021.05.16",
+		license = "GNU GPL, v2 or later",
+		layer = -50,
+		enabled = true,
+	}
+end
+
+-- Configurable Parts:
+local texture = "luaui/images/solid.png"
+
+local opacity = 0.19
+local teamcolorOpacity = 0.6
+
+---- GL4 Backend Stuff----
+local selectionVBO = nil
+local selectShader = nil
+local luaShaderDir = "LuaUI/Widgets/Include/"
+
+local hasBadCulling = ((Platform.gpuVendor == "AMD" and Platform.osFamily == "Linux") == true)
+-- Localize for speedups:
+local glStencilFunc         = gl.StencilFunc
+local glStencilOp           = gl.StencilOp
+local glStencilTest         = gl.StencilTest
+local glStencilMask         = gl.StencilMask
+local glDepthTest           = gl.DepthTest
+local glTexture             = gl.Texture
+local glClear               = gl.Clear
+local GL_ALWAYS             = GL.ALWAYS
+local GL_NOTEQUAL           = GL.NOTEQUAL
+local GL_KEEP               = 0x1E00 --GL.KEEP
+local GL_STENCIL_BUFFER_BIT = GL.STENCIL_BUFFER_BIT
+local GL_REPLACE            = GL.REPLACE
+local GL_POINTS				= GL.POINTS
+
+local selUnits = {}
+local updateSelection = true
+local selectedUnits = Spring.GetSelectedUnits()
+
+local unitTeam = {}
+local unitUnitDefID = {}
+
+local unitScale = {}
+local unitCanFly = {}
+local unitBuilding = {}
+for unitDefID, unitDef in pairs(UnitDefs) do
+	unitScale[unitDefID] = (7.5 * ( unitDef.xsize^2 + unitDef.zsize^2 ) ^ 0.5) + 8
+	if unitDef.canFly then
+		unitCanFly[unitDefID] = true
+		unitScale[unitDefID] = unitScale[unitDefID] * 0.7
+	elseif unitDef.isBuilding or unitDef.isFactory or unitDef.speed==0 then
+		unitBuilding[unitDefID] = {
+			unitDef.xsize * 8.2 + 12,
+			unitDef.zsize * 8.2 + 12
+		}
+	end
+end
+
+local function AddPrimitiveAtUnit(unitID)
+	if Spring.ValidUnitID(unitID) ~= true or Spring.GetUnitIsDead(unitID) == true then return end
+	local gf = Spring.GetGameFrame()
+
+	if not unitUnitDefID[unitID] then
+		unitUnitDefID[unitID] = Spring.GetUnitDefID(unitID)
+	end
+	local unitDefID = unitUnitDefID[unitID]
+	if unitDefID == nil then return end -- these cant be selected
+
+	local numVertices = 64 -- default to cornered rectangle
+	local cornersize = 0
+
+	local radius = unitScale[unitDefID]
+
+	if not unitTeam[unitID] then
+		unitTeam[unitID] = Spring.GetUnitTeam(unitID)
+	end
+
+	local additionalheight = 0
+	local width, length
+	if unitCanFly[unitDefID] then
+		numVertices = 3 -- triangles for planes
+		width = radius
+		length = radius
+	elseif unitBuilding[unitDefID] then
+		width = unitBuilding[unitDefID][1]
+		length = unitBuilding[unitDefID][2]
+		cornersize = (width + length) * 0.075
+		numVertices = 2
+	else
+		width = radius
+		length = radius
+	end
+
+	--Spring.Echo(unitID,radius,radius, Spring.GetUnitTeam(unitID), numvertices, 1, gf)
+	pushElementInstance(
+		selectionVBO, -- push into this Instance VBO Table
+		{
+			length, width, cornersize, additionalheight,  -- lengthwidthcornerheight
+			unitTeam[unitID], -- teamID
+			numVertices, -- how many trianges should we make
+			gf, 0, 0, 0, -- the gameFrame (for animations), and any other parameters one might want to add
+			0, 1, 0, 1, -- These are our default UV atlas tranformations
+			0, 0, 0, 0 -- these are just padding zeros, that will get filled in
+		},
+		unitID, -- this is the key inside the VBO TAble,
+		true, -- update existing element
+		nil, -- noupload, dont use unless you
+		unitID -- last one should be UNITID?
+	)
+end
+
+local drawFrame = 0
+function widget:DrawWorldPreUnit()
+	drawFrame = drawFrame + 1
+	if selectionVBO.usedElements > 0 then
+		if hasBadCulling then 
+			gl.Culling(false)
+		end
+		
+		glTexture(0, texture)
+		selectShader:Activate()
+		selectShader:SetUniform("iconDistance", 99999) -- pass
+		glStencilTest(true) --https://learnopengl.com/Advanced-OpenGL/Stencil-testing
+		glDepthTest(true)
+		glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE) -- Set The Stencil Buffer To 1 Where Draw Any Polygon		this to the shader
+		glClear(GL_STENCIL_BUFFER_BIT ) -- set stencil buffer to 0
+
+		glStencilFunc(GL_NOTEQUAL, 1, 1) -- use NOTEQUAL instead of ALWAYS to ensure that overlapping transparent fragments dont get written multiple times
+		glStencilMask(1)
+
+		selectShader:SetUniform("addRadius", 0)
+		selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+
+		glStencilFunc(GL_NOTEQUAL, 1, 1)
+		glStencilMask(0)
+		glDepthTest(true)
+
+		selectShader:SetUniform("addRadius", 1.3)
+		selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
+
+		glStencilMask(1)
+		glStencilFunc(GL_ALWAYS, 1, 1)
+		glDepthTest(true)
+
+		selectShader:Deactivate()
+		glTexture(0, false)
+		
+				
+		-- This is the correct way to exit out of the stencil mode, to not break drawing of area commands:
+		glStencilTest(false)
+		glStencilMask(255)
+		glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP)
+		glClear(GL_STENCIL_BUFFER_BIT)
+		-- All the above are needed :(
+	end
+end
+
+local function RemovePrimitive(unitID)
+	if selectionVBO.instanceIDtoIndex[unitID] then
+		popElementInstance(selectionVBO, unitID)
+	end
+end
+
+function widget:SelectionChanged(sel)
+	updateSelection = true
+end
+
+function widget:Update(dt)
+	if updateSelection then
+		selectedUnits = Spring.GetSelectedUnits()
+		updateSelection = false
+
+		local newSelUnits = {}
+		-- add to selection
+		for i, unitID in ipairs(selectedUnits) do
+			newSelUnits[unitID] = true
+			if not selUnits[unitID] then
+				AddPrimitiveAtUnit(unitID)
+			end
+		end
+		-- remove from selection
+		for unitID, _ in pairs(selUnits) do
+			if not newSelUnits[unitID] then
+				RemovePrimitive(unitID)
+			end
+		end
+		selUnits = newSelUnits
+	end
+end
+
+function widget:UnitTaken(unitID, unitDefID, oldTeamID, newTeamID)
+	if unitTeam[unitID] then
+		unitTeam[unitID] = newTeamID
+	end
+end
+
+function widget:UnitDestroyed(unitID)
+	--Spring.Echo("UnitDestroyed(unitID)",unitID, selectedUnits[unitID])
+	if selectedUnits[unitID] then
+		RemovePrimitive(unitID)
+	end
+	unitTeam[unitID] = nil
+	unitUnitDefID[unitID] = nil
+end
+
+local function init()
+	updateSelection = true
+	selUnits = {}	
+	local DPatUnit = VFS.Include(luaShaderDir.."DrawPrimitiveAtUnit.lua")
+	local InitDrawPrimitiveAtUnit = DPatUnit.InitDrawPrimitiveAtUnit
+	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE!
+	shaderConfig.BILLBOARD = 0
+	shaderConfig.TRANSPARENCY = opacity
+	shaderConfig.INITIALSIZE = 0.75
+	shaderConfig.GROWTHRATE = 3.5
+	shaderConfig.TEAMCOLORIZATION = teamcolorOpacity	-- not implemented, doing it via POST_SHADING below instead
+	shaderConfig.HEIGHTOFFSET = 4
+	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(mix(g_color.rgb * texcolor.rgb + addRadius, vec3(1.0), "..(1-teamcolorOpacity)..") , texcolor.a * TRANSPARENCY + addRadius);"
+	selectionVBO, selectShader = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnits")
+	if selectionVBO == nil then 
+		widgetHandler:RemoveWidget()
+		return false
+	end
+	return true
+end
+
+function widget:Initialize()
+	if not gl.CreateShader then -- no shader support, so just remove the widget itself, especially for headless
+		widgetHandler:RemoveWidget()
+		return
+	end
+	if not init() then return end
+	WG.selectedunits = {}
+	WG.selectedunits.getOpacity = function()
+		return opacity
+	end
+	WG.selectedunits.setOpacity = function(value)
+		opacity = value
+		init()
+	end
+	WG.selectedunits.getTeamcolorOpacity = function()
+		return teamcolorOpacity
+	end
+	WG.selectedunits.setTeamcolorOpacity = function(value)
+		teamcolorOpacity = value
+		init()
+	end
+	Spring.LoadCmdColorsConfig('unitBox  0 1 0 0')
+end
+
+function widget:Shutdown()
+	if not (WG.teamplatter or WG.highlightselunits) then
+		Spring.LoadCmdColorsConfig('unitBox  0 1 0 1')
+	end
+	WG.selectedunits = nil
+end
+
+function widget:GetConfigData(data)
+	return {
+		opacity = opacity,
+		teamcolorOpacity = teamcolorOpacity
+	}
+end
+
+function widget:SetConfigData(data)
+	opacity = data.opacity or opacity
+	teamcolorOpacity = data.teamcolorOpacity or teamcolorOpacity
+end

--- a/LuaUI/Widgets/gui_selectedunits_gl4.lua
+++ b/LuaUI/Widgets/gui_selectedunits_gl4.lua
@@ -53,7 +53,7 @@ local GL_REPLACE                                            = GL.REPLACE
 local GL_POINTS                                             = GL.POINTS
 
 local selUnits, isLocalSelection                            = {}, {}
-local doUpdate, allySelUnits
+local doUpdate, allySelUnits, hoverUnitID
 
 local paused, currentFrame, timeSinceLastFrame              = true, -1, 0
 
@@ -138,7 +138,6 @@ end
 
 local function FindPreselUnits()
 	local preselection = {}
-	local hoverUnitID = GetUnitUnderCursor(false)
 	if hoverUnitID then
 		preselection[hoverUnitID] = true
 	end
@@ -297,12 +296,19 @@ end
 function widget:Update(dt)
 	timeSinceLastFrame = timeSinceLastFrame + dt
 	SetPausedHack(currentFrame)
+	
+	local newHoverUnitID = GetUnitUnderCursor(false)
+	doUpdate = doUpdate or newHoverUnitID ~= hoverUnitID
+	hoverUnitID = newHoverUnitID
 
 	-- TODO: Add a callin for when ally selections change?
-	local allySelUpdated = WG.allySelUnits ~= allySelUnits
-	allySelUnits = WG.allySelUnits
+	local newAllySelUnits = WG.allySelUnits
+	doUpdate = doUpdate or newAllySelUnits ~= allySelUnits
+	allySelUnits = newAllySelUnits
 
-	if not doUpdate and not allySelUpdated and not IsSelectionBoxActive() then
+	doUpdate = doUpdate or IsSelectionBoxActive()
+
+	if not doUpdate then
 		return
 	end
 

--- a/LuaUI/Widgets/gui_selectedunits_gl4.lua
+++ b/LuaUI/Widgets/gui_selectedunits_gl4.lua
@@ -13,8 +13,9 @@ end
 -- Configurable Parts:
 local texture = "luaui/images/solid.png"
 
+-- TODO: Note these are placed in a WG setting on init and re-read from there.
 local opacity = 0.19
-local teamcolorOpacity = 0.6
+local teamcolorOpacity = 1.0
 
 ---- GL4 Backend Stuff----
 local selectionVBO = nil
@@ -86,10 +87,9 @@ local function AddPrimitiveAtUnit(unitID)
 		width = radius
 		length = radius
 	elseif unitBuilding[unitDefID] then
+		numVertices = 4
 		width = unitBuilding[unitDefID][1]
 		length = unitBuilding[unitDefID][2]
-		cornersize = (width + length) * 0.075
-		numVertices = 2
 	else
 		width = radius
 		length = radius
@@ -121,7 +121,7 @@ function widget:DrawWorldPreUnit()
 			gl.Culling(false)
 		end
 		
-		glTexture(0, texture)
+		-- glTexture(0, texture)
 		selectShader:Activate()
 		selectShader:SetUniform("iconDistance", 99999) -- pass
 		glStencilTest(true) --https://learnopengl.com/Advanced-OpenGL/Stencil-testing
@@ -139,7 +139,7 @@ function widget:DrawWorldPreUnit()
 		glStencilMask(0)
 		glDepthTest(true)
 
-		selectShader:SetUniform("addRadius", 1.3)
+		selectShader:SetUniform("addRadius", 3.0)
 		selectionVBO.VAO:DrawArrays(GL_POINTS, selectionVBO.usedElements)
 
 		glStencilMask(1)
@@ -147,7 +147,7 @@ function widget:DrawWorldPreUnit()
 		glDepthTest(true)
 
 		selectShader:Deactivate()
-		glTexture(0, false)
+		-- glTexture(0, false)
 		
 				
 		-- This is the correct way to exit out of the stencil mode, to not break drawing of area commands:
@@ -215,11 +215,11 @@ local function init()
 	local shaderConfig = DPatUnit.shaderConfig -- MAKE SURE YOU READ THE SHADERCONFIG TABLE!
 	shaderConfig.BILLBOARD = 0
 	shaderConfig.TRANSPARENCY = opacity
-	shaderConfig.INITIALSIZE = 0.75
-	shaderConfig.GROWTHRATE = 3.5
+	shaderConfig.ANIMATION = 0
 	shaderConfig.TEAMCOLORIZATION = teamcolorOpacity	-- not implemented, doing it via POST_SHADING below instead
-	shaderConfig.HEIGHTOFFSET = 4
-	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(mix(g_color.rgb * texcolor.rgb + addRadius, vec3(1.0), "..(1-teamcolorOpacity)..") , texcolor.a * TRANSPARENCY + addRadius);"
+	shaderConfig.HEIGHTOFFSET = 0
+	shaderConfig.USETEXTURE = 0
+	shaderConfig.POST_SHADING = "fragColor.rgba = vec4(g_color.rgb, texcolor.a * TRANSPARENCY + addRadius);"
 	selectionVBO, selectShader = InitDrawPrimitiveAtUnit(shaderConfig, "selectedUnits")
 	if selectionVBO == nil then 
 		widgetHandler:RemoveWidget()
@@ -267,6 +267,7 @@ function widget:GetConfigData(data)
 end
 
 function widget:SetConfigData(data)
-	opacity = data.opacity or opacity
-	teamcolorOpacity = data.teamcolorOpacity or teamcolorOpacity
+	-- FIXME: Restore this setting code?
+	-- opacity = data.opacity or opacity
+	-- teamcolorOpacity = data.teamcolorOpacity or teamcolorOpacity
 end

--- a/LuaUI/Widgets/gui_selectedunits_gl4.lua
+++ b/LuaUI/Widgets/gui_selectedunits_gl4.lua
@@ -57,14 +57,14 @@ local unitScale = {}
 local unitCanFly = {}
 local unitBuilding = {}
 for unitDefID, unitDef in pairs(UnitDefs) do
-	unitScale[unitDefID] = (7.5 * ( unitDef.xsize^2 + unitDef.zsize^2 ) ^ 0.5) + 8
+	unitScale[unitDefID] = (8 * ( unitDef.xsize^2 + unitDef.zsize^2 ) ^ 0.5) + 4
 	if unitDef.canFly then
 		unitCanFly[unitDefID] = true
 		unitScale[unitDefID] = unitScale[unitDefID] * 0.7
 	elseif unitDef.isBuilding or unitDef.isFactory or unitDef.speed==0 then
 		unitBuilding[unitDefID] = {
-			unitDef.xsize * 8.2 + 12,
-			unitDef.zsize * 8.2 + 12
+			unitDef.xsize * 8 + 0.5,
+			unitDef.zsize * 8 + 0.5
 		}
 	end
 end

--- a/LuaUI/Widgets/gui_selectedunits_gl4.lua
+++ b/LuaUI/Widgets/gui_selectedunits_gl4.lua
@@ -63,15 +63,13 @@ local function AddSelected(unitID, unitTeam, preselection)
 	if Spring.ValidUnitID(unitID) ~= true or Spring.GetUnitIsDead(unitID) == true then return end
 	local gf = Spring.GetGameFrame()
 
-	local unitDefID =  Spring.GetUnitDefID(unitID)
+	local unitDefID = Spring.GetUnitDefID(unitID)
 	if unitDefID == nil then return end -- these cant be selected
 
-	local numVertices = 64 -- default to cornered rectangle
-	local cornersize = 0
+	local numVertices = 64
 
 	local radius = unitScale[unitDefID]
 
-	local additionalheight = 0
 	local width, length
 	if unitCanFly[unitDefID] then
 		numVertices = 3 -- triangles for planes
@@ -90,7 +88,7 @@ local function AddSelected(unitID, unitTeam, preselection)
 	pushElementInstance(
 		selectionVBO, -- push into this Instance VBO Table
 		{
-			length, width, cornersize, additionalheight,  -- lengthwidthcornerheight
+			length, width, 0, 0,  -- lengthwidthcornerheight
 			unitTeam, -- teamID
 			numVertices, -- how many trianges should we make
 			gf, preselection and 1 or 0, 0, 0, -- the gameFrame (for animations), whether to animate (for preselection) and unused parameters


### PR DESCRIPTION
Credit: this is largely a copy of https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/luaui/Widgets/gui_selectedunits_gl4.lua and https://github.com/beyond-all-reason/Beyond-All-Reason/blob/master/luaui/Widgets/gui_allySelectedUnits.lua

This screenshot shows how it looks on default settings.

![image](https://github.com/moreginger/Zero-K/assets/1387874/d99f06ed-37ad-4273-aec4-95b943e23d32)

Ally/other (in replays) selections are shown in team color. Local selections are always in green and superimposed. Local selections are also animated with a breathe, see video later.

![image](https://github.com/moreginger/Zero-K/assets/1387874/2d4c1d4b-b05a-4e1f-b42b-5ef35bb21edd)

I included a few options but tried to keep things basic.

![image](https://github.com/moreginger/Zero-K/assets/1387874/a72888b6-5d96-4dc9-861f-55e3ef00917f)

This is intended to replace unit_shapes.lua. Can it do this, being GL4, or do we need both? The principle advantage is that it is considerably faster (~1% vs ~10% in some cases):

![image](https://github.com/moreginger/Zero-K/assets/1387874/37cf97a2-898e-4283-a003-4c0cfa3acc0f)

It differs from the BAR widgets in the following ways:

- The two widgets have been combined into one
- Highlights are more ZK-style. Notably:
   - Local selections are green
   - Buildings are squares, not cornerrects
   - Selection highlighting doesn't float above ground

The main visual difference from unit_shapes is that the selection lines are solid, not gradients. As discussed in Discord, it is plausible to write a fragment shader to replicate this style, but I'm not sure it's worth the effort - I actually like the look of this.

Video in action here: https://clipchamp.com/watch/PjEF4vvYxxJ