### PR TITLE
⚙️ Fix #5183, Athena and Newton selection volumes

### DIFF
--- a/units/athena.lua
+++ b/units/athena.lua
@@ -48,6 +48,9 @@ return { athena = {
   collisionVolumeOffsets = [[0 0 0]],
   collisionVolumeScales  = [[30 20 60]],
   collisionVolumeType    = [[ellipsoid]],
+  selectionVolumeOffsets = [[0 0 0]],
+  selectionVolumeScales  = [[45 20 75]],
+  selectionVolumeType    = [[ellipsoid]],
   cruiseAltitude      = 80,
 
   customParams        = {

--- a/units/turretimpulse.lua
+++ b/units/turretimpulse.lua
@@ -12,6 +12,9 @@ return { turretimpulse = {
   collisionVolumeOffsets        = [[0 0 0]],
   collisionVolumeScales         = [[50 50 50]],
   collisionVolumeType           = [[ellipsoid]],
+  selectionVolumeOffsets        = [[0 0 0]],
+  selectionVolumeScales         = [[60 60 60]],
+  selectionVolumeType           = [[ellipsoid]],
   corpse                        = [[DEAD]],
 
   customParams                  = {


### PR DESCRIPTION
Now they cover all the bits sticking out, with some leeway.
![image](https://github.com/ZeroK-RTS/Zero-K/assets/2573076/f600b38d-3039-4998-87d2-53725a246fd3)
![image](https://github.com/ZeroK-RTS/Zero-K/assets/2573076/7d2634d7-8638-4230-a4f7-8bba095db2bd)
