### PR TITLE
fix infinite loop

### DIFF
--- a/LuaUI/Widgets/gui_epicmenu.lua
+++ b/LuaUI/Widgets/gui_epicmenu.lua
@@ -1112,10 +1112,12 @@ local function AddOption(path, option) --Note: this is used when loading widgets
 	
 	local controlfunc = function() end
 	if option.type == 'button' and (option.action) and (not option.noAutoControlFunc) then
-		controlfunc =
-			function(self)
-				spSendCommands{option.action}
-			end
+		if not option.dontRegisterAction then
+			controlfunc =
+				function(self)
+					spSendCommands{option.action}
+				end
+		end
 	elseif option.type == 'bool' then
 		
 		controlfunc =


### PR DESCRIPTION
This cause an infinite loop unless option.dontRegisterAction is true (the action call option.OnChange which call the controlfunc ...) option.action can be either used to provoke the call of an action by a click, or to provoke the OnChange when calling the action, but not both...