### PR TITLE
Enforce FFA Noelo through a hack

### DIFF
--- a/LuaRules/Gadgets/game_over.lua
+++ b/LuaRules/Gadgets/game_over.lua
@@ -786,7 +786,7 @@ function gadget:GameOver()
 		Spring.Echo("gadget:GameOver")
 	end
 	gameIsOver = true
-	if noElo then
+	if noElo or Spring.Utilities.Gametype.isFFA() then
 		Spring.SendCommands("wbynum 255 SPRINGIE:noElo")
 	end
 	Spring.Log(gadget:GetInfo().name, LOG.INFO, "GAME OVER!!")


### PR DESCRIPTION
> FFA games are supposed to be noelo but there isn't anything in the server which forces them to be, at the moment. They will retroactively become no-elo at some point in the future. An unfortunate hack solution, but it is what it is.

This solves this issue by forcing Springiee to tell the server the game is noelo at game end.