### PR TITLE
Fix: Complete team vision detection for spectator in fullread

### DIFF
--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -2387,30 +2387,30 @@ function widgetHandler:UnitStunned(unitID, unitDefID, unitTeam, stunned)
 end
 
 
-function widgetHandler:UnitEnteredRadar(unitID, unitTeam)
+function widgetHandler:UnitEnteredRadar(unitID, unitTeam, forAllyTeamID, unitDefID)
 	for _, w in r_ipairs(self.UnitEnteredRadarList) do
-		w:UnitEnteredRadar(unitID, unitTeam)
+		w:UnitEnteredRadar(unitID, unitTeam, forAllyTeamID, unitDefID)
 	end
 end
 
 
-function widgetHandler:UnitEnteredLos(unitID, unitTeam)
+function widgetHandler:UnitEnteredLos(unitID, unitTeam, forAllyTeamID, unitDefID)
 	for _, w in r_ipairs(self.UnitEnteredLosList) do
-		w:UnitEnteredLos(unitID, unitTeam)
+		w:UnitEnteredLos(unitID, unitTeam, forAllyTeamID, unitDefID)
 	end
 end
 
 
-function widgetHandler:UnitLeftRadar(unitID, unitTeam)
+function widgetHandler:UnitLeftRadar(unitID, unitTeam, forAllyTeamID, unitDefID)
 	for _, w in r_ipairs(self.UnitLeftRadarList) do
-		w:UnitLeftRadar(unitID, unitTeam)
+		w:UnitLeftRadar(unitID, unitTeam, forAllyTeamID, unitDefID)
 	end
 end
 
 
-function widgetHandler:UnitLeftLos(unitID, unitDefID, unitTeam)
+function widgetHandler:UnitLeftLos(unitID, unitDefID, unitTeam, forAllyTeamID, unitDefID)
 	for _, w in r_ipairs(self.UnitLeftLosList) do
-		w:UnitLeftLos(unitID, unitDefID, unitTeam)
+		w:UnitLeftLos(unitID, unitDefID, unitTeam, forAllyTeamID, unitDefID)
 	end
 end
 

--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -2408,9 +2408,9 @@ function widgetHandler:UnitLeftRadar(unitID, unitTeam, forAllyTeamID, unitDefID)
 end
 
 
-function widgetHandler:UnitLeftLos(unitID, unitDefID, unitTeam, forAllyTeamID, unitDefID)
+function widgetHandler:UnitLeftLos(unitID, unitTeam, forAllyTeamID, unitDefID)
 	for _, w in r_ipairs(self.UnitLeftLosList) do
-		w:UnitLeftLos(unitID, unitDefID, unitTeam, forAllyTeamID, unitDefID)
+		w:UnitLeftLos(unitID, unitTeam, forAllyTeamID, unitDefID)
 	end
 end
 


### PR DESCRIPTION
UnitEntered/Left Radar, UnitEntered/Left Los deliver more information when spectating in fullread. So it become possible to know which unit got discovered by which ally team. Without those informations,  it is not possible to make sense of those calls when speccing FFA. It also save some useless checkings that would have to be done without.