### PR TITLE
Add link to development guide for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ To play the game, you need to **[Download]** the lobby.
 
 [*» Learn how to import content directly into the engine.*][Importing]
 
+Development guide: https://zero-k.info/mediawiki/Zero-K:Developing
+
 </div>
 
 <br>
+
 
 
 <!----------------------------------------------------------------------------->

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Development guide: https://zero-k.info/mediawiki/Zero-K:Developing
 <br>
 
 
-
 <!----------------------------------------------------------------------------->
 
 [Spring Engine]: https://springrts.com/


### PR DESCRIPTION
Fixes #5337 

New contributors might not be aware that wiki doc exists, so point them to the right direction (I ran into this myself haha).

I can also copy the wiki text directly and put in a `contributing.md` file but a single source of truth might be preferable so just linking for now.

Side note: The README has HTML tags and centered styling which seems to be very uncommon among Github projects, personally would love to use just vanilla Markdown and no styling but fine either way :)

