### PR TITLE
Fix little halt caused by CMD_MOVE

### DIFF
--- a/LuaUI/Widgets/cmd_customformations2.lua
+++ b/LuaUI/Widgets/cmd_customformations2.lua
@@ -718,6 +718,9 @@ function widget:MousePress(mx, my, mButton)
 	-- Without this, the unloads issued will use the area of the last area unload
 	if usingCmd == CMD_UNLOADUNITS then
 		usingCmd = CMD_UNLOADUNIT
+	elseif usingCmd == CMD_MOVE then
+		-- work around to avoid the little halt caused by CMD_MOVE, (ie when moving through right click while pointing at a feature)
+		usingCmd = CMD_RAW_MOVE
 	end
 
 	-- Is this command eligible for a custom formation ?


### PR DESCRIPTION
When moving onto a feature, CMD_MOVE cause a little halt before move starts, replacing the command with CMD_RAW_MOVE to avoid this.