### PR TITLE
correct flipped minimap mex placement

### DIFF
--- a/LuaUI/Widgets/cmd_mex_placement.lua
+++ b/LuaUI/Widgets/cmd_mex_placement.lua
@@ -1400,7 +1400,7 @@ function widget:DrawInMiniMap(minimapX, minimapY)
 		glPushMatrix()
 
 		if GetMiniMapFlipped() then
-			glTranslate(minimapY, 0, 0)
+			glTranslate(minimapX, 0, 0)
 			glScale(-minimapX/mapX, minimapY/mapZ, 1)
 		else
 			glTranslate(0, minimapY, 0)


### PR DESCRIPTION
when using the flipped map, the minimap mex placement is incorrect for non-quadratic maps. this pull request corrects it.