### PR TITLE
Fix non default, non random album initial choice

### DIFF
--- a/LuaUI/Widgets/snd_music2.lua
+++ b/LuaUI/Widgets/snd_music2.lua
@@ -112,8 +112,8 @@ options = {
 				randomChosen = false
 			end
 			if value ~= trackListName then
+				trackListName = value -- trackListName has to be changed prior tracks has been filled in, because options.OnChange will be triggered before initialization in Update
 				if includedAlbums[value] and includedAlbums[value].tracks then
-					trackListName = value
 					trackList = includedAlbums[value].tracks
 					if WG.Music then
 						WG.Music.StopTrack()


### PR DESCRIPTION
trackListName has to be changed prior .tracks has been filled in, because options.OnChange will be triggered before initialization in Update. Ideally a bigger rewrite should be made to change the way tracks are registered, suggestion: -remove the 'use included option'
-keep the vanilla albums in the pool of  album, add whatever user extra album has locally