### PR TITLE
increase max fade height

### DIFF
--- a/LuaUI/Widgets/unit_healthbars.lua
+++ b/LuaUI/Widgets/unit_healthbars.lua
@@ -187,7 +187,7 @@ options = {
 		name = 'Unit Bar Fade Height',
 		desc = 'If the camera is above this height, health bars will not be drawn.',
 		type = 'number',
-		min = 0, max = 8000, step = 50,
+		min = 0, max = 10000, step = 50,
 		value = 3000,
 		OnChange = OptionsChanged,
 	},


### PR DESCRIPTION
increases the max fade height. This allows a player (me) to see health bars when fully zoomed out.

Since unit_healthbars.lua uses GetVisibleUnits with the radar dot param as false, `/disticon` needs to be set to 10000 to see the bars fully zoomed out, as well as this setting.

If the param is set to true, the bars are under the radar dots anyway.

For the time being, I will be using gui_icontransition.
