### PR TITLE
to fix nimbus animation wrong gun smoke

### DIFF
--- a/scripts/gunshipheavyskirm.lua
+++ b/scripts/gunshipheavyskirm.lua
@@ -107,9 +107,9 @@ function script.AimFromWeapon(num)
 end
 
 function script.Shot(num)
+	gun = (gun)%4 + 1
 	EmitSfx(emits[gun].flare, 1024)
 	EmitSfx(emits[gun].barrel, 1025)
-	gun = (gun)%4 + 1
 end
 
 function script.Killed(recentDamage, maxHealth)


### PR DESCRIPTION
When nimbus shot slow, problem revealed. (see silly wafr fix:)
fn Shot seems called before fn QueryWeapon so in shot you need to change gun before emit effect