### PR TITLE
gui_replay_controls.lua: Calculate window vertical position based on …

### DIFF
--- a/LuaUI/Widgets/gui_replay_controls.lua
+++ b/LuaUI/Widgets/gui_replay_controls.lua
@@ -116,8 +116,8 @@ end
 
 function CreateTheUI()
 	--create main Chili elements
-	local screenWidth, _ = Spring.GetViewGeometry()
-	local windowY = math.floor(screenWidth*2/11 + 32)
+	local screenWidth, screenHeight = Spring.GetViewGeometry()
+	local windowY = math.floor(screenHeight/8)
 
 	local currSpeed = 2 --default button setting
 	if window then


### PR DESCRIPTION
…window height, not window width.

Ref: https://github.com/ZeroK-RTS/Zero-K/issues/5394

Small two-line patch. This could be done better, but at least this will keep the replay controls from being offscreen or below the minimap with default UI layouts when the game window is an ultrawide aspect ratio. This will PROBABLY place the controls over the default playerlist, but it's draggable from that position. 