### PR TITLE
Add Skuttle to Unit Marker config

### DIFF
--- a/LuaUI/Configs/unit_marker.lua
+++ b/LuaUI/Configs/unit_marker.lua
@@ -7,6 +7,7 @@ local unitlistNames = {
 	cloaksnipe = MARK_EACH,
 	cloakheavyraid = MARK_EACH,
 	cloakjammer = MARK_EACH,
+	jumpbomb = MARK_EACH,
 	spiderantiheavy = MARK_EACH,
 
 	energyheavygeo = DEFAULT,


### PR DESCRIPTION
While this could be done through a custom config (which is what I've personally done), it should probably be an option by default.