### PR TITLE
fix Chili.Object.AddChild

### DIFF
--- a/LuaUI/Widgets/chili_old/Controls/object.lua
+++ b/LuaUI/Widgets/chili_old/Controls/object.lua
@@ -264,11 +264,11 @@ function Object:AddChild(obj, dontUpdate, index)
     end
     table.insert(children, index, objDirect)
   else
-    local i = #children+1
-    children[i] = objDirect
-    children[hobj] = i
-    children[objDirect] = i
-  end
+		index = #children + 1
+		children[index] = objDirect
+	end
+	children[hobj] = index
+	children[objDirect] = index
     self:Invalidate()
 end
 


### PR DESCRIPTION
When use index, AddChild forgot to
```
children[hobj] = index
children[objDirect] = index
```