### PR TITLE
Fix unpredictable jump damage from excessive velocity on unit collision

### DIFF
--- a/LuaRules/Gadgets/unit_fall_damage.lua
+++ b/LuaRules/Gadgets/unit_fall_damage.lua
@@ -7,60 +7,60 @@ end
 --------------------------------------------------------------------------------
 
 function gadget:GetInfo()
-  return {
-    name      = "Fall Damage",
-    desc      = "Handles fall damage and out of map units",
-    author    = "Google Frog, msafwan (unit matching by damage)",
-    date      = "18 Feb 2012, 2 Jan 2014",
-    license   = "GNU GPL, v2 or later",
-    layer     = 0,
-    enabled   = true  --  loaded by default?
-  }
+	return {
+		name    = "Fall Damage",
+		desc    = "Handles fall damage and out of map units",
+		author  = "Google Frog, msafwan (unit matching by damage)",
+		date    = "18 Feb 2012, 2 Jan 2014",
+		license = "GNU GPL, v2 or later",
+		layer   = 0,
+		enabled = true --  loaded by default?
+	}
 end
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- CONFIG
-local NoDamageToSelf = {
+local NoDamageToSelf                  = {
 	[UnitDefNames["chicken"].id] = true,
 }
 
 -------------------------------------------------------------------------------------
 -------------------------------------------------------------------------------------
 
-local spGetUnitAllyTeam  = Spring.GetUnitAllyTeam
-local spAddUnitDamage = Spring.AddUnitDamage
+local spGetUnitAllyTeam               = Spring.GetUnitAllyTeam
+local spAddUnitDamage                 = Spring.AddUnitDamage
 
-local MAP_X = Game.mapX*512
-local MAP_Z = Game.mapY*512
-local GRAVITY = Game.gravity
+local MAP_X                           = Game.mapX * 512
+local MAP_Z                           = Game.mapY * 512
+local GRAVITY                         = Game.gravity
 
-local UNIT_UNIT_SPEED = 5.5
-local UNIT_UNIT_DAMAGE_FACTOR = 0.8
-local TANGENT_DAMAGE = 0.5
+local UNIT_UNIT_SPEED                 = 5.5
+local UNIT_UNIT_DAMAGE_FACTOR         = 0.8
+local TANGENT_DAMAGE                  = 0.5
 local DEBRIS_SPRING_DAMAGE_MULTIPLIER = 10 --tweaked arbitrarily
 
-local gameframe = Spring.GetGameFrame()
-local attributes = {}
+local gameframe                       = Spring.GetGameFrame()
+local attributes                      = {}
 local unitWantedVelocity
 local unitAlreadyProcessed
 
-for unitDefID=1,#UnitDefs do
+for unitDefID = 1, #UnitDefs do
 	local ud = UnitDefs[unitDefID]
 	attributes[unitDefID] = {
 		elasticity = tonumber(ud.customParams.elasticity) or 0.3,
 		friction = tonumber(ud.customParams.friction) or 0.8,
-		outOfMapDamagePerElmo = ud.health/800,
+		outOfMapDamagePerElmo = ud.health / 800,
 		velocityDamageThreshold = 3,
-		velocityDamageScale = ud.mass*0.6,
+		velocityDamageScale = ud.mass * 0.6,
 		mass = ud.mass,
 	}
 	if ud.isImmobile then -- buildings are more massive
-		attributes[unitDefID].velocityDamageScale = attributes[unitDefID].velocityDamageScale*10
+		attributes[unitDefID].velocityDamageScale = attributes[unitDefID].velocityDamageScale * 10
 	end
 end
 
-local wantedWeaponList = {-2, -3}
+local wantedWeaponList = { -2, -3 }
 
 local collisionDamageMult = {}
 local fallDamageImmunityWeaponID = {}
@@ -75,9 +75,9 @@ end
 
 local function outsideMapDamage(unitID, unitDefID)
 	local att = attributes[unitDefID]
-	local x,y,z = Spring.GetUnitPosition(unitID)
+	local x, y, z = Spring.GetUnitPosition(unitID)
 	if x < 0 or z < 0 or x > MAP_X or z > MAP_Z then
-		return math.max(-x,-z,x-MAP_X,z-MAP_Z)*att.outOfMapDamagePerElmo
+		return math.max(-x, -z, x - MAP_X, z - MAP_Z) * att.outOfMapDamagePerElmo
 	else
 		return 0
 	end
@@ -85,18 +85,18 @@ end
 
 
 local function LocalSpeedToDamage(unitID, unitDefID, speed)
-	local armor = select(2,Spring.GetUnitArmored(unitID)) or 1
+	local armor = select(2, Spring.GetUnitArmored(unitID)) or 1
 	local att = attributes[unitDefID]
 	if speed > att.velocityDamageThreshold then
-		return (speed-att.velocityDamageThreshold)*att.velocityDamageScale
+		return (speed - att.velocityDamageThreshold) * att.velocityDamageScale
 	else
 		return 0
 	end
 end
 
-local function SpringSpeedToDamage(colliderMass,collideeeMass,relativeSpeed) --Inelastic collision. Reference: Spring/rts/Sim/MoveTypes/GroundMoveType.cpp#875
-	local COLLISION_DAMAGE_MULT = 0.02 --Reference: Spring/rts/Sim/MoveTypes/GroundMoveType.cpp#66
-	local MAX_UNIT_SPEED = 1000 --Reference: Spring/rts/Sim/Misc/GlobalConstants.h
+local function SpringSpeedToDamage(colliderMass, collideeeMass, relativeSpeed) --Inelastic collision. Reference: Spring/rts/Sim/MoveTypes/GroundMoveType.cpp#875
+	local COLLISION_DAMAGE_MULT = 0.02                                       --Reference: Spring/rts/Sim/MoveTypes/GroundMoveType.cpp#66
+	local MAX_UNIT_SPEED = 1000                                              --Reference: Spring/rts/Sim/Misc/GlobalConstants.h
 	local impactSpeed = relativeSpeed * 0.5;
 	local colliderelMass = (colliderMass / (colliderMass + collideeeMass));
 	local colliderelImpactSpeed = impactSpeed * (1 - colliderelMass);
@@ -105,7 +105,7 @@ local function SpringSpeedToDamage(colliderMass,collideeeMass,relativeSpeed) --I
 	local collideeImpactDmgMult = math.min(collideeRelImpactSpeed * colliderMass * COLLISION_DAMAGE_MULT, MAX_UNIT_SPEED);
 	-- colliderImpactDmgMult = math.modf(colliderImpactDmgMult) --in case fraction need to be removed
 	-- collideeImpactDmgMult = math.modf(collideeImpactDmgMult)
-	
+
 	return colliderImpactDmgMult, collideeImpactDmgMult
 end
 
@@ -158,8 +158,8 @@ GG.SetCollisionDamageMult = SetCollisionDamageMult
 local function DoCollisionDamage(unitID, unitDefID, otherID)
 	local myVx, myVy, myVz, mySpeed = Spring.GetUnitVelocity(unitID)
 	local oVx, oVy, oVz, otherSpeed = Spring.GetUnitVelocity(otherID)
-	local relativeSpeed = math.sqrt((oVx - myVx)^2 + (oVy - myVy)^2 + (oVz - myVz)^2)
-	
+	local relativeSpeed = math.sqrt((oVx - myVx) ^ 2 + (oVy - myVy) ^ 2 + (oVz - myVz) ^ 2)
+
 	local otherUnitDefID = Spring.GetUnitDefID(otherID)
 	local noSelfDamage = false
 	if NoDamageToSelf[unitDefID] and NoDamageToSelf[otherUnitDefID] then
@@ -168,24 +168,25 @@ local function DoCollisionDamage(unitID, unitDefID, otherID)
 	if (mySpeed > UNIT_UNIT_SPEED or otherSpeed > UNIT_UNIT_SPEED) and not noSelfDamage then
 		local otherDamage = LocalSpeedToDamage(unitID, unitDefID, relativeSpeed)
 		local myDamage = LocalSpeedToDamage(otherID, otherUnitDefID, relativeSpeed)
-		local damageToDeal = math.min(myDamage, otherDamage) * UNIT_UNIT_DAMAGE_FACTOR -- deal the damage of the least massive unit
+		local damageToDeal = math.min(myDamage, otherDamage) *
+		UNIT_UNIT_DAMAGE_FACTOR                                                  -- deal the damage of the least massive unit
 		local isUnitAllied = (spGetUnitAllyTeam(unitID) == spGetUnitAllyTeam(otherID))
 		local colliderImmune = false
-		
+
 		local myMass = attributes[unitDefID].mass
 		local otherMass = attributes[otherUnitDefID].mass
-		local myVelFrac = myMass/(myMass + otherMass)
-		
-		local aVx = myVx*myVelFrac + oVx*(1 - myVelFrac)
-		local aVy = myVy*myVelFrac + oVy*(1 - myVelFrac)
-		local aVz = myVz*myVelFrac + oVz*(1 - myVelFrac)
-		
+		local myVelFrac = myMass / (myMass + otherMass)
+
+		local aVx = myVx * myVelFrac + oVx * (1 - myVelFrac)
+		local aVy = myVy * myVelFrac + oVy * (1 - myVelFrac)
+		local aVz = myVz * myVelFrac + oVz * (1 - myVelFrac)
+
 		unitWantedVelocity = unitWantedVelocity or {}
-		unitWantedVelocity[#unitWantedVelocity + 1] = {unitID, aVx, aVy, aVz}
-		unitWantedVelocity[#unitWantedVelocity + 1] = {otherID, aVx, aVy, aVz}
+		unitWantedVelocity[#unitWantedVelocity + 1] = { unitID, aVx, aVy, aVz }
+		unitWantedVelocity[#unitWantedVelocity + 1] = { otherID, aVx, aVy, aVz }
 		--GG.AddGadgetImpulseRaw(unitID, aVx - myVx, aVy - myVy, aVz - myVz, true, true)
 		--GG.AddGadgetImpulseRaw(otherID, aVx - oVx, aVy - oVy, aVz - oVz, true, true)
-		
+
 		if unitImmune[unitID] then
 			if unitImmune[unitID] < gameframe then
 				unitImmune[unitID] = nil
@@ -201,7 +202,7 @@ local function DoCollisionDamage(unitID, unitDefID, otherID)
 			end
 		end
 		if not colliderImmune then
-			spAddUnitDamage(unitID, damageToDeal*(collisionDamageMult[unitID] or 1), 0, otherID, -7)
+			spAddUnitDamage(unitID, damageToDeal * (collisionDamageMult[unitID] or 1), 0, otherID, -7)
 		end
 		local collideeImmune = false
 		if unitImmune[otherID] then
@@ -219,7 +220,7 @@ local function DoCollisionDamage(unitID, unitDefID, otherID)
 			end
 		end
 		if not collideeImmune then
-			spAddUnitDamage(otherID, damageToDeal*(collisionDamageMult[otherID] or 1), 0, unitID, -7)
+			spAddUnitDamage(otherID, damageToDeal * (collisionDamageMult[otherID] or 1), 0, unitID, -7)
 		end
 	end
 end
@@ -234,31 +235,31 @@ function gadget:UnitPreDamaged_GetWantedWeaponDef()
 	return wantedWeaponList
 end
 
-function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, attackerID, attackerDefID, attackerTeam)
-	
+function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, weaponDefID, attackerID, attackerDefID,
+							   attackerTeam)
 	if fallDamageImmunityWeaponID[weaponDefID] then
 		SetUnitFallDamageImmunity(unitID, fallDamageImmunityWeaponID[weaponDefID] + gameframe)
 		SetUnitFallDamageImmunityFeature(unitID, fallDamageImmunityWeaponID[weaponDefID] + gameframe)
 	end
-	
+
 	-- unit or wreck collision
 	if (weaponDefID == -3) and not unitPermanentImmune[unitID] then
 		if attackerID == nil then
 			-- Wreck collision
-			local vx,vy,vz = Spring.GetUnitVelocity(unitID)
+			local vx, vy, vz = Spring.GetUnitVelocity(unitID)
 			if vx then
-				local damageTotal = DEBRIS_SPRING_DAMAGE_MULTIPLIER*damage -- Why????
-				damageTotal = damageTotal*(collisionDamageMult[unitID] or 1)
+				local damageTotal = DEBRIS_SPRING_DAMAGE_MULTIPLIER * damage -- Why????
+				damageTotal = damageTotal * (collisionDamageMult[unitID] or 1)
 				--spAddUnitDamage(unitID, damageTotal, 0, nil, -7)
-				
+
 				unitWantedVelocity = unitWantedVelocity or {}
-				unitWantedVelocity[#unitWantedVelocity + 1] = {unitID, 0.3}
+				unitWantedVelocity[#unitWantedVelocity + 1] = { unitID, 0.3 }
 				--GG.AddGadgetImpulseRaw(unitID, -1*vx, -1*vy, -1*vz, true, true)
 				return damageTotal
 			end
 			return 0
 		end
-		
+
 		-- Unit on unit collision
 		unitAlreadyProcessed = unitAlreadyProcessed or {}
 		if unitAlreadyProcessed[unitID] then
@@ -270,17 +271,17 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 		end
 		return 0 -- units bounce but don't damage themselves.
 	end
-	
+
 	-- ground collision
 	if weaponDefID == -2 and attackerID == nil and Spring.ValidUnitID(unitID) and UnitDefs[unitDefID] then
 		-- Unit AI and script workarounds.
 		GG.WaitWaitMoveUnit(unitID)
-			
+
 		local env = Spring.UnitScript.GetScriptEnv(unitID)
 		if env and env.script.StartMoving then
 			Spring.UnitScript.CallAsUnit(unitID, env.script.StartMoving)
 		end
-	
+
 		if unitImmune[unitID] then
 			if unitImmune[unitID] >= gameframe then
 				return 0
@@ -291,26 +292,27 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, damage, paralyzer, w
 		-- normal is multiplied by elasticity, tangent by friction
 		-- unit takes damage based on velocity at normal to terrain + TANGENT_DAMAGE of velocity of tangent
 		local att = attributes[unitDefID]
-		local vx,vy,vz = Spring.GetUnitVelocity(unitID)
-		local x,y,z = Spring.GetUnitPosition(unitID)
-		local nx, ny, nz = Spring.GetGroundNormal(x,z)
-		local nMag = math.sqrt(nx^2 + ny^2 + nz^2)
-		nx, ny, nz = nx/nMag, ny/nMag, nz/nMag -- normal to unit vector
-		local dot = nx*vx + ny*vy + nz*vz
-		nx, ny, nz = dot*nx, dot*ny, dot*nz -- normal is now a component of velocity
+		local vx, vy, vz = Spring.GetUnitVelocity(unitID)
+		local x, y, z = Spring.GetUnitPosition(unitID)
+		local nx, ny, nz = Spring.GetGroundNormal(x, z)
+		local nMag = math.sqrt(nx ^ 2 + ny ^ 2 + nz ^ 2)
+		nx, ny, nz = nx / nMag, ny / nMag, nz / nMag -- normal to unit vector
+		local dot = nx * vx + ny * vy + nz * vz
+		nx, ny, nz = dot * nx, dot * ny, dot * nz -- normal is now a component of velocity
 		local tx, ty, tz = vx - nx, vy - ny, vz - nz -- tangent is the other component of velocity
 		local nf = att.elasticity
 		local tf = att.friction
-		vx, vy, vz = tx*tf + nx*nf - vx, ty*tf + ny*nf - vy, tz*tf + nz*nf - vz
+		vx, vy, vz = tx * tf + nx * nf - vx, ty * tf + ny * nf - vy, tz * tf + nz * nf - vz
 		GG.AddGadgetImpulseRaw(unitID, vx, vy, vz, true, true)
-		
+
 		if env and env.script.StopMoving then
 			env.script.StopMoving()
 		end
-		
-		local damgeSpeed = math.sqrt((nx + tx*TANGENT_DAMAGE)^2 + (ny + ty*TANGENT_DAMAGE)^2 + (nz + tz*TANGENT_DAMAGE)^2)
+
+		local damgeSpeed = math.sqrt((nx + tx * TANGENT_DAMAGE) ^ 2 + (ny + ty * TANGENT_DAMAGE) ^ 2 +
+		(nz + tz * TANGENT_DAMAGE) ^ 2)
 		local damageTotal = LocalSpeedToDamage(unitID, unitDefID, damgeSpeed) + outsideMapDamage(unitID, unitDefID)
-		damageTotal = damageTotal*(collisionDamageMult[unitID] or 1)
+		damageTotal = damageTotal * (collisionDamageMult[unitID] or 1)
 		return damageTotal
 	end
 
@@ -337,7 +339,7 @@ function gadget:GameFrame(frame)
 					else
 						-- Scale mode
 						local scale = unitWantedVelocity[i][2] - 1
-						GG.AddGadgetImpulseRaw(unitID, scale*vx, scale*vy, scale*vz, true, true)
+						GG.AddGadgetImpulseRaw(unitID, scale * vx, scale * vy, scale * vz, true, true)
 					end
 				end
 			end


### PR DESCRIPTION
Took a stab at fixing https://zero-k.info/Forum/Thread/38027, this approach just bounds max collision damage to the specified landing weapon. If there's no specified landing weapon, bounds the max val to 20% of health (arbitrary, happy to change this to whatever val is best).

If that's not ideal, I can also do it by clamping velocity as Googlefrog suggested in that thread.

NOTE: most of diff is from file formatting in line w the Lua style guide (first commit).

The commit to actually do the change is all in [this commit](https://github.com/ZeroK-RTS/Zero-K/commit/da0d13a64b3bf9069087b4de1ccb4efdadeace86)

Highly recommend split view in GH review UI for viewing formatting changes.