### PR TITLE
fix: #5498 When smooth icon zoom is enabled, switching between Team color options ingame does not update unit colors

### DIFF
--- a/LuaUI/Widgets/gui_icontransition.lua
+++ b/LuaUI/Widgets/gui_icontransition.lua
@@ -359,6 +359,11 @@ local function DrawWorldFunc()
 	glDepthMask(false)
 end
 
+local function clearUnitIcons()
+	renderOrders = { {}, {}, {} }
+	unitDefsToRender = {}
+end
+
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
 -- Event Call-ins
@@ -370,7 +375,10 @@ function widget:Initialize()
 	kp_timer = nil
 	current_mode = "Dynamic"
 	UpdateDynamic()
+	widget:addUnitIconsForAllUnits()
+end
 
+function widget:addUnitIconsForAllUnits()
 	local allUnits = spGetAllUnits()
 	for _,unitID in pairs (allUnits) do
 		local unitDefID = spGetUnitDefID(unitID)
@@ -425,6 +433,11 @@ end
 
 function widget:UnitCreated(unitID, unitDefID)
 	addUnitIcon(unitID, unitDefID)
+end
+
+function widget:TeamColorsChanged()
+	clearUnitIcons()
+	widget:addUnitIconsForAllUnits()
 end
 
 function widget:UnitTaken(unitID, unitDefID, oldTeamID, teamID)

--- a/LuaUI/Widgets/gui_local_colors.lua
+++ b/LuaUI/Widgets/gui_local_colors.lua
@@ -7,6 +7,7 @@ function widget:GetInfo()
 		license = "GNU GPL v2, or later",
 		layer = -10001,
 		enabled = true,
+		handler = true,
 	}
 end
 
@@ -184,6 +185,8 @@ local function SetNewTeamColors()
 	if not is_speccing then
 		Spring.SetTeamColor(myTeam, unpack(myColor)) -- overrides previously defined color
 	end
+
+	widgetHandler:TeamColorsChanged()
 end
 
 local function ResetOldTeamColors()

--- a/LuaUI/cawidgets.lua
+++ b/LuaUI/cawidgets.lua
@@ -243,6 +243,7 @@ local flexCallIns = {
 	'DrawShadowFeaturesLua',
 	'RecvSkirmishAIMessage',
 	'SelectionChanged',
+	'TeamColorsChanged',
 	'AddConsoleMessage',
 	'Save',
 	'Load',
@@ -1681,6 +1682,16 @@ function widgetHandler:CommandsChanged()
 	self.inCommandsChanged = false
 end
 
+
+function widgetHandler:TeamColorsChanged()
+	tracy.ZoneBeginN("W:TeamColorsChanged")
+	for _, w in r_ipairs(self.TeamColorsChangedList) do
+		tracy.ZoneBeginN("W:TeamColorsChanged:" .. w.whInfo.name)
+		w:TeamColorsChanged();
+		tracy.ZoneEnd()
+	end
+	tracy.ZoneEnd()
+end
 
 --------------------------------------------------------------------------------
 --


### PR DESCRIPTION
Fix: #5498

Icons now correctly update color when Team Color mode is toggled ingame

- Added new widget handler `TeamColorsChanged`
- Minor refactoring to reuse code in `gui_icontransition.lua`

