### PR TITLE
Fix #5504 : Commander noexplodes not correctly penetrating shields

### DIFF
--- a/LuaRules/Gadgets/weapon_noexplode_stopper.lua
+++ b/LuaRules/Gadgets/weapon_noexplode_stopper.lua
@@ -90,8 +90,9 @@ function gadget:ShieldPreDamaged(proID, proOwnerID, shieldEmitterWeaponNum, shie
 	--	passedProjectile[proID] = true
 	--	return true
 	elseif weaponDefID and shieldCarrierUnitID and shieldEmitterWeaponNum and noExplode[weaponDefID] then
+		local damageMult = Spring.ValidUnitID(proOwnerID) and Spring.GetUnitRulesParam(proOwnerID, "comm_damage_mult") or 1
 		local _, charge = Spring.GetUnitShieldState(shieldCarrierUnitID) --FIXME figure out a way to get correct shield
-		if charge and shieldDamages[weaponDefID] < charge then
+		if charge and shieldDamages[weaponDefID] * damageMult < charge then
 			Spring.DeleteProjectile(proID)
 			if flowAroundShield[weaponDefID] then
 				SetNewProjectileVelocity(shieldCarrierUnitID, proID)

--- a/LuaRules/Gadgets/weapon_shield_merge.lua
+++ b/LuaRules/Gadgets/weapon_shield_merge.lua
@@ -326,9 +326,9 @@ function gadget:ShieldPreDamaged(proID, proOwnerID, shieldEmitterWeaponNum, shie
 	if not weaponDefID then
 		return true
 	end
-
-	local damage = shieldDamages[weaponDefID]
-	local projectilePasses = DrainShieldAndCheckProjectilePenetrate(shieldCarrierUnitID, damage, defaultShielDamages[weaponDefID], hackyProID or proID)
+	local damageMult = Spring.ValidUnitID(proOwnerID) and Spring.GetUnitRulesParam(proOwnerID, "comm_damage_mult") or 1
+	local damage = shieldDamages[weaponDefID] * damageMult
+	local projectilePasses = DrainShieldAndCheckProjectilePenetrate(shieldCarrierUnitID, damage, defaultShielDamages[weaponDefID] * damageMult, hackyProID or proID)
 	return projectilePasses
 end
 


### PR DESCRIPTION
As reported a few week ago by garfild888 via FW discord and ZK discord:

```Update on sniper rifle bug:
if shield charge is greater than actual damage, it correctly takes damage
if shield charge is less than 1200 (damage modules do not change that number), shield is penetrated
if shield charge is less than damage, but greater than 1200, it gets disrupted, but takes no damage
This is somehow tied to noExplode being true and not exclusive to sniper rifle
Many shieldbots were harmed in production of this data
```
Source: https://discord.com/channels/800791984113319956/800791984113319959/1370846559469572156
Source (ZK): https://discord.com/channels/278805140708786177/278908415756206080/1371040264847884319

This is based on https://github.com/Arch-Shaman/ZK-Futurewars-Mod/commit/0aba4229d1bb4f142c4886de4f69bd91cb2de99b which is live and testable.

Replication steps [FW]:
1. Morph Support commander with Sniper Rifle, and 8 damage boosters
2. Fire at a shield, get it down to 1400 - 2000 shield charge left.
3. Note that shield does not get penetrated, and it takes 0 damage.

Theoretical replication on ZK:
1. Morph Flamethrower with some damage boosters and slow game down to 0.1
2. Fire at shield, ensure it has between original damage and new damage value.