### PR TITLE
unit transport load range is 30 elmo

### DIFF
--- a/LuaRules/Gadgets/unit_transport_load_unload.lua
+++ b/LuaRules/Gadgets/unit_transport_load_unload.lua
@@ -21,6 +21,8 @@ end
 local airTransports = {}
 local lightTransport = {}
 local allowTransportCache = {}
+local transportLoadRangeElmo = 30
+local transportLoadRangeDistanceSquared = (transportLoadRangeElmo*2)^2
 
 for unitDefID, ud in pairs(UnitDefs) do
 	if (ud.isTransport and ud.canFly) then
@@ -60,7 +62,7 @@ function gadget:AllowUnitTransportLoad(transporterID, transporterUnitDefID, tran
 		return true
 	end
 	local x, y, z = Spring.GetUnitPosition(transporterID)
-	if DistSq(x, y, z, goalX, goalY, goalZ) > 256 then
+	if DistSq(x, y, z, goalX, goalY, goalZ) > transportLoadRangeDistanceSquared then
 		return false
 	end
 	if Spring.GetUnitAllyTeam(transporterID) ~= Spring.GetUnitAllyTeam(transporteeID) then


### PR DESCRIPTION
Transports should now load most moving allied units when they are 30 elmo from them, instead of just following them around and constantly stopping.  At this value, charons should be able to consistently pick up moving glaives. Anything smaller and faster than that will still have trouble being picked up though (fleas, darts, daggers). Not really sure if that matters much though.

Also changed the code so its a bit more clear.