### PR TITLE
 less strict set target

### DIFF
--- a/LuaRules/Gadgets/unit_target_on_the_move.lua
+++ b/LuaRules/Gadgets/unit_target_on_the_move.lua
@@ -81,8 +81,7 @@ local setTargetSpeedMult = {}
 for i = 1, #UnitDefs do
 	local ud = UnitDefs[i]
 	weaponCounts[i] = (ud.weapons and #ud.weapons)
-	if ((not (ud.canFly and ((ud.isBomber or ud.isBomberAirUnit) and not ud.customParams.can_set_target))) and
-			ud.canAttack and ud.canMove and ud.maxWeaponRange and ud.maxWeaponRange > 0) or ud.isFactory then
+	if (ud.maxWeaponRange and ud.maxWeaponRange > 0) or ud.isFactory then
 		if getMovetype(ud) == 0 then
 			waitWaitUnits[i] = true
 		end

--- a/LuaUI/Widgets/unit_showallcommands_2.lua
+++ b/LuaUI/Widgets/unit_showallcommands_2.lua
@@ -66,8 +66,7 @@ local gaiaTeamID = Spring.GetGaiaTeamID()
 local setTargetUnitDefIDs = {}
 for i = 1, #UnitDefs do
 	local ud = UnitDefs[i]
-	if ((not (ud.canFly and ((ud.isBomber or ud.isBomberAirUnit) and not ud.customParams.can_set_target))) and
-			ud.canAttack and ud.canMove and ud.maxWeaponRange and ud.maxWeaponRange > 0) or ud.isFactory then
+	if (ud.maxWeaponRange and ud.maxWeaponRange > 0) or ud.isFactory then
 		setTargetUnitDefIDs[i] = true
 	end
 end


### PR DESCRIPTION
Way more units are allowed to set-target now.

This includes:
- Static defenses
- Bombers

This is partially to fix https://github.com/ZeroK-RTS/Zero-K/issues/5590 , since units that cant set-target will do nothing instead

However, there are also situations where these units would like to use set-target in general.

I'm not entirely sure why these units werent allowed from set-target in the first place, are there any issues that im not aware of? 