### PR TITLE
Show unit outlines when hidden UI is enabled

### DIFF
--- a/LuaUI/Widgets/gfx_outline_shader_gl4.lua
+++ b/LuaUI/Widgets/gfx_outline_shader_gl4.lua
@@ -86,7 +86,6 @@ local scaleWithHeight = true
 local functionScaleWithHeight = true
 local zoomScaleRange = 0.4
 local overrideDrawBoxes = false
-local hideWithUi = true
 
 local function PrintDrawBox()
 	if overrideDrawBoxes then
@@ -101,7 +100,7 @@ local function PrintDrawBox()
 end
 
 options_path = 'Settings/Graphics/Unit Visibility/Outline'
-options_order = {'thickness', 'scaleRange', 'scaleWithHeight', 'functionScaleWithHeight', 'disableWithUi', 'overrideDrawBox', 'overrideDrawBox_x', 'overrideDrawBox_y', 'overrideDrawBox_yoff'}
+options_order = {'thickness', 'scaleRange', 'scaleWithHeight', 'functionScaleWithHeight', 'overrideDrawBox', 'overrideDrawBox_x', 'overrideDrawBox_y', 'overrideDrawBox_yoff'}
 options = {
 	thickness = {
 		name = 'Outline Thickness',
@@ -141,16 +140,6 @@ options = {
 		noHotkey = true,
 		OnChange = function (self)
 			functionScaleWithHeight = self.value
-		end,
-	},
-	disableWithUi = {
-		name = 'Disable with hidden UI',
-		desc = 'Toggles outlines with Ctrl+F5.',
-		type = 'bool',
-		value = true,
-		noHotkey = true,
-		OnChange = function (self)
-			hideWithUi = self.value
 		end,
 	},
 	
@@ -756,7 +745,7 @@ local useStencil = true
 local STENCILOPPASS = GL_DECR -- KEEP OR DECR
 
 function widget:DrawWorld()
-	if (hideWithUi and Spring.IsGUIHidden()) or internalDisabled then
+	if internalDisabled then
 		return
 	end
 


### PR DESCRIPTION
Fixes https://github.com/ZeroK-RTS/Zero-K/issues/5242 by removing the option to hide unit outlines when the hidden UI is enabled (set to hide them by default) in the unit outline widget

An alternative solution would be to set the option to false by default (PR here https://github.com/ZeroK-RTS/Zero-K/pull/5614).