### PR TITLE
Implement options for allowing clicking through the Quick Selection Bar and the Command Panel

### DIFF
--- a/LuaUI/Widgets/gui_chili_core_selector.lua
+++ b/LuaUI/Widgets/gui_chili_core_selector.lua
@@ -233,7 +233,7 @@ options = {
 		name = 'Allow clicking through',
 		type='bool',
 		value=false,
-		desc = 'Mouse clicks through empty parts of the panel to act on whatever is underneath.',
+		desc = 'Mouse clicks through empty parts of the panel act on whatever is underneath.',
 		OnChange = function(self)
 			if mainBackground then
 				mainBackground.SetAllowClickThrough(self.value)

--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -217,7 +217,7 @@ options = {
 		name = 'Allow clicking through',
 		type='bool',
 		value=false,
-		desc = 'Mouse clicks through empty parts of the panel to act on whatever is underneath.',
+		desc = 'Mouse clicks through empty parts of the panel act on whatever is underneath.',
 		OnChange = function(self)
 			if background then
 				background.noClickThrough = not self.value

--- a/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
+++ b/LuaUI/Widgets/gui_chili_selections_and_cursortip.lua
@@ -389,7 +389,7 @@ options = {
 	},
 	allowclickthrough = {
 		name = 'Allow clicking through', type='bool', value=false,
-		desc = 'Mouse clicks through empty parts of the panel to act on whatever is underneath.',
+		desc = 'Mouse clicks through empty parts of the panel act on whatever is underneath.',
 		path = selPath,
 		OnChange = function(self)
 			if selectionWindow then


### PR DESCRIPTION
NB: The Selected Units Panel already has an option like this.

I put these new options right after the `background_opacity` option in each panel because the option in the Selected Units Panel is ordered similarly (after the `selection_opacity` option for that panel).

These options will be unset (can't click through the panels) by default preserving the existing behavior.

Implements https://github.com/ZeroK-RTS/Zero-K/issues/5503