### PR TITLE
Improve Quick Selection Bar's handling of transported cons

### DIFF
--- a/LuaUI/Widgets/gui_chili_core_selector.lua
+++ b/LuaUI/Widgets/gui_chili_core_selector.lua
@@ -468,10 +468,10 @@ local function SelectComm()
 	end
 	
 	local alt, ctrl, meta, shift = Spring.GetModKeyState()
-	local tuid = ConvertConIDToTransportIdCarryingItIfNeeded(unitID)
-	Spring.SelectUnit(tuid, shift)
+	unitID = ConvertConIDToTransportIdCarryingItIfNeeded(unitID)
+	Spring.SelectUnit(unitID, shift)
 	if not shift then
-		local x, y, z = Spring.GetUnitPosition(tuid)
+		local x, y, z = Spring.GetUnitPosition(unitID)
 		SetCameraTarget(x, y, z)
 	end
 end
@@ -546,13 +546,13 @@ local function SelectIdleCon()
 
 		for uid, v in pairs(idleCons) do
 			if uid ~= "count" then
-				tuid = ConvertConIDToTransportIdCarryingItIfNeeded(uid)
-				if (not Spring.IsUnitSelected(tuid)) then
-					local x,_,z = spGetUnitPosition(tuid)
+				uid = ConvertConIDToTransportIdCarryingItIfNeeded(uid)
+				if (not Spring.IsUnitSelected(uid)) then
+					local x,_,z = spGetUnitPosition(uid)
 					dist = (pos[1]-x)*(pos[1]-x) + (pos[3]-z)*(pos[3]-z)
 					if (dist < mindist) then
 						mindist = dist
-						muid = tuid
+						muid = uid
 					end
 				end
 			end
@@ -568,9 +568,9 @@ local function SelectIdleCon()
 			for uid, v in pairs(idleCons) do
 				if uid ~= "count" then
 					if i == conIndex then
-						tuid = ConvertConIDToTransportIdCarryingItIfNeeded(uid)
-						Spring.SelectUnit(tuid)
-						local x, y, z = Spring.GetUnitPosition(tuid)
+						uid = ConvertConIDToTransportIdCarryingItIfNeeded(uid)
+						Spring.SelectUnit(uid)
+						local x, y, z = Spring.GetUnitPosition(uid)
 						SetCameraTarget(x, y, z)
 						return
 					else


### PR DESCRIPTION
- Implement Quick Selection Bar's hotkeys selecting the transports carrying commanders and other cons instead of not selecting anything (only moving the camera's position)
- Consider transports carrying cons counting as idle cons when the transports are idle, and don't count them when they aren't
- Handles enemy transports properly (they aren't selectable/controllable so the cons they're carrying be considered idle)
  - Cons carried by enemy transports are never considered to be idle
- Updates idle cons count properly when transports carrying cons are destroyed

Fixes https://github.com/ZeroK-RTS/Zero-K/issues/5413 and https://github.com/ZeroK-RTS/Zero-K/issues/5412

# Tests
Enabling cheats and use of the cheat menu for the following tests is required!

Test 1, 2 and 4 confirmed to be working as expected. Test 3 confirmed to be working but it must be tested with another player in multiplayer because switching between "control teams" using the cheats menu breaks the ally/team/enemy detection part of the code.

The tests should be twice, once with the `monitoridlecomms` option on, and again with it off. Using a regular constructor instead of the commander as appropriate.

## 👍Test 1 (friendly transport-initiated load)
- Setup
	- Select your commander, execute a Stop command (important! currently units that haven't yet been given a command aren't considered as idle, see https://github.com/ZeroK-RTS/Zero-K/issues/5620) and set it to Hold Fire.
	- Spawn a heavy transport unit (eg. Hercules from the Gunship Plant) on your team then select it and set it to Hold Fire.
	- Expected Result:
		- The number of idle cons should be 1.
- Steps:
	- With the Hercules selected, right click on your idle commander to pick it up
		- Expected Result: the number of idle cons should remain at 1 during the whole process
	- With the Hercules selected, set it to Patrol.
		- Expected Result:
			- The number of idle cons should now be 0.
			- The "select * idle cons" hotkeys should clear your selection.
			- The "select commander" hotkey should select the Hercules.
	- With the Hercules selected, make it stop patrolling (stop command)
		- Expected Result:
			- The number of idle cons should be now be 1.
			- If you clear your selection, pressing either the "select idle cons" hotkey or the "select commander" hotkey should center the camera on the Hercules and select it.
			- If you clear your selection, pressing the "select all idle cons" hotkey should select the Hercules but NOT center the camera.
	- With the Hercules selected, execute the unload command on the ground
		- Expected Result:
			- The number of idle cons should be 0 once the command starts executing then become 1 after the cons unit is done unloading onto the ground.
			- The hotkeys should work as expected.
	- With the Hercules selected, right click on the commander to pick it up again. Spawn 2 anti-air units (eg. Trident(s) from the Gunship Plant) on the enemy team to attack and destroy the Hercules. Finally, move the Tridents away from the commander.
		- Expected Result:
			- Once the Hercules explodes, the number of idle cons should now be 1.
			- The hotkeys should work as expected.

## 👍Test 2 (commander-initiated load)
- Setup
	- Select your commander and execute a Stop command.
	- Spawn a heavy transport unit (eg. Hercules from the Gunship Plant) on your team then select it.
	- Expected Result:
		- The number of idle cons should be 1.
- Steps:
	- With your commander selected, right click on the Hercules to load into it
		- Expected Result:
			- The number of idle cons should drop to 0 as the commander is loading onto the transport.
			- Once that's done, the number of idle cons should now be 1.

## [multiplayer needed for this test] 👍 Test 3 (enemy transport-initiated load)
- Setup
	- Select your commander, execute a Stop command and set it to Hold fire.
	- Have your buddy spawn a heavy transport unit (eg. Hercules from the Gunship Plant) on the opposing team.
	- Expected Result:
		- The number of idle cons should be 1.
- Steps
	- Have your buddy select their Hercules (with the Control Team set to the enemy), then execute a Load command targeting your commander
		- Expected Result:
			- The number of idle cons at 1 until the transport successfully grabs onto the commander at which point the number of idle cons should become 0.
			- Using the "select * idle cons" hotkeys should do nothing and the "select commander" hotkey should do nothing.
	- Have your buddy select their Hercules, then execute a Patrol command 
		- Expected Result:
			- The number of idle cons should remain at 0.
	- Spawn 2 anti-air units (eg. Trident(s) from the Gunship Plant) on your team to attack and destroy the enemy Hercules.
		- Expected Result:
			- Once the Hercules is destroyed, the number of idle cons should immediately change from 0 to 1.
			- All the hotkeys should work as expected.

## 👍 Test 4 (multiple cons/transports)

- Setup:
    - Select your commander and execute a Stop command.
    - Spawn 4 cons (eg. Convicts from the Shieldbot Factory) and execute stop commands on them.
    - Group the commander and the Convicts close to each other.
    - Spawn 5 heavy transport units (eg. Hercules from the Gunship Plant) on your team.
- Steps:
    - With all 5 Hercules selected, perform a Area Load command by selecting Load then dragging with the Left Mouse on the commander and the Convicts
      - Expected Result:
          - The number of idle cons shouldn't change from 5.
          - Pressing the "select idle cons" hotkey should select each Hercules in turn.
          - Pressing the "select all idle cons" hotkey should select all 5 Hercules.
          - Pressing the "select commander" hotkey should select the Hercules carrying the commander.
- With one Hercules carrying a non-commander cons selected, perform an Unload command on the ground nearby
  - Expected Result:
    - During the execution of the Unload command, the number of idle cons should switch to 4, once completed the number of idle cons should become 5.
    - Pressing the "select idle cons" hotkey should select each Hercules and the grounded cons, in some order.
    - Pressing the "select all idle cons" hotkey should select the 4 Hercules carrying cons and the grounded cons.
    - Pressing the "select commander" hotkey should select the Hercules carrying the commander.
    
 # Videos
 
## Multiplayer test

enemy transport carrying commander then destroyed:
https://github.com/user-attachments/assets/49e3846d-2d95-4f12-a05a-b386b2a465c4

enemy transport picking up commander and moving around:
https://youtu.be/kmYtSV1h0lk

(we also tested unloading the commander which also worked as expected)