### PR TITLE
Replace "scroll speed" with "pan speed" in the simple options menu for the default camera for clarity.

### DIFF
--- a/LuaUI/Widgets/gui_simple_settings.lua
+++ b/LuaUI/Widgets/gui_simple_settings.lua
@@ -148,7 +148,7 @@ local optionGenerationTable = {
 	{
 		optionName = "scrollSpeed",
 		chobbyName = "CameraPanSpeed",
-		name = "Scroll Speed",
+		name = "Pan Speed",
 		min = 1,
 		max = 200,
 		default = 50,


### PR DESCRIPTION
In the context of camera movement it's much easier to get confused about the meaning of the word "scroll" due to the existence of the "scroll" wheel on a mouse, by default used to zoom in and out with the camera.

Fixes https://github.com/ZeroK-RTS/Zero-K/issues/3342