### PR TITLE
Fix resource bar energy/metal expense text being truncated when using large font sizes.

### DIFF
--- a/LuaUI/Widgets/gui_chili_economy_panel2.lua
+++ b/LuaUI/Widgets/gui_chili_economy_panel2.lua
@@ -1565,7 +1565,7 @@ function CreateWindow(oldX, oldY, oldW, oldH)
 		valign = "center",
 		align  = "left",
 		caption = "0",
-		autosize = false,
+		autosize = true,
 		objectOverrideFont = WG.GetSpecialFont(options.fontSize.value, "res_grey", {
 			outline = true, color = {.8,.8,.8,.9}, outlineWidth = 2, outlineWeight = 2.
 		}),
@@ -1580,7 +1580,7 @@ function CreateWindow(oldX, oldY, oldW, oldH)
 		caption = positiveColourStr.."+0.0",
 		valign = "center",
 		align  = "left",
-		autosize = false,
+		autosize = true,
 		objectOverrideFont = WG.GetSpecialFont(options.fontSize.value, "res_outline", {
 			outline = true, outlineWidth = 2, outlineWeight = 2,
 		}),
@@ -1595,7 +1595,7 @@ function CreateWindow(oldX, oldY, oldW, oldH)
 		caption = negativeColourStr.."-0.0",
 		valign = "center",
 		align  = "left",
-		autosize = false,
+		autosize = true,
 		objectOverrideFont = WG.GetSpecialFont(options.fontSize.value, "res_outline", {
 			outline = true, outlineWidth = 2, outlineWeight = 2,
 		}),
@@ -1721,7 +1721,7 @@ function CreateWindow(oldX, oldY, oldW, oldH)
 		valign = "center",
 		align  = "left",
 		caption = "0",
-		autosize = false,
+		autosize = true,
 		objectOverrideFont = WG.GetSpecialFont(options.fontSize.value, "res_grey", {
 			outline = true, color = {.8,.8,.8,.9}, outlineWidth = 2, outlineWeight = 2.
 		}),
@@ -1736,7 +1736,7 @@ function CreateWindow(oldX, oldY, oldW, oldH)
 		caption = positiveColourStr.."+0.0",
 		valign = "center",
 		align  = "left",
-		autosize = false,
+		autosize = true,
 		objectOverrideFont = WG.GetSpecialFont(options.fontSize.value, "res_outline", {
 			outline = true, outlineWidth = 2, outlineWeight = 2,
 		}),
@@ -1751,7 +1751,7 @@ function CreateWindow(oldX, oldY, oldW, oldH)
 		caption = negativeColourStr.."-0.0",
 		valign = "center",
 		align  = "left",
-		autosize = false,
+		autosize = true,
 		objectOverrideFont = WG.GetSpecialFont(options.fontSize.value, "res_outline", {
 			outline = true, outlineWidth = 2, outlineWeight = 2,
 		}),


### PR DESCRIPTION
Fixes https://github.com/ZeroK-RTS/Zero-K/issues/2221

before: 
![screen_2025-12-07_14-27-58-741](https://github.com/user-attachments/assets/80689f2f-b675-44ff-b9b7-2e2054effb15)

after:
![screen_2025-12-07_14-27-20-436](https://github.com/user-attachments/assets/a4a87fc4-79ee-45df-acc9-fcaf8d870aa7)