### PR TITLE
Fix typo in the custom grid hotkey menu's "Apply Changes" label

### DIFF
--- a/LuaUI/Widgets/gui_chili_integral_menu.lua
+++ b/LuaUI/Widgets/gui_chili_integral_menu.lua
@@ -290,7 +290,7 @@ options = {
 	label_apply = {
 		type = 'text',
 		name = 'Note: Click above to refresh',
-		value = 'Update modified custom grid hotkeys by clicking the button above. Reselecting any selected units may also be required. Note that "Apply Changes" can be bound to a key for convinence.',
+		value = 'Update modified custom grid hotkeys by clicking the button above. Reselecting any selected units may also be required. Note that "Apply Changes" can be bound to a key for convenience.',
 		path = customGridPath
 	},
 	label_tab = {


### PR DESCRIPTION
this issue can be closed https://github.com/ZeroK-RTS/Zero-K/issues/3894

This label is a lot clearer than it was when the issue was created, 