### PR TITLE
Siren dgun missile salvo concept

### DIFF
--- a/scripts/shipassault.lua
+++ b/scripts/shipassault.lua
@@ -74,6 +74,10 @@ function script.BlockShot(num, targetID)
 	if num == 2 and GG.OverkillPrevention_CheckBlock(unitID, targetID, 400.1, 90, false, false, true) then
 		return true
 	end
+	if num == 2 then
+		local reloadState = Spring.GetUnitWeaponState(unitID, 3, 'reloadState')
+		return not (reloadState and (reloadState < 0 or reloadState < Spring.GetGameFrame()))
+	end
 	return false
 end
 
@@ -95,7 +99,7 @@ function script.AimWeapon(num, heading, pitch)
 		WaitForTurn(sleeves, x_axis)
 		StartThread(RestoreAfterDelay)
 		return true
-	elseif num == 2 then
+	elseif num == 2 or num == 3 then
 		return true
 	end
 end
@@ -114,7 +118,7 @@ function script.Shot(num)
 		EmitSfx(gunPieces[gun_1].flare, 1024)
 		Move(gunPieces[gun_1].flare, z_axis, 0)
 		StartThread(Recoil, gunPieces[gun_1].barrel)
-	elseif num == 2 then
+	elseif num == 2 or num == 3 then
 		missileNum = missileNum + 1
 		if missileNum > 4 then missileNum = 1 end
 		EmitSfx(missiles[missileNum], 1025)

--- a/units/shipassault.lua
+++ b/units/shipassault.lua
@@ -104,6 +104,7 @@ return { shipassault = {
         craterMult              = 0,
 
         customParams            = {
+            combatRange = 225,
             force_ignore_ground = [[1]],
             slot = [[5]],
             muzzleEffectFire = [[custom:HEAVY_CANNON_MUZZLE]],
@@ -148,15 +149,12 @@ return { shipassault = {
     },
     
     MISSILE      = {
-      name                    = [[Destroyer Missiles]],
+      name                    = [[Destroyer Missile]],
       areaOfEffect            = 48,
       cegTag                  = [[missiletrailyellow]],
       collideFriendly         = false,
       craterBoost             = 1,
       craterMult              = 2,
-      customParams            = {
-        combatRange = 265,
-      },
       damage                  = {
         default = 400.01,
       },
@@ -187,7 +185,7 @@ return { shipassault = {
     },
     
     MISSILE_SALVO      = {
-      name                    = [[Destroyer Missiles Salvo]],
+      name                    = [[Destroyer Missile Salvo]],
       areaOfEffect            = 48,
       avoidFeature            = false,
       avoidFriendly           = false,
@@ -199,9 +197,6 @@ return { shipassault = {
       commandfire             = true,
       craterBoost             = 1,
       craterMult              = 2,
-      customParams            = {
-        combatRange = 265,
-      },
       damage                  = {
         default = 400.01,
       },


### PR DESCRIPTION
Siren's missile always felt a little hard to control or use in a way that feels good. 
It most often wastes it shot against a mobile target unless you pretarget a static and there is no way to prevent it from firing while keeping the main sonar gun active. 
Rightclicking/Forcefiring a distant target makes it fall back onto its missile, and so the Siren will not approach. (Dante has this too with its missiles after using dgun)

So the idea was to make Sirens missile easier to use effectively by allowing manual fire of a salvo of its missiles and to try to remove those wrinkles in the controlscheme. Could also be an opportunity to push its missile more into a costal siege/support role too.

In this implementation it is in addition to the automatic launch, where the cooldown of the manual missile salvo prevents the automatic missile fire, so the effective dps stays roughly the same while the Siren doesnt punish inactivity too much.
The salvo of 4 is 1600 damage/2 Ravens, and could be comboed with the automatic missile for 2000 burst damage, though has 64s reload to keep the dps even.

It may be better to use a pure manual fire approach and remove the automatic missile, as rightclicking a target still makes Siren wait for its missile instead of approaching, though there may be a workaround for that too and let the automatic missile not respond to forcefire.
A pure manualfire would get around that, and maybe allow the missiles to be balanced around its antistructure capability.

Also curious to hear your peepes's input on it

Oh, also included is an adjustment to combat distance, since I observed that two Sirens on Amove toward eachother keep too much distance to use their Sonar weapons.
