### PR TITLE
Fix more huge EMP award numbers.

### DIFF
--- a/LuaRules/Gadgets/unit_paralysis_damage.lua
+++ b/LuaRules/Gadgets/unit_paralysis_damage.lua
@@ -90,8 +90,19 @@ function gadget:UnitPreDamaged(unitID, unitDefID, unitTeam, rawDamage, paralyzer
 		local health, maxHealth, paralyzeDamage = spGetUnitHealth(unitID)
 		if health and maxHealth and health > 0 then -- taking no chances.
 			if GG.Awards and GG.Awards.AddAwardPoints then
-				local cost_emped = (rawDamage / maxHealth) * GetUnitCost(unitID)
-				GG.Awards.AddAwardPoints('emp', attackerTeam, cost_emped)
+				local maxStunFraction = paraTime[weaponDefID] / DECAY_SECONDS
+				local maxParaHealth = maxHealth * (1 + maxStunFraction)
+				local remainingParaHealth = maxParaHealth - paralyzeDamage
+
+				-- in theory overstun mult can modify things further,
+				-- but we don't care for similar reasons why the
+				-- mult from low health is ignored as well
+
+				if remainingParaHealth > 0 then -- smaller than 0 if already stunned by a stronger weapon
+					local cappedDamage = math.min(rawDamage, remainingParaHealth)
+					local cost_emped = (cappedDamage / maxHealth) * GetUnitCost(unitID)
+					GG.Awards.AddAwardPoints('emp', attackerTeam, cost_emped)
+				end
 			end
 			local damage = GetStunDamage(weaponDefID, rawDamage, health, maxHealth, paralyzeDamage)
 			if overstunTime[weaponDefID] > 0 then


### PR DESCRIPTION
Now takes max stun time into account. For example, Shockley could stun a Flea 750 times over if not for the max, but the award used to count this and provide ~18k metal's worth of progress per Flea.

Doesn't take overstun multiplier into account, so a weapon tuned to quickly reach 100% but struggle to go above by having huge raw damage but small multiplier (or vice versa) will still miscount.