### PR TITLE
Convert startbox config to 1-based indexing

### DIFF
--- a/LuaRules/Configs/StartBoxes/Terra.lua
+++ b/LuaRules/Configs/StartBoxes/Terra.lua
@@ -1,5 +1,5 @@
 local layout = {
-	[0] = {
+	{
 		boxes = {
 			{
 				{Game.mapSizeX / 2, 1},
@@ -63,7 +63,7 @@ local layout = {
 		nameLong  = "North",
 		nameShort = "N",
 	},
-	[1] = {
+	{
 		boxes = {{}},
 		startpoints = {},
 		nameLong  = "South",
@@ -71,16 +71,16 @@ local layout = {
 	}, -- mirrored automatically
 }
 
-for i = 1, #layout[0].boxes[1] do
-	layout[1].boxes[1][i] = {
-		Game.mapSizeX - layout[0].boxes[1][i][1],
-		Game.mapSizeZ - layout[0].boxes[1][i][2]
+for i = 1, #layout[1].boxes[1] do
+	layout[2].boxes[1][i] = {
+		Game.mapSizeX - layout[1].boxes[1][i][1],
+		Game.mapSizeZ - layout[1].boxes[1][i][2]
 	}
 end
-for i = 1, #layout[0].startpoints do
-	layout[1].startpoints[i] = {
-		Game.mapSizeX - layout[0].startpoints[i][1],
-		Game.mapSizeZ - layout[0].startpoints[i][2]
+for i = 1, #layout[1].startpoints do
+	layout[2].startpoints[i] = {
+		Game.mapSizeX - layout[1].startpoints[i][1],
+		Game.mapSizeZ - layout[1].startpoints[i][2]
 	}
 end
 


### PR DESCRIPTION
Lua tables are naturally 1‑indexed, and explicit 0‑based keys are mistake‑prone. 

This aligns the file with the standards described in [issue #5137](https://github.com/ZeroK-RTS/Zero-K/issues/5137) and updates all internal references accordingly.