### PR TITLE
Partially fix fixedwing takeoff funcs

### DIFF
--- a/scripts/bomberdisarm.lua
+++ b/scripts/bomberdisarm.lua
@@ -23,7 +23,7 @@ function script.Create()
 	Turn(Rwing, z_axis, math.rad(-90))
 	Turn(LwingTip, z_axis, math.rad(-165))
 	Turn(RwingTip, z_axis, math.rad(165))
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 end
 
@@ -39,7 +39,7 @@ function script.Deactivate()
 	Turn(Rwing, z_axis, math.rad(-10), 2)
 	Turn(LwingTip, z_axis, math.rad(-30), 2) -- -30
 	Turn(RwingTip, z_axis, math.rad(30), 2) --30
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 function script.FireWeapon(checkHeight)

--- a/scripts/bomberheavy.lua
+++ b/scripts/bomberheavy.lua
@@ -171,7 +171,7 @@ end
 
 function script.StopMoving()
 	StartThread(Stopping)
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 local function ShowBallWhenConstructionFinished()
@@ -203,7 +203,7 @@ function script.Create()
 	Hide(radiator_R)
 
 	SetInitialBomberSettings()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 
 	StartThread(ShowBallWhenConstructionFinished)

--- a/scripts/bomberheavyold.lua
+++ b/scripts/bomberheavyold.lua
@@ -56,12 +56,12 @@ end
 
 function script.StopMoving()
 	StartThread(Stopping)
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 function script.Create()
 	SetInitialBomberSettings()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 	Hide(rearthrust)
 	Hide(wingthrust1)

--- a/scripts/bomberprec.lua
+++ b/scripts/bomberprec.lua
@@ -52,7 +52,7 @@ function script.StopMoving()
 	Move(wingr2, x_axis, 5, 30)
 	Move(wingl1, x_axis, -5, 30)
 	Move(wingl2, x_axis, -5, 30)
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 local function Lights()
@@ -68,7 +68,7 @@ end
 
 function script.Create()
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	GG.FakeUpright.FakeUprightInit(xp, zp, drop)
 	--StartThread(Lights)
 end

--- a/scripts/bomberriot.lua
+++ b/scripts/bomberriot.lua
@@ -26,13 +26,13 @@ local function Lights()
 end
 
 function script.StopMoving()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 function script.Create()
 	SetInitialBomberSettings()
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	--StartThread(Lights)
 end
 

--- a/scripts/bomberstrike.lua
+++ b/scripts/bomberstrike.lua
@@ -38,7 +38,7 @@ end
 
 function script.Create()
 	SetInitialBomberSettings()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	StartThread(GG.Script.SmokeUnit, unitID, {wingtipl, wingtipr, head})
 	Turn(turret, y_axis, math.pi)
 	Move(wingl, x_axis, -5, 7)
@@ -64,7 +64,7 @@ end
 function script.StopMoving()
 	Move(wingl, x_axis, -5, 7)
 	Move(wingr, x_axis, 5, 7)
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 function script.AimWeapon(num, heading, pitch)

--- a/scripts/fixedwingTakeOff.lua
+++ b/scripts/fixedwingTakeOff.lua
@@ -3,17 +3,17 @@ if GG.TakeOffFuncs then
 end
 GG.TakeOffFuncs = {}
 
-function GG.TakeOffFuncs.NotTakingOff()
+function GG.TakeOffFuncs.NotTakingOff(unitID)
 	local state = Spring.GetUnitMoveTypeData(unitID)
 	return state and (state.aircraftState ~= "takeoff")
 end
 
-function GG.TakeOffFuncs.TakeOffThread(height, signal)
+function GG.TakeOffFuncs.TakeOffThread(unitID, height, signal)
 	local FUDGE_FACTOR = 1.5
 	
 	Signal(signal)
 	SetSignalMask(signal)
-	while GG.TakeOffFuncs.NotTakingOff() do
+	while GG.TakeOffFuncs.NotTakingOff(unitID) do
 		Sleep(1000)
 	end
 	for i = 1, 5 do

--- a/scripts/planelightscout.lua
+++ b/scripts/planelightscout.lua
@@ -52,11 +52,11 @@ function SprintDetonate()
 end
 
 function script.StopMoving()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 function script.Create()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 end
 

--- a/scripts/planescout.lua
+++ b/scripts/planescout.lua
@@ -29,12 +29,12 @@ function Cloak()
 end
 
 function script.StopMoving()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 end
 
 
 function script.Create()
-	StartThread(GG.TakeOffFuncs.TakeOffThread, takeoffHeight, SIG_TAKEOFF)
+	StartThread(GG.TakeOffFuncs.TakeOffThread, unitID, takeoffHeight, SIG_TAKEOFF)
 	StartThread(GG.Script.SmokeUnit, unitID, smokePiece)
 end
 


### PR DESCRIPTION
They would all use the unitID of the first fixedwing aircraft.

This does NOT solve #5673 (first Sparrow being able to hover mid-air), now all Sparrows have this "ability".