### PR TITLE
Fix: Scylla stows it's tacnuke correctly

### DIFF
--- a/scripts/subtacmissile.lua
+++ b/scripts/subtacmissile.lua
@@ -64,7 +64,7 @@ function script.EndBurst()
 	     actually spawned so the Turn would ruin the spawnpoint, up to
 	     clipping it into other units or seaside cliffs. ]]
 	Hide (missile)
-	Turn (missile, x_axis, 0)
+	Turn (missile, x_axis, 0, math.rad(90))
 
 	local slowMult = (Spring.GetUnitRulesParam(unitID,"baseSpeedMult") or 1)
 	Turn (door1, z_axis, 0, math.rad(80)*slowMult)


### PR DESCRIPTION
Scylla sometimes ends up with it's missile sticking out when the doors are closed. It just needed turnspeed applied.

Slows Scylla firerate by just a little since it needs to turn it's missile upward again though.