### PR TITLE
Starlight description is wrong

### DIFF
--- a/units/mahlazer.lua
+++ b/units/mahlazer.lua
@@ -133,7 +133,7 @@ return { mahlazer = {
       craterMult              = 0,
 
       customParams              = {
-        stats_damage = 18000,
+        stats_damage = 19500,
         stats_hide_shield_damage = 1,
         light_radius = 0,
         lups_noshockwave = [[1]],


### PR DESCRIPTION
Craterpuncher is displayed as dealing 18k damage. The LUS sets craterpuncher to fire for 30 ticks every time it triggers, with the craterpuncher ticks replacing the cutter ticks. ZK weapon convention is that a unit can fire all of it's weapons at once, so we subtract the dps of cutter to get a damage of `(800 - 150)*30 = 19500` for craterpuncher