### PR TITLE
Fix default DepthTest and Culling states

### DIFF
--- a/LuaUI/Widgets/map_edge_extension2.lua
+++ b/LuaUI/Widgets/map_edge_extension2.lua
@@ -861,6 +861,7 @@ function widget:DrawGroundDeferred()
 	--gl.DepthTest(false)
 	--gl.DepthMask(false)
 	gl.Culling(GL.BACK)
+	gl.Culling(false)
 
 end
 
@@ -894,10 +895,12 @@ function widget:DrawWorldPreUnit()
 	gl.Texture(1, false)
 	gl.Texture(2, false)
 
-	gl.DepthTest(GL.ALWAYS)
+	gl.DepthTest(GL.LEQUAL)
 	gl.DepthTest(false)
 	gl.DepthMask(false)
 	gl.Culling(GL.BACK)
+	gl.Culling(false)
+
 end
 
 local lastSunChanged = -1


### PR DESCRIPTION
Showeco and grid drawer (among others?) not working properly because of it.