### PR TITLE
Issue #4631 - Add Moderator and Scalpel to Ronin's kite list

### DIFF
--- a/LuaRules/Configs/tactical_ai_defs.lua
+++ b/LuaRules/Configs/tactical_ai_defs.lua
@@ -1367,7 +1367,8 @@ local behaviourConfig = {
 		name = "cloakskirm",
 
 		-- LLT isn't outranged, but is on the list for the reload step-back
-		skirms = medRangeAndTurretSkirmieeArray,
+		-- Similarly, a couple long-range units are included for the reload step-back
+		skirms = Union(medRangeAndTurretSkirmieeArray, NameToDefID({"jumpskirm", "hoverskirm"})),
 		swarms = medRangeSwarmieeArray,
 		--flees = {},
 		avoidHeightDiff = explodableFull,


### PR DESCRIPTION
## Make Ronin kite Moderator and Scalpel

Fixes #4631 

Ronin (`cloakskirm`) doesn't skirm Moderator (`jumpskirm`) or Scalpel (`hoverskirm`), even though it slightly outranges both, is faster, and they're slow alpha-strike units.

**Cause:** Both are classified in `longRangeSkirmieeArray`, a tier above Ronin's `medRangeAndTurretSkirmieeArray`.

**Change:** one line, Ronin-only, adding specifically these two into Ronin's `skirm` array.

**Testing:** dev game, Ronin vs Moderator/Scalpel with Unit AI on. Ronin now enters Skirm behavior against both. Fires, steps back. Both still generally defeat Ronin, but Ronin will last longer against blobs by limiting their exposure more.

It is possible that a unit's category should change, but that would be a much further impacting change in behaviors so I am refraining from that direction unless there are reasons to go that way.