### PR TITLE
Overdrive cables: raised cross-section, shadows, and deferred lighting

### DIFF
--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
@@ -9,6 +9,8 @@ uniform float gameTime;
 uniform float bakeTime;
 uniform float enableFlow;     // 1.0 = full bubble pass; 0.0 = static cables (no animation)
 uniform float ghostsEnabled;  // 1.0 = ghost branch active; 0.0 = enemy OOL discards immediately
+uniform sampler2DShadow shadowTex;  // engine shadow map ($shadow); sampled for shadow reception
+uniform float shadowsEnabled; // 1.0 = sample the shadow map; 0.0 = treat everything as fully lit
 
 // Same SSBO as the GS — per-edge coverage bitmask, gates per-segment
 // ghost rendering for enemy fragments.
@@ -267,6 +269,19 @@ vec3 gridEfficiencyColor(float eff) {
 	return hueToRgb(h / 255.0);
 }
 
+// Shadow reception. Returns 1.0 in full sun, → 0.0 fully shadowed. Mirrors the
+// engine's receive-side convention (cus_gl4.vert.glsl / map_lava.lua): transform
+// world pos by `shadowView` (from the engine UBO), recenter xy by +0.5, then a
+// projective compare against the depth map. NO `shadowProj` here — that's the
+// cast-side transform only; `shadowView` already maps into the sampling space.
+// shadowsEnabled gates the whole thing so we never sample a stale/absent map.
+float getShadowCoeff(vec3 wp) {
+	if (shadowsEnabled < 0.5) return 1.0;
+	vec4 sp = shadowView * vec4(wp, 1.0);
+	sp.xy += vec2(0.5);
+	return clamp(textureProj(shadowTex, sp), 0.0, 1.0);
+}
+
 void main() {
 	float v = cableUV.y * EDGE_BUFFER;
 	float t = abs(v);
@@ -419,9 +434,14 @@ void main() {
 	return;
 #endif
 
-	// Own lighting (forward rendered, no engine lighting applies)
+	// Own lighting (forward rendered; the engine doesn't light cables, so we
+	// sample the shadow map ourselves). Shadow darkens only the SUN term, never
+	// the ambient floor — a cable in shadow falls to DIFFUSE_FLOOR, not black.
+	// Bubbles are composited later and stay emissive (lights in the dark).
 	vec3 gridColor   = gridEfficiencyColor(gridData.x);
-	float diffuse = min(1.0, max(DIFFUSE_FLOOR, DIFFUSE_FLOOR + (1.0 - DIFFUSE_FLOOR) * dot(cylNormal, normalize(sunDir.xyz))));
+	float shadowCoeff = getShadowCoeff(worldPos);
+	float sunNdotL = dot(cylNormal, normalize(sunDir.xyz)) * shadowCoeff;
+	float diffuse = min(1.0, max(DIFFUSE_FLOOR, DIFFUSE_FLOOR + (1.0 - DIFFUSE_FLOOR) * sunNdotL));
 
 	// LOS state — sampled from $info:los (single-channel red), the engine's
 	// actual game-logic LOS texture. Independent of the user's overlay toggle:
@@ -434,7 +454,7 @@ void main() {
 	vec3 viewDir = normalize(cameraViewInv[3].xyz - worldPos);
 	float cameraDist = length(cameraViewInv[3].xyz - worldPos);
 	vec3 halfDir = normalize(normalize(sunDir.xyz) + viewDir);
-	float spec = pow(clamp(dot(cylNormal, halfDir), 0.0, 1.0), SPEC_EXP) * SPEC_MAGNITUDE;
+	float spec = pow(clamp(dot(cylNormal, halfDir), 0.0, 1.0), SPEC_EXP) * SPEC_MAGNITUDE * shadowCoeff;
 
 	// Bark / inner gray-scale tint by capacity. Industrial conduit look.
 	float capT = clamp(capacity / 100.0, 0.0, 1.0);

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
@@ -274,6 +274,17 @@ void main() {
 		if (along < witherFront) discard;
 	}
 
+#ifdef SHADOW_PASS
+	// Shadow caster: only own/spectator cables drop shadows for now (gridData.w
+	// >= 1.0). Enemy live (0.0) and ghost (-1.0) are skipped so the shadow pass
+	// can't leak un-scouted enemy grid. The grow/wither discards above already
+	// trimmed the silhouette to the visible cable; depth is all the shadow map
+	// needs, so skip lighting/bubbles entirely.
+	if (gridData.w < 0.5) discard;
+	fragColor = vec4(0.0);
+	return;
+#endif
+
 	// FAST GHOST PATH — orphaned-enemy edges (gridData.w = -1.0) skip all the
 	// cylinder-normal / lighting / bubble math below. Read LOS + coverage,
 	// decide, render translucent flat ghost or discard. Nothing else.

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
@@ -138,7 +138,16 @@ const float GHOST_EDGE_FADE_HI = 0.90;
 
 const float EDGE_BUFFER = 0.55; // Avoid rasterisation issues on the edge of the cable
 
+#ifdef DEFERRED_PASS
+// Deferred (model-gbuffer) variant writes cus_gl4's RENDERING_MODE==1 MRT
+// layout instead of a single lit colour. `fragColor` is aliased onto one of
+// the targets so the forward write statements still compile — they are dead
+// code in this variant (the DEFERRED_PASS block in main() returns first).
+out vec4 fragData[5];
+#define fragColor fragData[1]
+#else
 out vec4 fragColor;
+#endif
 
 float hash(vec2 p) {
 	return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
@@ -291,6 +300,20 @@ void main() {
 	return;
 #endif
 
+#ifdef DEFERRED_PASS
+	// Only LIVE cable fragments feed the model gbuffer (same gating the shadow
+	// pass uses): ghosts are translucent memory traces, not solid lit geometry,
+	// and enemy cables contribute only where they are in LOS — so a projectile
+	// light can never illuminate a cable the forward pass wouldn't have drawn.
+	// Falls through to the shared cylinder-normal math below; the gbuffer MRT
+	// write + return sit right after cylNormal is computed.
+	if (gridData.w < -0.5) discard;
+	if (gridData.w < 0.5) {
+		vec2 losUVd = clamp(worldPos.xz, vec2(0.0), mapSize.xy) / mapSize.xy;
+		if (texture(infoTex, losUVd).r < ENEMY_LOS_CUT) discard;
+	}
+#endif
+
 	// FAST GHOST PATH — orphaned-enemy edges (gridData.w = -1.0) skip all the
 	// cylinder-normal / lighting / bubble math below. Read LOS + coverage,
 	// decide, render translucent flat ghost or discard. Nothing else.
@@ -378,6 +401,23 @@ void main() {
 	float cylinderFactor = 0.95;
 	float up = sqrt(max(0.0, 1.0 - v * v / (2.0 * EDGE_BUFFER))) * cylinderFactor;
 	vec3 cylNormal = normalize(trueUp * up + perp3D * v / EDGE_BUFFER * (1.0 - 0.7*isBranch));
+
+#ifdef DEFERRED_PASS
+	// Feed cus_gl4's model gbuffer (normtex/difftex/...) so deferred projectile
+	// lights shade the cable's own cylinder normal rather than letting whatever
+	// terrain sits underneath bleed through. The animated bubble glow is NOT
+	// written here — it stays a forward-only overlay (DrawWorldPreUnit), so the
+	// light pass can neither dim nor re-light it. Depth is written by the draw
+	// (DepthMask on) so the light reconstructs the cable surface and occludes.
+	float capTd = clamp(capacity / 100.0, 0.0, 1.0);
+	vec3 gbDiff = mix(INNER_COLOR_LO, INNER_COLOR_HI, capTd);
+	fragData[0] = vec4(cylNormal * 0.5 + 0.5, 1.0);   // GBUFFER_NORMTEX (SNORM2NORM)
+	fragData[1] = vec4(gbDiff, 1.0);                  // GBUFFER_DIFFTEX (albedo)
+	fragData[2] = vec4(0.0, 0.0, 0.0, 1.0);           // GBUFFER_SPECTEX
+	fragData[3] = vec4(0.0, 0.0, 0.0, 1.0);           // GBUFFER_EMITTEX (no bloom yet)
+	fragData[4] = vec4(0.0, 0.0, 0.0, 1.0);           // GBUFFER_MISCTEX
+	return;
+#endif
 
 	// Own lighting (forward rendered, no engine lighting applies)
 	vec3 gridColor   = gridEfficiencyColor(gridData.x);

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
@@ -275,12 +275,18 @@ void main() {
 	}
 
 #ifdef SHADOW_PASS
-	// Shadow caster: only own/spectator cables drop shadows for now (gridData.w
-	// >= 1.0). Enemy live (0.0) and ghost (-1.0) are skipped so the shadow pass
-	// can't leak un-scouted enemy grid. The grow/wither discards above already
-	// trimmed the silhouette to the visible cable; depth is all the shadow map
-	// needs, so skip lighting/bubbles entirely.
-	if (gridData.w < 0.5) discard;
+	// Cast a shadow wherever the forward pass would render the LIVE cable, so
+	// the shadow never reveals more than the visible cable already does:
+	//   own / spectator (gridData.w >= 1.0) → always rendered    → always cast.
+	//   enemy live      (gridData.w == 0.0) → rendered only in LOS → LOS-gate.
+	//   ghost           (gridData.w <  -0.5) → memory trace, not in this VAO → never.
+	// The grow/wither discards above already trimmed the silhouette to the
+	// visible extent; depth is all the shadow map needs, so skip lighting.
+	if (gridData.w < -0.5) discard;
+	if (gridData.w < 0.5) {
+		vec2 losUV = clamp(worldPos.xz, vec2(0.0), mapSize.xy) / mapSize.xy;
+		if (texture(infoTex, losUV).r < ENEMY_LOS_CUT) discard;
+	}
 	fragColor = vec4(0.0);
 	return;
 #endif

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
@@ -7,8 +7,13 @@
 // Full GS: takes one GL_LINES primitive (cable endpoints) and emits the cable
 // ribbon. Uses GS invocations: each invocation runs main() with its own
 // max_vertices budget, so we can:
-//   invocation 0          → main wiggly ribbon (SEGMENTS+1 boundaries × 2 verts)
-//   invocations 1..N-1    → one twig each (4 verts), conditional on a hash
+//   invocation 0          → left tent slope  (ridge→ground, SEGMENTS+1 × 2 verts)
+//   invocation 1          → right tent slope (ridge→ground, SEGMENTS+1 × 2 verts)
+//   invocations 2..N-1    → one twig each (4 verts), conditional on a hash
+// Splitting the cross-section into two single-sheet slopes (one per invocation)
+// is what lets the full raised-ridge tent fit: each slope gets its own
+// GL_MAX_GEOMETRY_OUTPUT_COMPONENTS budget, so neither busts the 1024 ceiling a
+// single combined sheet (~100 verts) would.
 // This sidesteps the per-program max_vertices limit and keeps the FS body
 // unchanged.
 
@@ -103,6 +108,10 @@ const int   MAX_SEGMENTS      = 24;   // hardware budget (max_vertices=50 → 25
 const float SEG_LEN_TARGET    = 22.0; // elmos of 3D arc per segment
 const float NOISE_AMP_ABS     = 4.0;
 const float WIDTH_FACTOR      = 0.6;
+// Tent cross-section: lift the centerline ridge by this fraction of halfW
+// (the cross "radius"). The two slopes meet at the ridge; 0.0 reproduces the
+// old flat ribbon, ~0.9 gives a roughly semicircular tube.
+const float TENT_HEIGHT_FACTOR = 0.9;
 const float MIN_TRUNK_WIDTH   = 2.8;
 const float MAX_TRUNK_WIDTH   = 4.5;
 const float MAX_CAPACITY_REF  = 400.0;
@@ -243,10 +252,17 @@ float maxHeightInWindow(vec2 p, vec2 dirH, float fullStep) {
 	return yMax;
 }
 
-void emitMainRibbon(vec2 a, vec2 d, vec2 perpAB,
-                    float halfW, float widthVal, float effAmp, float seed,
-                    vec4 gridD, vec2 timeD, float cap, int numSeg, float arcDh) {
+// Emit ONE slope of the cable's raised "tent" cross-section as a single
+// triangle strip: from the outer ground edge (cableUV.y = side) up to the
+// shared ridge apex at the centerline (cableUV.y = 0). `side` = -1 → left
+// slope, +1 → right; the two are dispatched to separate GS invocations and
+// meet watertight at the ridge. Per-slope cost == the old flat ribbon (2
+// verts/boundary), so the full tent only costs one extra invocation.
+void emitTentHalf(float side, vec2 a, vec2 d, vec2 perpAB,
+                  float halfW, float widthVal, float effAmp, float seed,
+                  vec4 gridD, vec2 timeD, float cap, int numSeg, float arcDh) {
 	gOutBranch = 0.0;
+	float tentHeight = halfW * TENT_HEIGHT_FACTOR;
 	// `along` is fed into the FS as cableUV.x and drives bubble advection.
 	// It MUST be a 3D arc length, otherwise downslope cables look like the
 	// flow is racing because the same 2D Δalong covers more visible meters.
@@ -296,28 +312,27 @@ void emitMainRibbon(vec2 a, vec2 d, vec2 perpAB,
 		float yC = maxHeightInWindow(p, dirH, fullStep) + CENTERLINE_CLEAR;
 		vec3 center3D = vec3(p.x, yC, p.y);
 
-		// Geometry convention MUST match the twig emitter:
-		//   v = -1  →  vertex at center − B3*halfW  (so outward = −B3)
-		//   v = +1  →  vertex at center + B3*halfW  (so outward = +B3)
-		// The FS reconstructs perp3D ≈ B3, then cylNormal = perp3D * v at the
-		// side, which therefore matches the *actual* outward direction. Prior
-		// version had these swapped, which inverted the lit side relative to
-		// the sun on every cable (and was inconsistent with twigs).
-		vec3 leftPos  = center3D - B3 * halfW;
-		vec3 rightPos = center3D + B3 * halfW;
+		// Tent cross-section. Both ground edges along the stable chord-averaged
+		// cross basis B3; we emit only the one on `side` this invocation, but
+		// compute both so the ridge guard below is identical in both slopes.
+		// Anti-underground clamp (concave cross-slope can push an edge below the
+		// heightmap) is unchanged from the flat ribbon.
+		vec3 outerL = center3D - B3 * halfW;
+		outerL.y = max(outerL.y, heightAtWorldPos(outerL.xz) + SIDE_CLEAR);
+		vec3 outerR = center3D + B3 * halfW;
+		outerR.y = max(outerR.y, heightAtWorldPos(outerR.xz) + SIDE_CLEAR);
+		vec3 outerPos = (side < 0.0) ? outerL : outerR;
 
-		// Anti-underground clamp: on terrain that curves up faster than linear
-		// (concave cross-slope), the slope-tangent-plane offset can put L or R
-		// below the actual heightmap at their XZ. Raise to local terrain +
-		// SIDE_CLEAR whenever that happens. On linear terrain the L/R points
-		// already sit at clearance above ground so this is a no-op there.
-		leftPos.y  = max(leftPos.y,  heightAtWorldPos(leftPos.xz)  + SIDE_CLEAR);
-		rightPos.y = max(rightPos.y, heightAtWorldPos(rightPos.xz) + SIDE_CLEAR);
-
-		// Also raise center3D if a clamp lifted the sides above it (preserves the
-		// cylinder appearance — center should never sit below a side vertex).
-		float midY = max(center3D.y, 0.5 * (leftPos.y + rightPos.y));
-		center3D.y = midY;
+		// Ridge apex: lift the centerline along the LOCAL terrain normal so on a
+		// slope/cliff the tube banks into the surface (the terrain supplies a
+		// cross frame that stays ~perpendicular to the cable tangent). The lift
+		// is bounded by tentHeight, so the per-vertex normal variation that
+		// corkscrewed the old per-vertex basis is here capped to a small roll.
+		vec3 Nloc = terrainNormal(p);
+		vec3 apexPos = center3D + Nloc * tentHeight;
+		// Guard uses BOTH outer edges (not the side-specific one) so the apex is
+		// identical in the left and right invocations → watertight ridge.
+		apexPos.y = max(apexPos.y, max(outerL.y, outerR.y) + 0.1);
 
 		// Per-vertex tangent: forward-diff at vertex 0 (chord direction), and
 		// back-diff for subsequent vertices (centerline direction from the
@@ -337,12 +352,12 @@ void emitMainRibbon(vec2 a, vec2 d, vec2 perpAB,
 
 		if (i > 0) along += distance(prev3D, center3D);
 		prev3D = center3D;
-		leftPos.y += hash1(seed)*0.1; // z-fighting
-		leftPos.y = max(leftPos.y, rightPos.y);
-		rightPos.y = leftPos.y;
-
-		emitVtx(leftPos,  vtxTangent, vec2(along, -1.0), widthVal, gridD, timeD, cap);
-		emitVtx(rightPos, vtxTangent, vec2(along,  1.0), widthVal, gridD, timeD, cap);
+		// Strip order: apex (v=0, ridge — FS points the cylinder normal up) then
+		// outer (v=side, ground — FS leans the normal fully sideways). The faked
+		// cylinder normal now matches the real raised ridge instead of fighting a
+		// flat strip, and both slopes share the apex line so they form one tube.
+		emitVtx(apexPos,  vtxTangent, vec2(along, 0.0),  widthVal, gridD, timeD, cap);
+		emitVtx(outerPos, vtxTangent, vec2(along, side), widthVal, gridD, timeD, cap);
 	}
 	EndPrimitive();
 }
@@ -457,14 +472,14 @@ void main() {
 	vec2  timeD = dataIn[0].vsCableData.yz;
 	vec4  gridD = dataIn[0].vsGridData;
 
-	// Ghost edges (gridData.w = -1.0) emit only the main ribbon (no twigs),
-	// using the SAME wiggly path as live so the live→ghost transition has
-	// no visual snap. Ghost FS path is fast (no lighting/bubble math), and
-	// the GS still skips 4 of 5 invocations (twigs). Coverage updates use
-	// the live atomicAnd path with the wiggly samples → consistent with
-	// what the player visually sees.
+	// Ghost edges (gridData.w = -1.0) emit the same two tent slopes as live
+	// (no twigs), using the SAME wiggly path so the live→ghost transition has
+	// no visual snap. Ghost FS path is fast (no lighting/bubble math), and the
+	// GS still skips the 3 twig invocations. Coverage updates use the live
+	// atomicAnd path with the wiggly samples → consistent with what the player
+	// visually sees.
 	bool isGhostEdge = gridD.w < -0.5;
-	if (isGhostEdge && gl_InvocationID > 0) return;
+	if (isGhostEdge && gl_InvocationID > 1) return;
 
 	float widthVal = MIN_TRUNK_WIDTH +
 		clamp(cap / MAX_CAPACITY_REF, 0.0, 1.0) * (MAX_TRUNK_WIDTH - MIN_TRUNK_WIDTH);
@@ -566,15 +581,20 @@ void main() {
 				if (clrMask != 0u) atomicAnd(cableCoverage[slot].x, ~clrMask);
 			}
 		}
-		emitMainRibbon(a, d, perpAB, halfW, widthVal, effAmp, seed, gridD, timeD, cap, numSeg, arcDh);
+		emitTentHalf(-1.0, a, d, perpAB, halfW, widthVal, effAmp, seed, gridD, timeD, cap, numSeg, arcDh);
+	} else if (gl_InvocationID == 1) {
+		// Right slope of the tent — its own invocation, hence its own
+		// GL_MAX_GEOMETRY_OUTPUT_COMPONENTS budget. This is what lets the full
+		// raised-ridge tent fit: one combined sheet (~100 verts) would bust the
+		// 1024 ceiling, two single-sheet slopes (~50 each) don't.
+		emitTentHalf(1.0, a, d, perpAB, halfW, widthVal, effAmp, seed, gridD, timeD, cap, numSeg, arcDh);
 	} else {
 		if (isGhostEdge) return;   // ghosts skip twig invocations entirely
-		// Twig density scales with 3D arc length: ~one twig per 110 elmos,
-		// capped at 4. Short cables get 0-1 twigs, long ones get the full set.
-		// Surviving twigs are then respread across [0.15, 0.85] so spacing
-		// remains roughly even regardless of twig count.
-		int idx = gl_InvocationID - 1;          // 0..3
-		int expectedTwigs = clamp(int(len3D / 85.0 + 0.5), 0, 4);
+		// Twig density scales with 3D arc length: ~one twig per 85 elmos. Twigs
+		// now live on invocations 2..4 (3 slots; invocation 1 was reassigned to
+		// the second tent slope), so cap to 3 and reindex from gl_InvocationID-2.
+		int idx = gl_InvocationID - 2;          // 0..2
+		int expectedTwigs = clamp(int(len3D / 85.0 + 0.5), 0, 3);
 		if (idx >= expectedTwigs) return;
 		float tCenterRaw = 0.15 + (float(idx) + 0.5) * (0.7 / float(expectedTwigs));
 		// Snap to a main-ribbon segment vertex. The cable is rendered as

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
@@ -565,7 +565,12 @@ void main() {
 		// LOS scan entirely. Ghost edges with all bits clear have nothing
 		// left to clear → skip too. Massive savings on long-running matches
 		// where most live cables hit saturation quickly.
-#ifndef SHADOW_PASS
+		//
+		// Excluded from BOTH the shadow and deferred passes: the forward pass
+		// owns coverage. The deferred draw binds nothing at binding=6, so a
+		// stray atomicOr/atomicAnd there would hit an unbound buffer; and a
+		// second per-frame update would risk double-clearing ghost bits.
+#if !defined(SHADOW_PASS) && !defined(DEFERRED_PASS)
 		int slot = dataIn[0].vsSlot;
 		bool isGhost = gridD.w < -0.5;
 		// Hard gate on the user-facing ghosts toggle — skip ALL coverage

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
@@ -155,7 +155,18 @@ void emitVtx(vec3 wp, vec3 tangent3D, vec2 cuv,
 	spawnAlongMain = gOutSpawnAlong;
 	gsSlot = gOutSlot;
 	// (vsTangent varying disabled — exceeded GS output budget on this hardware)
+#ifdef SHADOW_PASS
+	// Recoil shadow-map convention (mirrors cus_gl4.vert.glsl's shadow pass):
+	// it is NOT shadowViewProj * world. shadowView maps to a recentred space
+	// that needs +0.5 on XY before shadowProj; the precombined shadowViewProj
+	// omits that offset, which shoved the cable out of the shadow frustum.
+	vec4 lightVertexPos = shadowView * vec4(wp, 1.0);
+	lightVertexPos.xy += vec2(0.5);
+	lightVertexPos.z += 5e-5;            // small constant depth bias (acne)
+	gl_Position = shadowProj * lightVertexPos;
+#else
 	gl_Position = cameraViewProj * vec4(wp, 1.0);
+#endif
 	EmitVertex();
 }
 
@@ -554,6 +565,7 @@ void main() {
 		// LOS scan entirely. Ghost edges with all bits clear have nothing
 		// left to clear → skip too. Massive savings on long-running matches
 		// where most live cables hit saturation quickly.
+#ifndef SHADOW_PASS
 		int slot = dataIn[0].vsSlot;
 		bool isGhost = gridD.w < -0.5;
 		// Hard gate on the user-facing ghosts toggle — skip ALL coverage
@@ -581,6 +593,7 @@ void main() {
 				if (clrMask != 0u) atomicAnd(cableCoverage[slot].x, ~clrMask);
 			}
 		}
+#endif
 		emitTentHalf(-1.0, a, d, perpAB, halfW, widthVal, effAmp, seed, gridD, timeD, cap, numSeg, arcDh);
 	} else if (gl_InvocationID == 1) {
 		// Right slope of the tent — its own invocation, hence its own

--- a/LuaRules/Gadgets/gfx_overdrive_cables.lua
+++ b/LuaRules/Gadgets/gfx_overdrive_cables.lua
@@ -2860,7 +2860,9 @@ function gadget:DrawShadowUnitsLua()
 	local frameOff = Spring.GetFrameTimeOffset and Spring.GetFrameTimeOffset() or 0
 	cableShadowShader:SetUniform("gameTime", Spring.GetGameSeconds() + frameOff / GAME_SPEED)
 
-	-- GS samples the heightmap to place vertices; same binding as the forward pass.
+	-- $info:los gates enemy cables to LOS so their shadow matches their in-LOS
+	-- visibility; the GS samples the heightmap to place vertices.
+	gl.Texture(0, "$info:los")
 	gl.Texture(1, "$heightmap")
 	-- Thin tent → let both faces cast (mirror the forward pass's Culling(false)).
 	gl.Culling(false)
@@ -2870,6 +2872,7 @@ function gadget:DrawShadowUnitsLua()
 	gl.DepthMask(true)
 	cableVAO:DrawArrays(GL.LINES, numCableVerts)
 
+	gl.Texture(0, false)
 	gl.Texture(1, false)
 	gl.Culling(GL.BACK)   -- restore engine default for subsequent shadow draws
 	cableShadowShader:Deactivate()
@@ -2927,7 +2930,7 @@ function gadget:Initialize()
 		vertex   = vsSrc,
 		geometry = injectShadowDefine(gsSrc),
 		fragment = injectShadowDefine(fsSrc),
-		uniformInt   = { heightmapTex = 1 },
+		uniformInt   = { heightmapTex = 1, infoTex = 0 },
 		uniformFloat = { gameTime = 0 },
 	}, "Cable Shadow Shader")
 	if not cableShadowShader:Initialize() then

--- a/LuaRules/Gadgets/gfx_overdrive_cables.lua
+++ b/LuaRules/Gadgets/gfx_overdrive_cables.lua
@@ -2789,6 +2789,11 @@ function gadget:DrawWorldPreUnit()
 	--cableShader:SetUniform("bakeTime", bubbleBakeTime)
 	cableShader:SetUniform("enableFlow", cableFlowMode and 1.0 or 0.0)
 	cableShader:SetUniform("ghostsEnabled", cableGhosts and 1.0 or 0.0)
+	-- Shadow reception: only sample the shadow map when the engine actually has
+	-- one this frame, so the FS never reads a stale/absent $shadow (it returns
+	-- "fully lit" when disabled). The texture is bound below at unit 3.
+	local haveShadows = (Spring.HaveShadows and Spring.HaveShadows()) or false
+	cableShader:SetUniform("shadowsEnabled", haveShadows and 1.0 or 0.0)
 
 	-- Bind the per-edge coverage SSBO at binding=6. Both the live and ghost
 	-- VBO draws use the same shader program so a single binding covers them.
@@ -2806,6 +2811,7 @@ function gadget:DrawWorldPreUnit()
 	gl.Texture(0, "$info:los")
 	gl.Texture(1, "$heightmap")
 	gl.Texture(2, CABLE_TEXTURE)
+	if haveShadows then gl.Texture(3, "$shadow") end
 	gl.Culling(false)
 	gl.DepthTest(GL.LEQUAL)
 	gl.DepthMask(true)
@@ -2837,6 +2843,7 @@ function gadget:DrawWorldPreUnit()
 	gl.Texture(0, false)
 	gl.Texture(1, false)
 	gl.Texture(2, false)
+	if haveShadows then gl.Texture(3, false) end
 	gl.DepthTest(false)
 	gl.DepthMask(false)
 	gl.Culling(GL.BACK)
@@ -2952,12 +2959,14 @@ function gadget:Initialize()
 			infoTex = 0,
 			heightmapTex = 1,
 			cableTex = 2,
+			shadowTex = 3,
 		},
 		uniformFloat = {
 			gameTime = 0,
-			--bakeTime = 0, 
+			--bakeTime = 0,
 			enableFlow = cableFlowMode and 1.0 or 0.0,
 			ghostsEnabled = cableGhosts and 1.0 or 0.0,
+			shadowsEnabled = 0,
 		},
 	}, "Cable Forward Shader")
 

--- a/LuaRules/Gadgets/gfx_overdrive_cables.lua
+++ b/LuaRules/Gadgets/gfx_overdrive_cables.lua
@@ -2206,6 +2206,7 @@ local geomCache = {
 }
 
 local cableShader       -- forward shader for cable rendering
+local cableShadowShader -- depth-only SHADOW_PASS variant, drawn in the shadow map pass
 local cableVAO          -- live cable geometry
 local numCableVerts = 0
 -- (drawPerf collapsed into cablePerf at the top of the file; flowMode
@@ -2841,6 +2842,40 @@ function gadget:DrawWorldPreUnit()
 end
 
 -------------------------------------------------------------------------------------
+-- Shadow casting. DrawShadowUnitsLua fires inside the engine's unit shadow-map
+-- pass (same callin cus_gl4 uses to shadow units), once per gadget. We re-draw
+-- the live cable VAO through the SHADOW_PASS shader variant: identical tent
+-- geometry, but positions go through shadowViewProj and the FS writes depth
+-- only. The engine has the shadow FBO + depth state bound around this call, so
+-- we touch as little GL state as possible. Ghosts (separate VAO) are not drawn,
+-- so they don't cast shadows.
+-------------------------------------------------------------------------------------
+function gadget:DrawShadowUnitsLua()
+	if not cableEnabled then return end
+	if not cableShadowShader or not cableVAO or numCableVerts == 0 then return end
+
+	cableShadowShader:Activate()
+	-- Match the forward pass's smooth game-time so a growing/withering cable
+	-- casts a shadow trimmed to exactly the visible extent (FS reads gameTime).
+	local frameOff = Spring.GetFrameTimeOffset and Spring.GetFrameTimeOffset() or 0
+	cableShadowShader:SetUniform("gameTime", Spring.GetGameSeconds() + frameOff / GAME_SPEED)
+
+	-- GS samples the heightmap to place vertices; same binding as the forward pass.
+	gl.Texture(1, "$heightmap")
+	-- Thin tent → let both faces cast (mirror the forward pass's Culling(false)).
+	gl.Culling(false)
+	-- Force depth write — the whole point of the shadow pass is populating the
+	-- shadow depth map; don't assume the engine left DepthMask on for us.
+	gl.DepthTest(true)
+	gl.DepthMask(true)
+	cableVAO:DrawArrays(GL.LINES, numCableVerts)
+
+	gl.Texture(1, false)
+	gl.Culling(GL.BACK)   -- restore engine default for subsequent shadow draws
+	cableShadowShader:Deactivate()
+end
+
+-------------------------------------------------------------------------------------
 -- Lifecycle
 -------------------------------------------------------------------------------------
 
@@ -2877,6 +2912,27 @@ function gadget:Initialize()
 		Spring.Echo("[CableTree] Shader compile failed")
 		gadgetHandler:RemoveGadget()
 		return
+	end
+
+	-- Shadow-caster variant: the same VS/GS/FS compiled with SHADOW_PASS
+	-- defined. The GS swaps cameraViewProj -> shadowViewProj and skips the
+	-- coverage SSBO update; the FS trims to own/spectator cables and writes
+	-- depth only (no lighting). Drawn from gadget:DrawShadowUnitsLua so the
+	-- cables drop shadows in the same shadow-map pass as units. If it fails to
+	-- compile we just skip shadow casting (the forward pass is unaffected).
+	local function injectShadowDefine(src)
+		return (src:gsub("(#version%s+%d+)", "%1\n#define SHADOW_PASS 1", 1))
+	end
+	cableShadowShader = LuaShader({
+		vertex   = vsSrc,
+		geometry = injectShadowDefine(gsSrc),
+		fragment = injectShadowDefine(fsSrc),
+		uniformInt   = { heightmapTex = 1 },
+		uniformFloat = { gameTime = 0 },
+	}, "Cable Shadow Shader")
+	if not cableShadowShader:Initialize() then
+		Spring.Echo("[CableTree] Shadow shader compile failed; shadow casting disabled")
+		cableShadowShader = nil
 	end
 
 	-- Per-edge coverage SSBO. Spring's VBO API requires vec4-aligned attribs,
@@ -2956,6 +3012,7 @@ end
 
 function gadget:Shutdown()
 	if cableShader then cableShader:Finalize() end
+	if cableShadowShader then cableShadowShader:Finalize() end
 	cableVAO = nil
 end
 

--- a/LuaRules/Gadgets/gfx_overdrive_cables.lua
+++ b/LuaRules/Gadgets/gfx_overdrive_cables.lua
@@ -2205,8 +2205,9 @@ local geomCache = {
 	provs = nil,          -- [provObj] (distinct, one per emitNoisyPath call)
 }
 
-local cableShader       -- forward shader for cable rendering
-local cableShadowShader -- depth-only SHADOW_PASS variant, drawn in the shadow map pass
+local cableShader         -- forward shader for cable rendering
+local cableShadowShader   -- depth-only SHADOW_PASS variant, drawn in the shadow map pass
+local cableDeferredShader -- model-gbuffer DEFERRED_PASS variant, drawn in DrawOpaqueUnitsLua
 local cableVAO          -- live cable geometry
 local numCableVerts = 0
 -- (drawPerf collapsed into cablePerf at the top of the file; flowMode
@@ -2879,6 +2880,55 @@ function gadget:DrawShadowUnitsLua()
 end
 
 -------------------------------------------------------------------------------------
+-- Deferred lighting. DrawOpaqueUnitsLua fires once per opaque-unit pass; the
+-- engine passes deferredPass=true on the invocation that fills the *model
+-- gbuffer* (the same MRT cus_gl4 writes for units). We re-draw the live cable
+-- VAO through the DEFERRED_PASS variant: identical tent geometry via
+-- cameraViewProj, but the FS writes normal/diffuse into the gbuffer instead of
+-- a lit colour. This makes deferred projectile lights shade the cable's own
+-- cylinder normal rather than bleeding the terrain underneath through it.
+--
+-- The forward visible cable still comes from DrawWorldPreUnit (FS unchanged,
+-- bubbles intact) — the gbuffer is purely auxiliary geometry for the light
+-- pass, exactly as it is for units (which also draw forward AND deferred). So
+-- this should NOT double-light the cable; if it ever looks double-bright, the
+-- assumption that the gbuffer isn't separately resolved would be wrong.
+-------------------------------------------------------------------------------------
+function gadget:DrawOpaqueUnitsLua(deferredPass, drawReflection, drawRefraction)
+	-- Only the genuine deferred gbuffer fill. The forward-opaque invocation is
+	-- already covered by DrawWorldPreUnit; reflection/refraction don't need
+	-- cables in the gbuffer.
+	if not deferredPass or drawReflection or drawRefraction then return end
+	if not cableEnabled then return end
+	if not cableDeferredShader or not cableVAO or numCableVerts == 0 then return end
+
+	cableDeferredShader:Activate()
+	-- Match the forward pass's smooth game-time so the gbuffer silhouette tracks
+	-- the growing/withering visible extent (FS shares the grow/wither discards).
+	local frameOff = Spring.GetFrameTimeOffset and Spring.GetFrameTimeOffset() or 0
+	cableDeferredShader:SetUniform("gameTime", Spring.GetGameSeconds() + frameOff / GAME_SPEED)
+
+	-- $info:los gates enemy cables to LOS (matching their forward visibility);
+	-- $heightmap places the GS vertices.
+	gl.Texture(0, "$info:los")
+	gl.Texture(1, "$heightmap")
+	-- Thin tent → both faces contribute. Opaque replace into the MRT (no blend),
+	-- depth-test against units already in the gbuffer, and write our own depth so
+	-- the light pass reconstructs the cable surface and occludes correctly.
+	gl.Culling(false)
+	gl.Blending(false)
+	gl.DepthTest(GL.LEQUAL)
+	gl.DepthMask(true)
+	cableVAO:DrawArrays(GL.LINES, numCableVerts)
+
+	gl.Texture(0, false)
+	gl.Texture(1, false)
+	gl.Blending(true)
+	gl.Culling(GL.BACK)
+	cableDeferredShader:Deactivate()
+end
+
+-------------------------------------------------------------------------------------
 -- Lifecycle
 -------------------------------------------------------------------------------------
 
@@ -2923,19 +2973,38 @@ function gadget:Initialize()
 	-- depth only (no lighting). Drawn from gadget:DrawShadowUnitsLua so the
 	-- cables drop shadows in the same shadow-map pass as units. If it fails to
 	-- compile we just skip shadow casting (the forward pass is unaffected).
-	local function injectShadowDefine(src)
-		return (src:gsub("(#version%s+%d+)", "%1\n#define SHADOW_PASS 1", 1))
+	local function injectDefine(src, define)
+		return (src:gsub("(#version%s+%d+)", "%1\n#define " .. define .. " 1", 1))
 	end
 	cableShadowShader = LuaShader({
 		vertex   = vsSrc,
-		geometry = injectShadowDefine(gsSrc),
-		fragment = injectShadowDefine(fsSrc),
+		geometry = injectDefine(gsSrc, "SHADOW_PASS"),
+		fragment = injectDefine(fsSrc, "SHADOW_PASS"),
 		uniformInt   = { heightmapTex = 1, infoTex = 0 },
 		uniformFloat = { gameTime = 0 },
 	}, "Cable Shadow Shader")
 	if not cableShadowShader:Initialize() then
 		Spring.Echo("[CableTree] Shadow shader compile failed; shadow casting disabled")
 		cableShadowShader = nil
+	end
+
+	-- Deferred-lighting variant: same VS/GS/FS compiled with DEFERRED_PASS. The
+	-- GS uses the normal cameraViewProj path (not shadow) and skips the coverage
+	-- SSBO update (the forward pass owns it); the FS writes cus_gl4's model
+	-- gbuffer MRT (normal/diffuse) instead of a lit colour, so deferred
+	-- projectile lights illuminate the cable's own cylinder surface instead of
+	-- the terrain underneath. Drawn from gadget:DrawOpaqueUnitsLua's deferred
+	-- pass. Compile failure just disables the integration (forward unaffected).
+	cableDeferredShader = LuaShader({
+		vertex   = vsSrc,
+		geometry = injectDefine(gsSrc, "DEFERRED_PASS"),
+		fragment = injectDefine(fsSrc, "DEFERRED_PASS"),
+		uniformInt   = { heightmapTex = 1, infoTex = 0 },
+		uniformFloat = { gameTime = 0 },
+	}, "Cable Deferred Shader")
+	if not cableDeferredShader:Initialize() then
+		Spring.Echo("[CableTree] Deferred shader compile failed; deferred lighting integration disabled")
+		cableDeferredShader = nil
 	end
 
 	-- Per-edge coverage SSBO. Spring's VBO API requires vec4-aligned attribs,
@@ -3016,6 +3085,7 @@ end
 function gadget:Shutdown()
 	if cableShader then cableShader:Finalize() end
 	if cableShadowShader then cableShadowShader:Finalize() end
+	if cableDeferredShader then cableDeferredShader:Finalize() end
 	cableVAO = nil
 end
 


### PR DESCRIPTION
## What

Gives the overdrive grid cables a real presence in the 3D world, in three layered changes:

1. **Raised "tent" cross-section** — the flat, ground-hugging ribbon becomes a raised tube.
2. **Shadow casting** — the cables drop shadows in the engine's shadow-map pass.
3. **Deferred lighting** — the cables participate in deferred lighting (projectile lights) and the outline pass, via the model gbuffer.

---

## 1. Tent cross-section

### Why
Once the cables read as 3D tubes rather than painted stripes, the flat ribbon's lack of volume became obvious — especially where a cable crosses a cliff at an oblique angle. There the cross-sections only translated vertically (no rotation), so the cable looked like a "serpentine ladder" poking out of the terrain with no thickness.

### How
- `emitMainRibbon` → `emitTentHalf(side, …)`: emits one slope as a single triangle strip, ridge (`cableUV.y = 0`) → outer ground edge (`cableUV.y = ±1`).
- The two slopes are dispatched to **separate GS invocations** (0 = left, 1 = right). This is what makes the full raised cross-section fit: each slope keeps its own `GL_MAX_GEOMETRY_OUTPUT_COMPONENTS` budget (~50 verts), whereas one combined sheet (~100 verts) would bust the 1024 min-spec ceiling.
- The ridge is lifted along the **local terrain normal**, so on slopes/cliffs the tube banks into the surface (the terrain supplies a cross frame that stays ~perpendicular to the cable tangent) instead of displacing flat.
- **No fragment-shader change.** `cableUV.y = 0` was already lit as the cylinder top and `±1` as the sides, so the real raised geometry now agrees with the previously-faked cylinder normal instead of fighting a flat strip.
- New constant `TENT_HEIGHT_FACTOR` controls ridge lift (`0.0` reproduces the old flat ribbon).
- Twigs moved to invocations 2–4 (capped at 3; invocation 1 was reassigned to the second slope).

---

## 2. Shadows (cast + receive)

Casting and receiving are unrelated mechanisms; both are wired up.

**Casting** re-draws the live cable VAO through a `SHADOW_PASS` shader variant from `gadget:DrawShadowUnitsLua` — the same callin `cus_gl4` uses to shadow units, so cables drop into the same shadow map.

- Identical tent geometry, but vertices go through the Recoil shadow-map transform (`shadowView * world; xy += 0.5; shadowProj *` — mirroring `cus_gl4.vert.glsl`; using the precombined `shadowViewProj` omits the `+0.5` recenter and pushes geometry out of the shadow frustum).
- The FS writes depth only and reuses the forward grow/wither discards, so a growing/withering cable casts a shadow trimmed to exactly its visible extent.
- **No information leak:** own/spectator cables always cast; enemy cables cast only where they're in LOS (the same `$info:los` gate the visible cable uses); ghosts never cast.

**Receiving** samples the shadow map in the forward FS — the cable's sun term was a bare `dot(cylNormal, sunDir)` with an ambient floor and never tested the map, so it stayed at full sun under any occluder.

- Uses the engine receive convention (`shadowView * world; xy += 0.5; textureProj` against a `sampler2DShadow`, as in `map_lava.lua`).
- The coefficient darkens **only the sun term** — a shadowed cable falls to `DIFFUSE_FLOOR` (ambient), not black — and the specular. Bubbles are composited afterwards and stay emissive, matching the existing LOS-dim design (plasma reads as lights in the dark).
- Gated on `Spring.HaveShadows()`: with shadows off, `getShadowCoeff` returns `1.0` without sampling and `$shadow` isn't bound.

---

## 3. Deferred lighting

Draws the live cable into the **model gbuffer** (`cus_gl4`'s `RENDERING_MODE==1` MRT) from a `DEFERRED_PASS` variant, run on `gadget:DrawOpaqueUnitsLua`'s deferred invocation.

- The FS writes the cable's cylinder normal + a capacity-tinted diffuse (plus depth, via the draw) into `normtex`/`difftex` instead of a lit colour. Deferred projectile lights then shade the cable's **own** surface rather than letting the terrain underneath bleed through it (which also explains a long-standing "terrain normals affect the cables" artefact — the light pass was reading the terrain gbuffer at the cable's pixels).
- **Bonus:** the outline pass reads the same gbuffer, so it stops cutting through the cable geometry.
- The forward `DrawWorldPreUnit` draw is **unchanged** — the visible cable, its lighting, and the animated bubble/pulse glow all stay forward-only, so the light pass can neither dim nor re-light the glow. The gbuffer is purely auxiliary geometry for screen-space effects, exactly as it is for units (which also draw both forward *and* deferred) — so there's no double-lighting.
- The GS reuses the normal `cameraViewProj` path and skips the coverage-SSBO update in the deferred pass (the forward pass owns coverage; the deferred draw binds nothing at binding 6, and a second per-frame update could double-clear ghost bits). Ghosts and enemy-out-of-LOS cables are gated out of the gbuffer with the same rule the shadow pass uses.

---

## Testing

`/luarules reload`, then:
- **Tent:** inspect cables crossing terrain steps obliquely; set `TENT_HEIGHT_FACTOR = 0.0` to A/B against the old flat ribbon.
- **Shadows:** confirm cables cast into the shadow map and the shadow tracks growing/withering; scroll to check there's no shadow offset.
- **Deferred:** pass a projectile light (Newton stream, firing unit, explosion) over a cable in shadow/at dusk — the light should rake the tube's near face with the rounded cylinder falloff, not a flat terrain-shaped wash.

## Known follow-ups (deferred)

- Left/right edge displacement doesn't yet respect the 2D downhill direction of the terrain (the `B3` sign is chosen only to match `perpAB`).
- Sheer cliffs are still under-segmented (boundaries are uniform in 2D `t`), so very vertical faces get few rings to drape over.
- The bubble/pulse glow is not yet routed to the gbuffer emission target, so it doesn't feed bloom — a separate, optional nicety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
