### PR TITLE
Overdrive cables: wiggle noise, twig rooting, and cliff-lip overshoot fixes

### DIFF
--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.frag.glsl
@@ -6,7 +6,6 @@
 uniform sampler2D infoTex;
 uniform sampler2D cableTex;
 uniform float gameTime;
-uniform float bakeTime;
 uniform float enableFlow;     // 1.0 = full bubble pass; 0.0 = static cables (no animation)
 uniform float ghostsEnabled;  // 1.0 = ghost branch active; 0.0 = enemy OOL discards immediately
 uniform sampler2DShadow shadowTex;  // engine shadow map ($shadow); sampled for shadow reception
@@ -26,7 +25,7 @@ in DataGS {
 	float width;
 	vec2 cableUV;
 	vec2 timeData;
-	vec3 gridData;          // was vec4; .z was unused, dropped to fund cableTangent (see GS BUDGET NOTE). Old .w (isOwnAlly / ghost flag) is now .z.
+	vec3 gridData;          // (gridEfficiency, flow, isOwnAlly / ghost flag); see GS BUDGET NOTE
 	vec3 cableTangent;      // smooth per-vertex cable along-direction; interpolated → drives the lit frame below
 	float spawnAlongMain;   // overloaded: main ribbon → lenPerSeg; twig → twig-along
 	flat int gsSlot;
@@ -39,9 +38,10 @@ in DataGS {
 // Pure aesthetic constants; nothing here changes geometry or topology.
 // =====================================================================
 
-// Grow/wither animation rates (elmos/s) — must match unsynced GROWTH_RATE/
-// WITHER_RATE so the CPU-side bubble phase anchor and the FS-side growth
-// front sweep at the same speed.
+// Grow/wither animation rates (elmos/s). The CPU only supplies appear/wither
+// timestamps (timeData); the fronts sweep entirely FS-side. The unsynced
+// WITHER_HOLD_FRAMES must stay generous relative to worst-case cable length /
+// WITHER_RATE so geometry outlives the animation.
 const float GROWTH_RATE        = 250.0;
 const float WITHER_RATE        = 400.0;
 
@@ -100,8 +100,9 @@ const float SIZE_4 = 1.32;
 // dimFactor instead but always render.
 const float ENEMY_LOS_CUT      = 0.1;
 
-// Bubble flow mapping. Must mirror Lua flowToSpeed() exactly for CPU-baked
-// phase anchoring + FS extrapolation to remain continuous across baking.
+// Bubble flow mapping. Advection is FS-only: phase derives purely from
+// gameTime via the crossfaded speed ladder in main() — nothing is
+// CPU-integrated, so there is no bake to stay continuous across.
 const float MAX_SPEED          = 130.0;
 const float MAX_DENSITY_FLOW   = 100.0;
 const float MIN_TRUNK_W        = 3.0;
@@ -176,10 +177,9 @@ float hash1(float n) {
 // Shading: faint inner glow + Fresnel rim + small offset highlight, all with
 // smoothstep edges to avoid pixelation at oblique camera angles. Returns
 // (body, specular).
-// `phase` is the integrated travel distance baked + extrapolated by the
-// caller (CPU integrates ∫ speed dt, shader extrapolates the last segment
-// with the current speed). Subtracting from `along` advects bubbles smoothly
-// across speed changes.
+// `phase` is the travel distance the caller derives from gameTime (via the
+// crossfaded speed ladder in main(), so subtle flow changes can't teleport
+// bubbles). Subtracting it from `along` advects the bubbles.
 //
 // Returns vec3: (body, specular, halo). Caller composites all three with
 // possibly different colour weights for richer look.
@@ -299,7 +299,6 @@ float getShadowCoeff(vec3 wp, float NdotL) {
 void main() {
 	float v = cableUV.y * EDGE_BUFFER;
 	float t = abs(v);
-	if (t > 0.90) discard;
 
 	// Visual grow/wither: cableUV.x is distance along cable in elmos.
 	// Growth front advances from u=0 forward.
@@ -566,14 +565,12 @@ void main() {
 	//   - Two layered streams of bubbles (big + small) with random per-bubble
 	//     size + cross-axis offset, so the cable looks like a real bubbly
 	//     slurry instead of a metronome of identical dots.
-	// Bubble speed/density mapping. MUST match the CPU's flowToSpeed for the
-	// integrated phase anchoring to stay consistent.
 	//
 	// Cable thickness conveys capacity (orthogonal);
 	float flow = gridData.y;
 	// Linear thickness divisor: a cable 4× thicker than min gets its flow
 	// signal scaled to 1/4 before the sqrt → ~0.5× visual liveliness. Slight
-	// negative bias for thick cables, matching the CPU's flowToSpeed.
+	// negative bias for thick cables ("wide pipe, same flow, calmer look").
 	float thicknessRatio = max(1.0, width / MIN_TRUNK_W);
 	float effFlow = max(flow, 0.0) / thicknessRatio;
 	float flowFactor = min(1.0, sqrt(effFlow / MAX_DENSITY_FLOW));

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
@@ -115,6 +115,28 @@ float hash1(float n) {
 	return fract(sin(n * 12.9898) * 43758.5453);
 }
 
+// Band-limited 2D value noise in [-1,1] over WORLD space. Replaces the raw
+// per-vertex gsHash() wiggle, which was white noise: at high vertex density
+// (cliff oversampling raises numSeg, see curvSeg in main) adjacent vertices
+// got fully-independent ±effAmp kicks, producing a tight full-amplitude
+// zigzag. Quantizing to NOISE_CELL-sized cells and smoothstep-interpolating
+// the four corner hashes gives a fixed feature wavelength: denser sampling
+// converges on the same smooth curve instead of aliasing into noise. Keyed on
+// world position (not arc-length t), so it stays direction-independent — a
+// parent/child MST flip doesn't teleport the pattern.
+const float NOISE_CELL = 16.0;   // elmos per noise cell (feature wavelength)
+float gsValueNoise2(vec2 w, float seed) {
+	vec2 q  = w * (1.0 / NOISE_CELL);
+	vec2 i0 = floor(q);
+	vec2 f  = q - i0;
+	vec2 u  = f * f * (3.0 - 2.0 * f);   // smoothstep weights
+	float n00 = gsHash(i0.x,       i0.y,       seed);
+	float n10 = gsHash(i0.x + 1.0, i0.y,       seed);
+	float n01 = gsHash(i0.x,       i0.y + 1.0, seed);
+	float n11 = gsHash(i0.x + 1.0, i0.y + 1.0, seed);
+	return mix(mix(n00, n10, u.x), mix(n01, n11, u.x), u.y);
+}
+
 const int   MAX_SEGMENTS      = 22;   // hardware budget (max_vertices=46 → 23 boundaries × 2; lowered from 24 to make room for the cableTangent varying). Cable lengths are bounded by pylon range (longest ≈ energypylon's 500 elmo); at SEG_LEN_TARGET this wants ~23, so the very longest backbone cables lose ~1-2 segments — far outweighed by the tangent killing the per-segment faceting.
 const float SEG_LEN_TARGET    = 22.0; // elmos of 3D arc per segment
 const float NOISE_AMP_ABS     = 4.0;
@@ -267,7 +289,7 @@ vec2 arcBiasedCenter(vec2 a, vec2 d, vec2 perpAB, float t, float lenAB, float dh
 vec2 wigglyCablePoint(vec2 a, vec2 d, vec2 perpAB, float t, float lenAB,
                       float arcDh, float effAmp, float seed) {
 	vec2 base = arcBiasedCenter(a, d, perpAB, t, lenAB, arcDh);
-	float n = gsHash(base.x * 0.1, base.y * 0.1, seed) * effAmp * gsNoiseScale(t);
+	float n = gsValueNoise2(base, seed) * effAmp * gsNoiseScale(t);
 	vec2 perpCanon = perpAB;
 	if (perpCanon.x < 0.0 || (perpCanon.x == 0.0 && perpCanon.y < 0.0)) {
 		perpCanon = -perpCanon;

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
@@ -9,7 +9,7 @@
 // max_vertices budget, so we can:
 //   invocation 0          → left tent slope  (ridge→ground, SEGMENTS+1 × 2 verts)
 //   invocation 1          → right tent slope (ridge→ground, SEGMENTS+1 × 2 verts)
-//   invocations 2..N-1    → one twig each (4 verts), conditional on a hash
+//   invocations 2..N-1    → one twig each (3 verts), conditional on a hash
 // Splitting the cross-section into two single-sheet slopes (one per invocation)
 // is what lets the full raised-ridge tent fit: each slope gets its own
 // GL_MAX_GEOMETRY_OUTPUT_COMPONENTS budget, so neither busts the 1024 ceiling a
@@ -21,7 +21,7 @@ layout (lines, invocations = 5) in;
 // 46 verts/invocation fits the min-spec total-components budget once the
 // per-vertex cableTangent varying is included (46 × 22 = 1012 ≤ 1024). The
 // tent-slope invocations use the full 46 (= 23 boundaries × 2); twig
-// invocations use 4.
+// invocations use 3.
 layout (triangle_strip, max_vertices = 46) out;
 
 uniform sampler2D heightmapTex;
@@ -42,7 +42,7 @@ layout (std430, binding = 6) coherent buffer cableCoverageBuffer {
 in DataVS {
 	vec2 vsWorldXZ;
 	vec3 vsCableData;
-	vec4 vsGridData;
+	vec3 vsGridData;
 	flat int vsSlot;
 } dataIn[];
 
@@ -52,11 +52,12 @@ in DataVS {
 // pulse animation). For main-ribbon fragments (isBranch<0.5) it carries the
 // cable's len-per-segment so the FS can derive a per-segment bit index for
 // the coverage SSBO. The two semantics are disjoint by isBranch so no conflict.
-// BUDGET NOTE: `gridData` is a vec3 (was vec4 — the .z component was never read
-// by the FS). Shrinking it reclaimed one component so `cableTangent` could be
-// added without busting GL_MAX_GEOMETRY_OUTPUT_COMPONENTS' total budget: with
-// the tangent the per-vertex count is 22 (incl. gl_Position), so max_vertices
-// drops 50→46 to keep 46 × 22 = 1012 ≤ 1024 (min-spec).
+// BUDGET NOTE: `gridData` is a vec3 (eff, flow, isOwnAlly/ghost flag). It was a
+// vec4 whose .z carried a CPU-integrated bubble phase the FS never read;
+// dropping that float (now removed end-to-end — the CPU sends 3 floats)
+// reclaimed the component that funds `cableTangent`: with the tangent the
+// per-vertex count is 22 (incl. gl_Position), so max_vertices is 46 to keep
+// 46 × 22 = 1012 ≤ 1024 (min-spec GL_MAX_GEOMETRY_OUTPUT_COMPONENTS).
 out DataGS {
 	vec3 worldPos;
 	float capacity;
@@ -162,14 +163,13 @@ const int   PLACEMENT_OVERSAMPLE = 2;
 const int   MAX_GRID             = MAX_SEGMENTS * 2;   // local-array bound for the scan
 const float KINK_GAIN            = 0.15;
 
-// Twig parameters mirror the Lua-side BRANCH_* constants.
+// Twig parameters (chance/geometry of the small side branches).
 const float BRANCH_CHANCE     = 0.85;
 const float BRANCH_LEN_MIN    = 6.0;
 const float BRANCH_LEN_MAX    = 8.0;
 const float BRANCH_ANGLE_MIN  = 1.2;
 const float BRANCH_ANGLE_MAX  = 1.5;
 const float BRANCH_WIDTH      = 2.1;
-const float CONE_TIP_WIDTH    = 0.0;
 const float BRANCH_WIDTH_TWIG_LENGTH_FACTOR = 2.0;
 
 // Clearance over the heightmap, applied along the cable's chord-averaged surface
@@ -196,14 +196,14 @@ float gOutSpawnAlong = 0.0;
 int   gOutSlot       = -1;
 
 void emitVtx(vec3 wp, vec3 tangent3D, vec2 cuv,
-             float w, vec4 grid, vec2 td, float cap) {
+             float w, vec3 grid, vec2 td, float cap) {
 	worldPos = wp;
 	capacity = cap;
 	isBranch = gOutBranch;
 	width = w;
 	cableUV = cuv;
 	timeData = td;
-	gridData = grid.xyw;          // .z dropped (unused by FS); see DataGS BUDGET NOTE
+	gridData = grid;
 	cableTangent = tangent3D;     // smooth along-dir → FS interpolates the lit frame
 	spawnAlongMain = gOutSpawnAlong;
 	gsSlot = gOutSlot;
@@ -455,7 +455,7 @@ int placeRibbonVertices(vec2 a, vec2 d, vec2 perpAB, float lenAB, float arcDh,
 // verts/boundary), so the full tent only costs one extra invocation.
 void emitTentHalf(float side, vec2 a, vec2 d, vec2 perpAB,
                   float halfW, float widthVal, float effAmp, float seed,
-                  vec4 gridD, vec2 timeD, float cap, int numSeg, float arcDh) {
+                  vec3 gridD, vec2 timeD, float cap, int numSeg, float arcDh) {
 	gOutBranch = 0.0;
 	float tentHeight = halfW * TENT_HEIGHT_FACTOR;
 	// `along` is fed into the FS as cableUV.x and drives bubble advection.
@@ -594,7 +594,7 @@ void emitTentHalf(float side, vec2 a, vec2 d, vec2 perpAB,
 // hash says "no twig here" — leaving an empty primitive, which is a no-op.
 void emitTwig(vec2 a, vec2 d, vec2 perpAB,
               float halfMainW, float widthVal, float effAmp, float seed,
-              vec4 gridD, vec2 timeD, float cap, float tCenter,
+              vec3 gridD, vec2 timeD, float cap, float tCenter,
               float spawnAlongMain, int twigIdx, float arcDh, int numSeg,
               vec3 railPrev, vec3 railCenter) {
 	// Resolve spawn point on the wiggly main path at tCenter so twigs root on
@@ -624,19 +624,14 @@ void emitTwig(vec2 a, vec2 d, vec2 perpAB,
 	float bLen = BRANCH_LEN_MIN + widthVal*BRANCH_WIDTH_TWIG_LENGTH_FACTOR +
 		gsHashU(spawn.x, spawn.y, twigSeed + 3.0) * (BRANCH_LEN_MAX - BRANCH_LEN_MIN);
 
+	// The twig is a 3-vertex triangle: a full-width root edge tapering to a
+	// point at tip3D. The WIDTH varying passed to the FS stays UNIFORM at
+	// `twigW` along the whole twig, so bubble math sees constant halfWidthE
+	// and bubble radius/spacing don't change with along position; the visible
+	// bubble simply projects smaller near the point. This decouples "bubble
+	// flow looks uniform" from "twig has a cone shape".
 	float twigW    = max(2.5, widthVal * BRANCH_WIDTH);
 	float twigHWr  = min(twigW, widthVal * 0.55) * BRANCH_WIDTH;
-	// Geometric cone taper at 0.45 — visible shape narrows toward the tip
-	// (looks like a branch, not a tube). The WIDTH varying we pass to the FS
-	// stays UNIFORM at `twigW` along the entire twig, so bubble math sees
-	// constant halfWidthE and bubble radius/spacing don't change with along
-	// position. The visible bubble naturally fits the tapered geometry: in v
-	// space the bubble keeps the same cross-axis extent (relative to the
-	// cable's UV cross), which projects to a smaller world-cross at the
-	// thinner tip. At the very end the cable's `t > 0.9` cross discard clips
-	// any bubble that runs off the tip. This decouples "bubble flow looks
-	// uniform" from "twig has cone shape".
-	float twigHWt  = twigHWr * CONE_TIP_WIDTH;
 
 	// Build the twig as a flat ribbon in the slope's local tangent plane at
 	// the spawn point. This way, viewing perpendicular to the slope, the twig
@@ -689,8 +684,6 @@ void emitTwig(vec2 a, vec2 d, vec2 perpAB,
 
 	vec3 rootL = root3D - twigPerp3D * twigHWr;
 	vec3 rootR = root3D + twigPerp3D * twigHWr;
-	vec3 tipL  = tip3D  - twigPerp3D * twigHWt;
-	vec3 tipR  = tip3D  + twigPerp3D * twigHWt;
 
 	// cableUV.x carries the cable-wide along distance so the FS growth gate
 	// hides this twig until the main growth front has reached spawnAlongMain.
@@ -698,10 +691,10 @@ void emitTwig(vec2 a, vec2 d, vec2 perpAB,
 	// FS derives perp3D from cross(worldUp, vsTangent) so cylindrical lighting
 	// follows the twig's pointing direction.
 	gOutBranch = 1.0;
-	gOutSpawnAlong = spawnAlongMain;   // shared by all 4 twig vertices; lets FS compute twig-local along
-	emitVtx(rootL, twigDir3D, vec2(spawnAlongMain,        -1.0), twigW,        gridD, timeD, cap);
-	emitVtx(rootR, twigDir3D, vec2(spawnAlongMain,         1.0), twigW,        gridD, timeD, cap);
-	emitVtx(tipL,  twigDir3D, vec2(spawnAlongMain + bLen, -1.0), twigW, gridD, timeD, cap);
+	gOutSpawnAlong = spawnAlongMain;   // shared by all 3 twig vertices; lets FS compute twig-local along
+	emitVtx(rootL, twigDir3D, vec2(spawnAlongMain,        -1.0), twigW, gridD, timeD, cap);
+	emitVtx(rootR, twigDir3D, vec2(spawnAlongMain,         1.0), twigW, gridD, timeD, cap);
+	emitVtx(tip3D, twigDir3D, vec2(spawnAlongMain + bLen, -1.0), twigW, gridD, timeD, cap);
 	EndPrimitive();
 	gOutSpawnAlong = 0.0;
 }
@@ -723,15 +716,15 @@ void main() {
 
 	float cap   = dataIn[0].vsCableData.x;
 	vec2  timeD = dataIn[0].vsCableData.yz;
-	vec4  gridD = dataIn[0].vsGridData;
+	vec3  gridD = dataIn[0].vsGridData;
 
-	// Ghost edges (gridData.w = -1.0) emit the same two tent slopes as live
+	// Ghost edges (gridData.z = -1.0) emit the same two tent slopes as live
 	// (no twigs), using the SAME wiggly path so the live→ghost transition has
 	// no visual snap. Ghost FS path is fast (no lighting/bubble math), and the
 	// GS still skips the 3 twig invocations. Coverage updates use the live
 	// atomicAnd path with the wiggly samples → consistent with what the player
 	// visually sees.
-	bool isGhostEdge = gridD.w < -0.5;
+	bool isGhostEdge = gridD.z < -0.5;
 	if (isGhostEdge && gl_InvocationID > 1) return;
 
 	float widthVal = MIN_TRUNK_WIDTH +
@@ -797,8 +790,8 @@ void main() {
 
 	if (gl_InvocationID == 0) {
 		// Coverage SSBO update — once per cable per frame, not per fragment.
-		// Live edges (gridData.w >= -0.5) atomicOr bits for segments currently
-		// in LOS; ghost edges (gridData.w < -0.5) atomicAnd to clear bits the
+		// Live edges (gridData.z >= -0.5) atomicOr bits for segments currently
+		// in LOS; ghost edges (gridData.z < -0.5) atomicAnd to clear bits the
 		// player has re-scouted. Sampling along the actual wiggly path keeps
 		// reveal accurate even with arc bias on slopes.
 		//
@@ -814,7 +807,7 @@ void main() {
 		// second per-frame update would risk double-clearing ghost bits.
 #if !defined(SHADOW_PASS) && !defined(DEFERRED_PASS)
 		int slot = dataIn[0].vsSlot;
-		bool isGhost = gridD.w < -0.5;
+		bool isGhost = gridD.z < -0.5;
 		// Hard gate on the user-facing ghosts toggle — skip ALL coverage
 		// bookkeeping (the n-tap LOS scan, atomic ops, even the SSBO read)
 		// when ghosts are off. Restores live-only perf parity with pre-slice-1.

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
@@ -297,21 +297,29 @@ vec2 wigglyCablePoint(vec2 a, vec2 d, vec2 perpAB, float t, float lenAB,
 	return base + perpCanon * n;
 }
 
-// Lift y to the max heightmap value sampled within ±fullStep along dirH.
-// Linear interpolation between adjacent segment vertices can dip below
-// terrain on convex/rolling slopes — taking the max within a window that
-// covers the next vertex's position guarantees adjacent envelopes overlap
-// at the segment midpoint, so the rendered ribbon stays above any peak in
-// the gap. Used by the main ribbon (centerline lift) and twig emitter
-// (spawn point lift) so they share the same vertical anchor.
-float maxHeightInWindow(vec2 p, vec2 dirH, float fullStep) {
+// Lift y to the max heightmap value sampled within ±window along dirH.
+// Linear interpolation between adjacent samples can dip below terrain on
+// convex/rolling slopes — taking the max within a window that reaches most of
+// the way to the neighbouring sample makes adjacent envelopes overlap, so the
+// profile built from the samples stays above any sub-sample terrain peak.
+//
+// A max-filter along the path is a morphological DILATION of the terrain
+// profile: on a monotone slope every sample takes the height ~0.85·window
+// uphill of it, i.e. the whole profile shifts horizontally downhill by a
+// constant amount. Size `window` to the SMALLEST span that still catches
+// sub-sample terrain — an oversized window reads as the cable overshooting
+// cliff lips like it had inertia. placeRibbonVertices passes the scan-grid
+// cell span (not the emitted-vertex span) for exactly this reason; the
+// per-EMITTED-vertex anti-clip is handled there with windows sized to the
+// local clustered gap.
+float maxHeightInWindow(vec2 p, vec2 dirH, float window) {
 	float yMax = heightAtWorldPos(p);
-	yMax = max(yMax, heightAtWorldPos(p + dirH * (fullStep * 0.30)));
-	yMax = max(yMax, heightAtWorldPos(p - dirH * (fullStep * 0.30)));
-	yMax = max(yMax, heightAtWorldPos(p + dirH * (fullStep * 0.55)));
-	yMax = max(yMax, heightAtWorldPos(p - dirH * (fullStep * 0.55)));
-	yMax = max(yMax, heightAtWorldPos(p + dirH * (fullStep * 0.85)));
-	yMax = max(yMax, heightAtWorldPos(p - dirH * (fullStep * 0.85)));
+	yMax = max(yMax, heightAtWorldPos(p + dirH * (window * 0.30)));
+	yMax = max(yMax, heightAtWorldPos(p - dirH * (window * 0.30)));
+	yMax = max(yMax, heightAtWorldPos(p + dirH * (window * 0.55)));
+	yMax = max(yMax, heightAtWorldPos(p - dirH * (window * 0.55)));
+	yMax = max(yMax, heightAtWorldPos(p + dirH * (window * 0.85)));
+	yMax = max(yMax, heightAtWorldPos(p - dirH * (window * 0.85)));
 	return yMax;
 }
 
@@ -349,17 +357,26 @@ int placeRibbonVertices(vec2 a, vec2 d, vec2 perpAB, float lenAB, float arcDh,
                         out float yBaseArr[MAX_SEGMENTS + 1],
                         out float alongArr[MAX_SEGMENTS + 1]) {
 	vec2  dirH     = (lenAB > 0.0) ? d / lenAB : vec2(1.0, 0.0);
-	float fullStep = lenAB / float(numSeg);   // max-filter window ~ avg emit span
 	int   G        = clamp(PLACEMENT_OVERSAMPLE * numSeg, 1, MAX_GRID);
+	float gridStep = lenAB / float(G);   // scan-cell span
 
-	// Profile scan: max-filtered terrain height along the cable path. Its second
+	// Profile scan: terrain height along the cable path, max-filtered only over
+	// ONE scan cell — just enough to catch terrain between scan samples, NOT the
+	// old ±0.85·(lenAB/numSeg) window. That global-average window dilated the
+	// profile by ~19 elmos along the cable, which on any monotone slope is a
+	// constant horizontal shift downhill: cables carried cliff-top height well
+	// past the lip before dropping, as if they had inertia. The anti-clip duty
+	// the wide window used to carry moved to the per-emitted-vertex pass below,
+	// where the window is sized to the LOCAL clustered gap. The profile's second
 	// difference (below) is the along-cable curvature — directional by
-	// construction (crossing a ridge spikes it, running along a crest does not).
+	// construction (crossing a ridge spikes it, running along a crest does not);
+	// the narrower filter also stops smearing kinks across two cells, so
+	// clustering lands harder exactly on the lip.
 	float yCgrid[MAX_GRID + 1];
 	for (int i = 0; i <= G; i++) {
 		float tg = float(i) / float(G);
 		vec2 pg = wigglyCablePoint(a, d, perpAB, tg, lenAB, arcDh, effAmp, seed);
-		yCgrid[i] = maxHeightInWindow(pg, dirH, fullStep);   // base terrain profile
+		yCgrid[i] = maxHeightInWindow(pg, dirH, gridStep);   // base terrain profile
 	}
 
 	// Per-cell importance = uniform floor (1.0, keeps flats at equal arc spacing)
@@ -374,10 +391,8 @@ int placeRibbonVertices(vec2 a, vec2 d, vec2 perpAB, float lenAB, float arcDh,
 	}
 	float wStep = cum[G] / float(numSeg);
 
-	int   gi       = 0;
-	int   prevIdx  = -1;
-	float along    = 0.0;
-	vec3  prevBase = vec3(0.0);
+	int   gi      = 0;
+	int   prevIdx = -1;
 	for (int k = 0; k <= numSeg; k++) {
 		// Pick the grid index whose cumulative weight is nearest k·wStep. gi and k
 		// both advance monotonically → one linear sweep. The max(prevIdx+1) guard
@@ -389,18 +404,44 @@ int placeRibbonVertices(vec2 a, vec2 d, vec2 perpAB, float lenAB, float arcDh,
 		if (gi < G && (target - cum[gi]) > (cum[gi+1] - target)) idx = gi + 1;
 		idx = min(max(idx, prevIdx + 1), G);
 		prevIdx = idx;
+		idxArr[k] = idx;
+	}
+
+	// Per-vertex anti-clip lift, sized to the LOCAL emitted gaps: each vertex
+	// takes the max of the scan profile over ~0.55 of the gap to each emitted
+	// neighbour, so the two endpoints of every gap jointly cover all its scan
+	// samples with overlap at the midpoint (0.55 + 0.55 > 1) — the same
+	// envelope guarantee the old global-average window gave, but the dilation
+	// radius now shrinks with clustering: at a cliff lip, where curvature
+	// packs vertices into adjacent scan cells, the lift degenerates to the
+	// vertex's own (one-cell-filtered) sample and the "inertia" overshoot is
+	// bounded by one scan cell instead of ±0.85·(lenAB/numSeg). On sparse
+	// stretches the window grows with the gap — but sparse means flat, where
+	// the max is invisible. int() truncation keeps the reach strictly inside
+	// the gap for adjacent-cell neighbours (nothing to cover between them).
+	float along    = 0.0;
+	vec3  prevBase = vec3(0.0);
+	for (int k = 0; k <= numSeg; k++) {
+		int iC = idxArr[k];
+		int iL = (k > 0)      ? idxArr[k-1] : iC;
+		int iR = (k < numSeg) ? idxArr[k+1] : iC;
+		int lo = max(iC - int(float(iC - iL) * 0.55), 0);
+		int hi = min(iC + int(float(iR - iC) * 0.55), G);
+		float yB = yCgrid[iC];
+		for (int i = lo; i <= hi; i++) {
+			yB = max(yB, yCgrid[i]);
+		}
 
 		// Accumulate 3D arc length over the emitted vertices. The clearance pad is
 		// a uniform per-cable Navg shift, so it cancels in consecutive distances —
 		// accumulating over the bare (xz, yBase) points matches emitTentHalf's
 		// center3D-based accumulation exactly.
-		vec2 p    = wigglyCablePoint(a, d, perpAB, float(idx) / float(G), lenAB, arcDh, effAmp, seed);
-		vec3 base = vec3(p.x, yCgrid[idx], p.y);
+		vec2 p    = wigglyCablePoint(a, d, perpAB, float(iC) / float(G), lenAB, arcDh, effAmp, seed);
+		vec3 base = vec3(p.x, yB, p.y);
 		if (k > 0) along += distance(prevBase, base);
 		prevBase = base;
 
-		idxArr[k]   = idx;
-		yBaseArr[k] = yCgrid[idx];
+		yBaseArr[k] = yB;
 		alongArr[k] = along;
 	}
 	return G;

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.geom.glsl
@@ -315,6 +315,20 @@ float maxHeightInWindow(vec2 p, vec2 dirH, float fullStep) {
 	return yMax;
 }
 
+// Chord-averaged surface normal — the cable's shared "up", sampled at 5 anchor
+// points along the chord (same anchors as cableArcDh). Factored out so the twig
+// emitter lifts its root along the SAME axis the tent apex and clearance pad
+// ride, instead of a local per-point normal that diverges from the trunk frame
+// on uneven ground (which let the root dangle off the tube on slopes).
+vec3 cableNavg(vec2 a, vec2 d) {
+	vec3 nAcc = vec3(0.0);
+	for (int j = 0; j < 5; j++) {
+		float tj = (float(j) + 0.5) * (1.0 / 5.0);
+		nAcc += terrainNormal(a + d * tj);
+	}
+	return normalize(nAcc);
+}
+
 // Adaptive vertex placement, factored out so the twig emitter can replay the
 // EXACT vertex set the ribbon renders and root onto it. Scans the max-filtered
 // centerline profile on a grid PLACEMENT_OVERSAMPLE× denser than the emit
@@ -427,16 +441,9 @@ void emitTentHalf(float side, vec2 a, vec2 d, vec2 perpAB,
 	// vertical ROLL from the terrain normal; cross(worldUp, tangent) has no roll
 	// (worldUp is fixed), it only yaws to track the bend. It also matches the FS
 	// lighting frame, which already derives perp3D = cross(worldUp, cableTangent),
-	// so geometry and shading agree.
-	vec3 Navg;
-	{
-		vec3 nAcc = vec3(0.0);
-		for (int j = 0; j < 5; j++) {
-			float tj = (float(j) + 0.5) * (1.0 / 5.0);
-			nAcc += terrainNormal(a + d * tj);
-		}
-		Navg = normalize(nAcc);
-	}
+	// so geometry and shading agree. cableNavg is shared with the twig emitter so
+	// twig roots ride the same axis.
+	vec3 Navg = cableNavg(a, d);
 	vec3 cableDirH_g = normalize(vec3(d.x, 0.0, d.y));
 	// Fallback width axis for the first vertex (chord tangent) and any vertex
 	// whose local tangent degenerates: horizontal, perpendicular to the chord.
@@ -547,7 +554,8 @@ void emitTentHalf(float side, vec2 a, vec2 d, vec2 perpAB,
 void emitTwig(vec2 a, vec2 d, vec2 perpAB,
               float halfMainW, float widthVal, float effAmp, float seed,
               vec4 gridD, vec2 timeD, float cap, float tCenter,
-              float spawnAlongMain, int twigIdx, float arcDh, int numSeg) {
+              float spawnAlongMain, int twigIdx, float arcDh, int numSeg,
+              vec3 railPrev, vec3 railCenter) {
 	// Resolve spawn point on the wiggly main path at tCenter so twigs root on
 	// the visible cable.
 	float lenAB = length(d);
@@ -601,25 +609,41 @@ void emitTwig(vec2 a, vec2 d, vec2 perpAB,
 	vec3 T = normalize(cableDirH - dot(cableDirH, N) * N);
 	vec3 B = normalize(cross(N, T));
 
+	// Rail frame at the emitted vertex the twig roots on: tangent = back-diff
+	// of adjacent emitted centerline points (exactly emitTentHalf's vtxTangent
+	// at this vertex), width axis B_v = its horizontal perpendicular (exactly
+	// the axis the tent rails are laid on).
+	vec3 railTangent = railCenter - railPrev;
+	float rtL = length(railTangent);
+	railTangent = (rtL > 1e-4) ? railTangent / rtL : cableDirH;
+	vec3 B_v = cross(vec3(0.0, 1.0, 0.0), railTangent);
+	float bvL = length(B_v);
+	B_v = (bvL > 1e-3) ? B_v / bvL : normalize(cross(vec3(0.0, 1.0, 0.0), cableDirH));
+	// Local N gives B an arbitrary sign that can disagree with the rail axis on
+	// broken ground. Align them so the twig grows AWAY from the tube on the
+	// SAME side its root is placed (+B_v*halfMainW*side below) instead of
+	// doubling back across the trunk.
+	if (dot(B, B_v) < 0.0) B = -B;
+
 	float ca = cos(angleOff);
 	float sa = sin(angleOff) * side;
 	vec3 twigDir3D  = ca * T + sa * B;
 	vec3 twigPerp3D = normalize(cross(N, twigDir3D));
 
-	// Anchor spawn to the same max-of-window lift the main ribbon uses, offset
-	// along the local normal N — at this 0.3 magnitude N tracks the trunk's
-	// chord-averaged Navg pad closely enough to keep the junction seated, and N
-	// is already the twig's own basis. TWIG_CLEAR is slightly less than
-	// CENTERLINE_CLEAR so the junction sits just under the trunk's centerline
-	// (z-fight avoidance, see TWIG_CLEAR comment).
-	vec2 dirH = (lenAB > 0.0) ? d / lenAB : vec2(1.0, 0.0);
-	float fullStep = lenAB / float(numSeg);
-	float spawnYbase = maxHeightInWindow(spawn, dirH, fullStep);
-	vec3 spawn3D = vec3(spawn.x, spawnYbase, spawn.y) + N * TWIG_CLEAR;
-
-	// Anchor the root to the spawn-side edge of the cable's in-slope cross
-	// section so the twig pokes out of the side, not the midline.
-	vec3 root3D = spawn3D + B * (halfMainW * 0.2 * side);
+	// Root anchor: reproduce the trunk's spawn-side OUTER rail vertex — the
+	// same center ± B_v*halfW the tent slopes emit, with the same SIDE_CLEAR
+	// anti-underground clamp — so the junction is welded to a vertex the
+	// ribbon actually renders. The old code offset by 0.2*halfW along the
+	// LOCAL-normal B from a max-of-window spawn at the belly; on slopes that
+	// both diverged from the trunk frame and dangled below the visible tube,
+	// detaching the twig. A small lift along the trunk's shared Navg
+	// (TWIG_CLEAR) tucks the junction just proud of the rail to avoid
+	// z-fighting.
+	vec3 Navg = cableNavg(a, d);
+	vec3 center3D = railCenter + Navg * CENTERLINE_CLEAR;
+	vec3 root3D = center3D + B_v * (halfMainW * side);
+	root3D.y = max(root3D.y, heightAtWorldPos(root3D.xz) + SIDE_CLEAR);
+	root3D += Navg * TWIG_CLEAR;
 	vec3 tip3D  = root3D + twigDir3D * bLen;
 
 	vec3 rootL = root3D - twigPerp3D * twigHWr;
@@ -817,7 +841,17 @@ void main() {
 		}
 		float tCenter        = float(idxArr[bestK]) / float(G);
 		float spawnAlongMain = alongArr[bestK];
+		// Rebuild the rooted vertex and its predecessor exactly as emitTentHalf
+		// does (same wigglyCablePoint xz, same base height) so emitTwig can
+		// reconstruct the local rail frame at the junction. bestK >= 1 always,
+		// so bestK-1 is a valid emitted vertex.
+		float tPrev = float(idxArr[bestK - 1]) / float(G);
+		vec2 pC = wigglyCablePoint(a, d, perpAB, tCenter, lenAB, arcDh, effAmp, seed);
+		vec2 pP = wigglyCablePoint(a, d, perpAB, tPrev,   lenAB, arcDh, effAmp, seed);
+		vec3 railCenter = vec3(pC.x, yBaseArr[bestK],     pC.y);
+		vec3 railPrev   = vec3(pP.x, yBaseArr[bestK - 1], pP.y);
 		emitTwig(a, d, perpAB, halfW, widthVal, effAmp, seed,
-		         gridD, timeD, cap, tCenter, spawnAlongMain, twigIdx, arcDh, numSeg);
+		         gridD, timeD, cap, tCenter, spawnAlongMain, twigIdx, arcDh, numSeg,
+		         railPrev, railCenter);
 	}
 }

--- a/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.vert.glsl
+++ b/LuaRules/Gadgets/Shaders/gfx_overdrive_cables.vert.glsl
@@ -10,7 +10,7 @@
 
 layout (location = 0) in vec2 vertPos;     // (x, z) world coords
 layout (location = 1) in vec3 vertData;    // (capacity, appearTime, witherTime)
-layout (location = 2) in vec4 vertGrid;    // (gridEfficiency, flow, bubblePhase, isOwnAlly)
+layout (location = 2) in vec3 vertGrid;    // (gridEfficiency, flow, isOwnAlly / ghost flag)
 layout (location = 3) in float vertSlot;   // coverage SSBO slot (-1 = disabled)
 
 out gl_PerVertex {
@@ -20,7 +20,7 @@ out gl_PerVertex {
 out DataVS {
 	vec2 vsWorldXZ;
 	vec3 vsCableData;
-	vec4 vsGridData;
+	vec3 vsGridData;
 	flat int vsSlot;
 };
 

--- a/LuaRules/Gadgets/gfx_overdrive_cables.lua
+++ b/LuaRules/Gadgets/gfx_overdrive_cables.lua
@@ -58,7 +58,6 @@ local function IsActiveForGrid(unitID)
 	return true
 end
 
-local sqrt  = math.sqrt
 local max   = math.max
 local floor = math.floor
 
@@ -88,7 +87,6 @@ local CABLE_TEXTURE = "Luarules/Images/cables/cableTexture.png"
 
 local pylonDefs = {}
 local mexDefs = {}
-local generatorDefs = {}
 local pmaxByDef = {}      -- [defID] = nameplate production for non-wind generators
 local isWindgenByDef = {} -- [defID] = true (production resolved via WindMax at runtime)
 local voltageByDef = {}   -- [defID] = neededlink value (counts as static Dmax)
@@ -111,9 +109,6 @@ for i = 1, #UnitDefs do
 	end
 	local energyIncome = tonumber(cp.income_energy) or 0
 	local isWind = (cp.windgen and true) or false
-	if energyIncome > 0 or isWind then
-		generatorDefs[i] = true
-	end
 	if energyIncome > 0 then
 		pmaxByDef[i] = energyIncome
 	end
@@ -456,16 +451,15 @@ local perfStats = {
 -- when nothing meaningfully changed. Quiet ticks (settled grid, no draw
 -- spikes) become near-zero on the topology side.
 local lastSentFlow = {}   -- [edgeKey] = flow (E/s)
-local lastSentEff  = {}   -- [edgeKey] = grid efficiency
--- A send is forced if max relative flow change exceeds this OR any eff
--- changed by more than EFF_EPSILON. The thresholds are loose because
--- visual-flow only needs ballpark accuracy: bubble speed ∝ sqrt(flow), so
--- a 10% flow change is ~5% bubble-speed change — well below perception.
+-- A send is forced if max relative flow change exceeds this. The threshold is
+-- loose because visual-flow only needs ballpark accuracy: bubble speed ∝
+-- sqrt(flow), so a 10% flow change is ~5% bubble-speed change — well below
+-- perception. Eff changes alone do NOT force a send; the eff hue refreshes on
+-- the FORCE_SEND_TICKS cadence below.
 local FLOW_REL_EPSILON = 0.10
 local FLOW_ABS_EPSILON = 0.5    -- E/s, for tiny flows where relative is noisy
-local EFF_EPSILON      = 0.02
--- Force a refresh at least this often even when stable, so any drift in
--- the FS phase extrapolation doesn't accumulate without bound.
+-- Force a refresh at least this often even when stable, so slow-moving state
+-- (eff hue, small flow drift under the epsilons) still reaches the renderer.
 local FORCE_SEND_TICKS = 5      -- ~5 seconds at SYNC_PERIOD=30 / 30fps
 local ticksSinceSend   = 0
 
@@ -511,13 +505,6 @@ local function MarkGridRemove(ally, gridID, uid)
 	if entry then entry.removes[#entry.removes + 1] = uid end
 end
 
--- Backward-compat for callers (UnitGiven) that just want to flag a grid as
--- needing reconsideration without naming a specific unit (e.g. when a whole
--- pylon's affiliation changes).
-local function MarkGridDirty(ally, gridID)
-	GetPendingEntry(ally, gridID)
-end
-
 -- Stable nameplate production: solar/fusion/sing fixed; windgen = current WindMax.
 local function GetNodePmax(unitDefID)
 	if isWindgenByDef[unitDefID] then return GetWindMax() end
@@ -531,13 +518,6 @@ local function GetNodeDmax(unitID, unitDefID)
 		return spGetUnitRulesParam(unitID, "max_energy_drain") or INF_DRAW
 	end
 	return voltageByDef[unitDefID] or 0
-end
-
--- Current real production: any generator publishes "current_energyIncome"
--- (windgens, solar, fusion, singu — all set by unit_mex_overdrive each tick).
-local function GetNodePcurrent(unitID, unitDefID)
-	if not generatorDefs[unitDefID] then return 0 end
-	return spGetUnitRulesParam(unitID, "current_energyIncome") or 0
 end
 
 -- Current real draw. Mexes consume via the overdrive system, which the
@@ -886,15 +866,14 @@ local function BuildGridMSTFromScratch(allyTeamID, gridID, allyNodes, allyCells)
 	local mst = MakeEmptyMst(allyTeamID, gridID)
 	if not allyNodes then return mst end
 
-	-- Collect this grid's pylons + per-pylon position+range in arrays.
-	local px, pz, prange, puid = {}, {}, {}, {}
+	-- Collect this grid's pylons + per-pylon positions in arrays.
+	local px, pz, puid = {}, {}, {}
 	for uid, node in pairs(allyNodes) do
 		if lastGridNum[uid] == gridID then
 			local idx = #puid + 1
 			puid[idx] = uid
 			px[idx] = node.x
 			pz[idx] = node.z
-			prange[idx] = node.range
 		end
 	end
 	local n = #puid
@@ -1708,7 +1687,6 @@ local function SendAll()
 			pa.effs[i] = eff
 			-- Snapshot for the next tick's stability check.
 			lastSentFlow[key] = pa.flows[i]
-			lastSentEff[key]  = eff
 		end
 	end
 	local tBin1 = perf and Spring.GetTimer()
@@ -1771,7 +1749,6 @@ local function ClearAll()
 	topologyDirty = false
 	-- Reset stability snapshots; on next enable, all edges read as new.
 	lastSentFlow = {}
-	lastSentEff  = {}
 	ticksSinceSend = 0
 end
 
@@ -1857,7 +1834,6 @@ local function SetDetailLevel(level)
 		-- (toggling between noflow ↔ full needs to push the new flow values
 		-- to the renderer; the FS uniform also needs the new enableFlow).
 		lastSentFlow = {}
-		lastSentEff  = {}
 		ticksSinceSend = FORCE_SEND_TICKS  -- force-send next tick
 		topologyDirty = true
 		SendAll()
@@ -2086,20 +2062,6 @@ end
 
 local spGetMyAllyTeamID    = Spring.GetMyAllyTeamID
 local spGetSpectatingState = Spring.GetSpectatingState
-local spGetGroundHeight    = Spring.GetGroundHeight
-
-local floor = math.floor
-local sqrt  = math.sqrt
-local max   = math.max
-local min   = math.min
-local abs   = math.abs
-local PI    = math.pi
-local cos   = math.cos
-local sin   = math.sin
-local atan2 = math.atan2
-
-local MAP_WIDTH  = Game.mapSizeX
-local MAP_HEIGHT = Game.mapSizeZ
 
 local luaShaderDir = "LuaUI/Widgets/Include/"
 local LuaShader = VFS.Include(luaShaderDir .. "LuaShader.lua")
@@ -2108,27 +2070,6 @@ VFS.Include(luaShaderDir .. "instancevbotable.lua")
 -------------------------------------------------------------------------------------
 -- Config
 -------------------------------------------------------------------------------------
-
-local MIN_TRUNK_WIDTH  = 3
-local MAX_TRUNK_WIDTH  = 12
--- One singu's output (energysingu.energyMake = 225) saturates the cable to
--- max thickness. Below that, thickness scales linearly with capacity.
-local MAX_CAPACITY_REF = 225
-
-local SEG_LENGTH       = 10    -- shorter = smoother curves
--- Noise amplitude is in absolute elmos (not a fraction of cable width). Tying
--- it to width made thick trunks visibly more wobbly than thin twigs, which is
--- the opposite of the intended look (a thick trunk should read as "stable").
-local NOISE_AMP_ABS    = 1.0
-local BRANCH_CHANCE    = 0.25
-local BRANCH_LEN_MIN   = 15
-local BRANCH_LEN_MAX   = 50
-local BRANCH_ANGLE_MIN = 0.4
-local BRANCH_ANGLE_MAX = 1.1
-local BRANCH_WIDTH     = 0.5
-
-local MERGE_ANGLE    = 0.8
-local STEM_FRACTION  = 0.35
 
 -- Depth bias that pulls the drawn cable toward the camera so it wins the
 -- z-fight against terrain. NOT to mask a geometry bug: the cable hugs the
@@ -2145,46 +2086,10 @@ local STEM_FRACTION  = 0.35
 local CABLE_DEPTH_BIAS_FACTOR = -1.0   -- slope-scaled term (cables are near-flat, so this stays small)
 local CABLE_DEPTH_BIAS_UNITS  = -4.0   -- constant term in min-resolvable-depth units
 
--- Visual grow/wither animation rates (elmos/sec); fragment shader trims geometry.
-local GROWTH_RATE = 250
-local WITHER_RATE = 400
+-- Wither hold pacing (see WITHER_HOLD_FRAMES). The actual grow/wither sweep
+-- rates live in the fragment shader (GROWTH_RATE/WITHER_RATE, elmos/sec);
+-- the CPU only supplies the appear/wither timestamps.
 local GAME_SPEED  = Game.gameSpeed or 30
-
--- Bubble speed mapping — must mirror the formula in the fragment shader. We
--- integrate phase = ∫ speed(t) dt CPU-side per edge, so speed changes don't
--- jump bubbles across the cable; the shader just extrapolates from the last
--- anchor with the current speed.
---
--- Cable-thickness/capacity is treated as orthogonal identity (it's the cable's
--- "how big a pipe" reading, NOT a flow signal). Flow itself is encoded by
--- speed + density only. Each scales as sqrt(flow / FLOW_REF) and they grow
--- together, so the product (= perceived flow ≈ density × speed) is linear in
--- flow. One unified "more lively" gestalt instead of three integrated dials.
-local BUBBLE_MAX_SPEED      = 110
-local BUBBLE_FLOW_REF       = 50.0   -- flow at which n=1 (reference speed/density)
-local BUBBLE_TRUNK_W_MIN    = 3.0    -- mirror of GLSL MIN_TRUNK_WIDTH
-local BUBBLE_TRUNK_W_MAX    = 12.0   -- mirror of GLSL MAX_TRUNK_WIDTH
-local BUBBLE_CAP_REF        = MAX_CAPACITY_REF
-
-local function widthOfCapacity(cap)
-	local t = (cap or 0) / BUBBLE_CAP_REF
-	if t < 0 then t = 0 elseif t > 1 then t = 1 end
-	return BUBBLE_TRUNK_W_MIN + t * (BUBBLE_TRUNK_W_MAX - BUBBLE_TRUNK_W_MIN)
-end
-
--- Slight negative bias for thicker cables: divide flow by (width/minWidth).
--- A max-thickness cable (4× minWidth) sees its flow signal scaled to 1/4
--- before the sqrt, yielding ~0.5× visual liveliness vs a thin cable at the
--- same actual flow. Conveys "this thick cable is wide so the same flow looks
--- relatively calmer through it" without the heavier 2.5-power weighting we
--- tried before.
-local function flowToSpeed(flow, capacity)
-	if not flow or flow <= 0 then return 0 end
-	local widthVal = widthOfCapacity(capacity)
-	local thicknessRatio = widthVal / BUBBLE_TRUNK_W_MIN
-	local effFlow = flow / thicknessRatio
-	return BUBBLE_MAX_SPEED * math.sqrt(effFlow / BUBBLE_FLOW_REF)
-end
 
 -------------------------------------------------------------------------------------
 -- State
@@ -2219,20 +2124,6 @@ local numGhostVerts = 0
 local ghostCleanupCursor = nil   -- next key to start at; nil = restart from head
 local GHOST_CLEANUP_PER_FRAME = 32
 
--- Geometry cache. Topology-stable rebuilds reuse `allPaths` (the noisy paths,
--- twigs and cluster stems). Per-call, we walk the prov objects (one per
--- emitNoisyPath invocation) and refresh just the dynamic fields (flow, eff,
--- bubblePhase, appearFrame, witherFrame) from the current renderEdges.
--- Vert emission then re-reads from prov.
---
--- Invalidated by: new edge in OnCableTreeFull, edge marked withering,
--- withering edge dropped in GameFrame, cluster sign-flip during refresh.
-local geomCache = {
-	valid = false,
-	allPaths = nil,       -- [{ points, widths, capacity, isBranch, prov }]
-	provs = nil,          -- [provObj] (distinct, one per emitNoisyPath call)
-}
-
 local cableShader         -- forward shader for cable rendering
 local cableShadowShader   -- depth-only SHADOW_PASS variant, drawn in the shadow map pass
 local cableDeferredShader -- model-gbuffer DEFERRED_PASS variant, drawn in DrawOpaqueUnitsLua
@@ -2240,76 +2131,14 @@ local cableVAO          -- live cable geometry
 local numCableVerts = 0
 -- (drawPerf collapsed into cablePerf at the top of the file; flowMode
 -- collapsed into cableFlowMode. Both names live in the topology block above.)
--- Game-second timestamp captured the moment the current VBO's bubblePhase
--- snapshots were taken. The shader extrapolates each cable's phase forward
--- from this anchor using `phase = bakedPhase + flowToSpeed(flow) * (gameTime
--- - bakeTime)`, which means flow changes update the rate of advance without
--- ever teleporting the bubbles.
-local bubbleBakeTime = 0
 
 -------------------------------------------------------------------------------------
--- Deterministic noise
+-- Per-edge VBO build
 -------------------------------------------------------------------------------------
 
-local function Hash(x, z, seed)
-	local h = sin(x * 12.9898 + z * 78.233 + (seed or 0) * 43.17) * 43758.5453
-	return (h - floor(h)) * 2 - 1
-end
-
-local function HashUnit(x, z, seed)
-	return (Hash(x, z, seed) + 1) * 0.5
-end
-
-local function GetTrunkWidth(capacity)
-	local t = min(1, capacity / MAX_CAPACITY_REF)
-	return MIN_TRUNK_WIDTH + t * (MAX_TRUNK_WIDTH - MIN_TRUNK_WIDTH)
-end
-
-local function NoisyPath(x1, z1, x2, z2, amplitude, seed)
-	local dx = x2 - x1
-	local dz = z2 - z1
-	local len = sqrt(dx * dx + dz * dz)
-	if len < 2 then
-		return { {x = x1, z = z1}, {x = x2, z = z2} }
-	end
-	local steps = max(2, floor(len / SEG_LENGTH))
-	local nx = -dz / len
-	local nz =  dx / len
-	local points = {}
-	-- Cap effective amplitude by a fraction of the segment length: very short
-	-- cables shouldn't get the same wiggle as long ones.
-	local effAmp = amplitude
-	if len < 80 then effAmp = amplitude * (len / 80) end
-	for i = 0, steps do
-		local t = i / steps
-		local px = x1 + t * dx
-		local pz = z1 + t * dz
-		local noiseScale = 1
-		if t < 0.1 then noiseScale = t / 0.1
-		elseif t > 0.9 then noiseScale = (1 - t) / 0.1 end
-		local n = Hash(px * 0.1, pz * 0.1, seed) * effAmp * noiseScale
-		points[#points + 1] = { x = px + nx * n, z = pz + nz * n }
-	end
-	return points
-end
-
--------------------------------------------------------------------------------------
--- Organic tree router (same logic, outputs vertex data for VBO)
--------------------------------------------------------------------------------------
-
-local function normalizeAngle(a)
-	while a > PI do a = a - PI * 2 end
-	while a < -PI do a = a + PI * 2 end
-	return a
-end
-
--- Per-edge VBO build: emit two vertices per cable (the two endpoints), each
--- carrying the same per-edge payload. The geometry shader expands each line
--- into the noisy wiggly ribbon. CPU work shrinks from "build full triangle
--- soup" (lots of NoisyPath / clustering / twig generation) to "iterate edges".
--- Cluster stems and twigs are deliberately gone in this first GS pass — to be
--- reintroduced as either CPU-emitted phantom edges (stems) or GS-side branches
--- (twigs) once the basic pipeline is verified.
+-- Emit two vertices per cable (the two endpoints), each carrying the same
+-- per-edge payload. The geometry shader expands each line into the wiggly
+-- ribbon and its twigs at draw time; the CPU side just iterates edges.
 local function GenerateOrganicTree()
 	local _, fullview = spGetSpectatingState()
 	local n = #renderEdges
@@ -2319,12 +2148,11 @@ local function GenerateOrganicTree()
 	local k = 0
 	for i = 1, n do
 		local e = renderEdges[i]
-		local cap = max(1, e.capacity or 1) 
+		local cap = max(1, e.capacity or 1)
 		local appearTime = (e.appearFrame or 0) / GAME_SPEED
 		local witherTime = e.witherFrame and (e.witherFrame / GAME_SPEED) or 0
 		local eff = (e.eff or 0) * (e.maxxed and -1 or 1)
 		local flow = e.flow or 0
-		local phase = e.bubblePhase or 0
 		local isOwn = (fullview and 2) or (e.isOwnAlly and 1) or 0
 		-- Coverage SSBO slot index, or -1 to disable bit updates / lookups
 		-- on the GS side. Stored as float here for VBO layout simplicity;
@@ -2332,24 +2160,24 @@ local function GenerateOrganicTree()
 		-- through the float<-int round-trip for any reasonable slot count.
 		local slot = e.slot or -1
 
-		-- Vertex 0: parent end (10 floats: pos2 + data3 + grid4 + slot)
+		-- Vertex 0: parent end (9 floats: pos2 + data3 + grid3 + slot)
 		verts[k+1] = e.px;          verts[k+2] = e.pz
 		verts[k+3] = cap;           verts[k+4] = appearTime;  verts[k+5] = witherTime
-		verts[k+6] = eff;           verts[k+7] = flow;        verts[k+8] = phase;       verts[k+9] = isOwn
-		verts[k+10] = slot
+		verts[k+6] = eff;           verts[k+7] = flow;        verts[k+8] = isOwn
+		verts[k+9] = slot
 		-- Vertex 1: child end (same per-edge payload)
-		verts[k+11] = e.cx;         verts[k+12] = e.cz
-		verts[k+13] = cap;          verts[k+14] = appearTime; verts[k+15] = witherTime
-		verts[k+16] = eff;          verts[k+17] = flow;       verts[k+18] = phase;      verts[k+19] = isOwn
-		verts[k+20] = slot
-		k = k + 20
+		verts[k+10] = e.cx;         verts[k+11] = e.cz
+		verts[k+12] = cap;          verts[k+13] = appearTime; verts[k+14] = witherTime
+		verts[k+15] = eff;          verts[k+16] = flow;       verts[k+17] = isOwn
+		verts[k+18] = slot
+		k = k + 18
 	end
 	return verts, n * 2
 end
 
 -- Build verts for the ghost VBO from `ghostEdges`. Same per-vertex layout as
--- the live pass (10 floats), so the same VS/GS/FS chain handles both. The FS
--- distinguishes ghosts via gridData.w = -1.0 (sentinel; live edges send 0/1).
+-- the live pass (9 floats), so the same VS/GS/FS chain handles both. The FS
+-- distinguishes ghosts via gridData.z = -1.0 (sentinel; live edges send 0/1/2).
 local function GenerateGhostTree()
 	local verts = {}
 	local k = 0
@@ -2357,22 +2185,21 @@ local function GenerateGhostTree()
 	for _, e in pairs(ghostEdges) do
 		local cap = max(1, e.capacity or 1) * (e.maxxed and -1 or 1)
 		local slot  = e.slot or -1
-		-- Ghost edges have no temporal animation: appear=0, wither=0, no flow,
-		-- no bubble phase. gridData.w = -1.0 tells the FS "always ghost".
+		-- Ghost edges have no temporal animation: appear=0, wither=0, no flow.
+		-- gridData.z = -1.0 tells the FS "always ghost".
 		local apT, wiT  = 0.0, 0.0
 		local eff, flow = 0.0, 0.0
-		local phase     = 0.0
 		local ghostFlag = -1.0
 
 		verts[k+1]  = e.px;  verts[k+2]  = e.pz
 		verts[k+3]  = cap;   verts[k+4]  = apT;       verts[k+5]  = wiT
-		verts[k+6]  = eff;   verts[k+7]  = flow;      verts[k+8]  = phase;     verts[k+9]  = ghostFlag
-		verts[k+10] = slot
-		verts[k+11] = e.cx;  verts[k+12] = e.cz
-		verts[k+13] = cap;   verts[k+14] = apT;       verts[k+15] = wiT
-		verts[k+16] = eff;   verts[k+17] = flow;      verts[k+18] = phase;     verts[k+19] = ghostFlag
-		verts[k+20] = slot
-		k = k + 20
+		verts[k+6]  = eff;   verts[k+7]  = flow;      verts[k+8]  = ghostFlag
+		verts[k+9]  = slot
+		verts[k+10] = e.cx;  verts[k+11] = e.cz
+		verts[k+12] = cap;   verts[k+13] = apT;       verts[k+14] = wiT
+		verts[k+15] = eff;   verts[k+16] = flow;      verts[k+17] = ghostFlag
+		verts[k+18] = slot
+		k = k + 18
 		count = count + 1
 	end
 	return verts, count * 2
@@ -2388,10 +2215,6 @@ local function RebuildGhostVBO()
 	-- the current vert payload in.
 	ghostVBO:Upload(verts)
 end
-
--- Old generic angle clustering — kept commented as a reference for when we
--- reintroduce CPU-side stem merging (cluster decomposition is a graph
--- operation that doesn't fit cleanly in a geometry shader).
 
 -------------------------------------------------------------------------------------
 -- Forward cable rendering via DrawWorldPreUnit.
@@ -2418,7 +2241,7 @@ local cableFSSrc = VFS.LoadFile(SHADER_DIR .. 'gfx_overdrive_cables.frag.glsl')
 -- (always visible, optionally ghosted out of LOS) vs "enemy" (only visible
 -- inside actual LOS). Specs and full-view see everything as own.
 local function isOwnAlly(allyTeamID)
-	local spec, fullview = spGetSpectatingState()
+	local _, fullview = spGetSpectatingState()
 	if fullview then
 		return true
 	end
@@ -2523,9 +2346,7 @@ function OnCableTreeFull(data)
 				end
 			else
 				e.witherFrame = frame
-			end
-			geomCache.valid = false   -- topology change → full geometry rebuild
-		end
+			end		end
 	end
 
 	-- If a fresh edge resurrects an old ghost (enemy rebuilt the same pylon
@@ -2546,11 +2367,6 @@ function OnCableTreeFull(data)
 	end
 
 	-- Add new, refresh capacity / flow / efficiency on survivors.
-	-- For each surviving edge, we integrate its bubble phase up to NOW with
-	-- the *old* speed before swapping in the new one. That way, when flow
-	-- (and hence speed) changes, the bubble position remains continuous —
-	-- it just starts evolving at a different rate from this moment on.
-	local nowSec = Spring.GetGameSeconds()
 	for k, i in pairs(incoming) do
 		local e = existing[k]
 		local newFlow = data.flows and data.flows[i] or 0
@@ -2562,21 +2378,13 @@ function OnCableTreeFull(data)
 			e.witherFrame = nil
 		end
 		if e and not e.witherFrame then
-			-- Catch the phase up to `nowSec` using whatever speed the cable
-			-- was running at since its last anchor.
-			local oldSpeed = e.bubbleSpeed or 0
-			local oldAnchor = e.bubbleAnchorTime or nowSec
-			e.bubblePhase = (e.bubblePhase or 0) + oldSpeed * (nowSec - oldAnchor)
-			e.bubbleAnchorTime = nowSec
-			e.bubbleSpeed = flowToSpeed(newFlow, data.caps[i])
-
 			-- Visible properties (capacity drives ribbon width, position drives
 			-- the chord) only refresh when the player can see the edge. For
 			-- enemy edges in fog we keep the last-seen values so a build that
 			-- changes an unobserved cable's thickness doesn't suddenly update
-			-- its ghost render. Bubble phase / flow / eff are also only
-			-- meaningful in LOS (they animate the live render), so refreshing
-			-- them in fog is harmless but we keep the gate uniform.
+			-- its ghost render. Flow / eff are also only meaningful in LOS
+			-- (they animate the live render), so refreshing them in fog is
+			-- harmless but we keep the gate uniform.
 			local visible = ownAlly or anyInLOS(data.pxs[i], data.pzs[i], data.cxs[i], data.czs[i])
 			if visible then
 				e.capacity = data.caps[i]
@@ -2623,14 +2431,7 @@ function OnCableTreeFull(data)
 				witherFrame = nil,
 				key      = k,
 				slot     = slot,
-				-- Fresh edge starts with zero phase; speed is set so the
-				-- shader can extrapolate forward from this anchor.
-				bubblePhase      = 0,
-				bubbleAnchorTime = nowSec,
-				bubbleSpeed      = flowToSpeed(newFlow, data.caps[i]),
-			}
-			geomCache.valid = false   -- topology change → full geometry rebuild
-		end
+			}		end
 	end
 
 	edgesByAllyTeam[ally] = existing
@@ -2654,20 +2455,6 @@ end
 
 local function RebuildVBO()
 	local tStart = cablePerf and Spring.GetTimer() or nil
-
-	-- Snapshot every edge's bubble phase to NOW before geometry generation,
-	-- and re-anchor; the shader will extrapolate from `bubbleBakeTime`.
-	bubbleBakeTime = Spring.GetGameSeconds()
-	for _, edges in pairs(edgesByAllyTeam) do
-		for _, e in pairs(edges) do
-			local oldSpeed = e.bubbleSpeed or 0
-			local oldAnchor = e.bubbleAnchorTime or bubbleBakeTime
-			e.bubblePhase = (e.bubblePhase or 0) + oldSpeed * (bubbleBakeTime - oldAnchor)
-			e.bubbleAnchorTime = bubbleBakeTime
-		end
-	end
-
-	local tGen0 = cablePerf and Spring.GetTimer() or nil
 	local verts, vertCount = GenerateOrganicTree()
 	if vertCount == 0 then
 		numCableVerts = 0
@@ -2678,13 +2465,13 @@ local function RebuildVBO()
 	cableVAO = nil
 	local vbo = gl.GetVBO(GL.ARRAY_BUFFER, false)
 	if not vbo then return end
-	-- Per-vertex layout (10 floats): vertPos(2) + vertData(3) + vertGrid(4)
+	-- Per-vertex layout (9 floats): vertPos(2) + vertData(3) + vertGrid(3)
 	-- + vertSlot(1). Two vertices per cable form one GL_LINES primitive; the
 	-- geometry shader expands each line into a wiggly ribbon at draw time.
 	vbo:Define(vertCount, {
 		{ id = 0, name = "vertPos",   size = 2 },
 		{ id = 1, name = "vertData",  size = 3 },  -- (capacity, appearTime, witherTime)
-		{ id = 2, name = "vertGrid",  size = 4 },  -- (efficiency, flow E/s, bubble phase elmos, isOwnAlly)
+		{ id = 2, name = "vertGrid",  size = 3 },  -- (efficiency, flow E/s, isOwnAlly / ghost flag)
 		{ id = 3, name = "vertSlot",  size = 1 },  -- coverage SSBO slot, or -1
 	})
 	local tUp0 = cablePerf and Spring.GetTimer() or nil
@@ -2697,10 +2484,9 @@ local function RebuildVBO()
 	if cablePerf then
 		local tEnd = Spring.GetTimer()
 		Spring.Echo(string.format(
-			"[CableTree] draw rebuild: phase=%.2f ms  build=%.2f ms  upload=%.2f ms  verts=%d edges=%d",
-			Spring.DiffTimers(tGen0, tStart) * 1000,
-			Spring.DiffTimers(tUp0,  tGen0)  * 1000,
-			Spring.DiffTimers(tEnd,  tUp0)   * 1000,
+			"[CableTree] draw rebuild: build=%.2f ms  upload=%.2f ms  verts=%d edges=%d",
+			Spring.DiffTimers(tUp0, tStart) * 1000,
+			Spring.DiffTimers(tEnd, tUp0)   * 1000,
 			vertCount, vertCount / 2))
 	end
 end
@@ -2745,16 +2531,10 @@ function gadget:GameFrame(n)
 	end
 	if dropped then
 		RebuildRenderEdges()
-		needsRebuild = true
-		geomCache.valid = false
-	end
+		needsRebuild = true	end
 
-	-- 3) Rebuild immediately when dirty. Throttling caused visible phase
-	--    jumps: between OnCableTreeFull (which mutates per-edge bubbleSpeed)
-	--    and the rebake, the shader still extrapolates with the OLD speed,
-	--    then snaps to the new baked state. The jump magnitude is
-	--    Δspeed × (bakeTime - nowSec) so any latency here directly produces
-	--    a visible discontinuity.
+	-- 3) Rebuild immediately when dirty, so topology changes (new/withered
+	--    edges, refreshed flow/eff) reach the GPU without visible latency.
 	if needsRebuild then
 		RebuildVBO()
 	end
@@ -2773,7 +2553,7 @@ function gadget:GameFrame(n)
 	--    (3 × IsPosInLos per scanned entry). Replaces the prior
 	--    "iterate everything every 30 frames" stutter.
 	if cableGhosts and next(ghostEdges) then
-		local spec, fullView = spGetSpectatingState()
+		local _, fullView = spGetSpectatingState()
 		if not fullView then
 			local ally = spGetMyAllyTeamID()
 			local removed = false
@@ -2816,7 +2596,6 @@ function gadget:DrawWorldPreUnit()
 	-- between sim ticks on all game speeds.
 	local frameOff = Spring.GetFrameTimeOffset and Spring.GetFrameTimeOffset() or 0
 	cableShader:SetUniform("gameTime", Spring.GetGameSeconds() + frameOff / GAME_SPEED)
-	--cableShader:SetUniform("bakeTime", bubbleBakeTime)
 	cableShader:SetUniform("enableFlow", cableFlowMode and 1.0 or 0.0)
 	cableShader:SetUniform("ghostsEnabled", cableGhosts and 1.0 or 0.0)
 	-- Shadow reception: only sample the shadow map when the engine actually has
@@ -3010,7 +2789,6 @@ function gadget:Initialize()
 		},
 		uniformFloat = {
 			gameTime = 0,
-			--bakeTime = 0,
 			enableFlow = cableFlowMode and 1.0 or 0.0,
 			ghostsEnabled = cableGhosts and 1.0 or 0.0,
 			shadowsEnabled = 0,
@@ -3093,7 +2871,7 @@ function gadget:Initialize()
 		ghostVBO:Define(ghostVBOCapacity, {
 			{ id = 0, name = "vertPos",   size = 2 },
 			{ id = 1, name = "vertData",  size = 3 },
-			{ id = 2, name = "vertGrid",  size = 4 },
+			{ id = 2, name = "vertGrid",  size = 3 },
 			{ id = 3, name = "vertSlot",  size = 1 },
 		})
 		ghostVAO = gl.GetVAO()
@@ -3133,9 +2911,7 @@ function gadget:PlayerChanged(playerID)
 			ghostNeedsRebuild = true
 		end
 	end
-	if touched then
-		geomCache.valid = false
-		needsRebuild = true
+	if touched then		needsRebuild = true
 	end
 end
 


### PR DESCRIPTION
Fixes three issues that have been plaguing the cables feature since release, plus a redo of the dead-weight cleanup that had drifted out of mergeability.

## Fixes

**Band-limited wiggle noise** (`a41d8fe`) — the wiggle offset was raw per-vertex white noise, so the pointiness-adaptive tessellation (which densifies vertices on cliffs) fed adjacent vertices fully-independent ±amplitude kicks: a tight full-amplitude zigzag exactly where the cable was already struggling. Replaced with cell-quantized, smoothstep-interpolated value noise (fixed 16-elmo feature wavelength), so denser sampling converges on the same smooth curve. Keyed on world XZ, so MST parent/child flips don't teleport the pattern.

**Twig roots welded to the rendered rail** (`beafd2a`) — twigs are emitted by separate GS invocations and must rebuild the exact trunk geometry to stay attached. The old root anchor offset from a belly-height spawn along a local-normal axis; on slopes it diverged from the trunk frame and dangled below the tube, and the noise change exposed the mismatch everywhere. The twig dispatch now rebuilds its target emitted vertex (and predecessor) and reconstructs the trunk's own rail frame — the root lands on the literal outer-rail vertex the tent invocation emits, with the same terrain clamp, plus a small Navg lift against z-fighting. The twig's growth basis is sign-aligned to the rail axis so it can't fold back across the trunk.

**Cliff-lip "inertia"** (`96f40b1`) — the centerline lift took the terrain max within ±0.85·(lenAB/numSeg) *along* the cable. A max-filter along the path is a morphological dilation: on any monotone slope the whole height profile shifts ~19 elmos downhill, so cables carried cliff-top height well past the lip before dropping — tracing the ground curvature perfectly but with a consistent horizontal push. The wide window predates the kink-adaptive tessellation and was doing anti-clip duty that clustering now covers. The profile scan now max-filters over one scan cell, and each emitted vertex takes the max over ~0.55 of its local gaps: same stay-above-terrain envelope, but the overshoot collapses to about one scan cell at the lip (where clustering is dense), and endpoints no longer sample terrain beyond the pylons.

## Cleanup redo (`68431aa`)

Re-derivation of the old `cable-cutting` cleanup against the post-tent-rework code (the original commit predates the tent geometry and could not be merged textually). No intended behaviour change: removes the never-read CPU-side bubble-phase integration (the FS advects purely from gameTime), shrinks the vertex payload 10→9 floats (`vertGrid` vec4→vec3 end-to-end; the ghost sentinel moves from `.w` to `.z`), and deletes `geomCache`, `EFF_EPSILON`/`lastSentEff`, dead CPU-router remnants, the twig `tipR`/`CONE_TIP_WIDTH` chain, and the unreachable `t > 0.90` FS discard. luacheck is down to the known gl/GL unsynced false-positives + pre-existing `edges` shadowing.

## Testing

Verified in a dev run: shaders compile on all three passes, cables hug cliff descents without the horizontal offset, wiggle stays smooth on oversampled slopes, and twig junctions stay seated. Worth a second pair of eyes on **ghost edges / enemy-LOS gating**, since the attribute repack moved the ghost sentinel component.

*(screenshot incoming)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
