### PR TITLE
Fix LuaShader crash when debug.getinfo is unavailable in gadget context

### DIFF
--- a/LuaRules/Gadgets/Include/LuaShader.lua
+++ b/LuaRules/Gadgets/Include/LuaShader.lua
@@ -196,7 +196,7 @@ function LuaShader:GetHandle()
 	if self.shaderObj ~= nil then
 		return self.shaderObj
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()?", funcName))
 	end
 end
@@ -205,7 +205,7 @@ function LuaShader:Delete()
 	if self.shaderObj ~= nil then
 		gl.DeleteShader(self.shaderObj)
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 	end
 end
@@ -217,7 +217,7 @@ function LuaShader:Activate()
 		self.active = true
 		return glUseShader(self.shaderObj)
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 		return false
 	end
@@ -238,7 +238,7 @@ function LuaShader:ActivateWith(func, ...)
 		glActiveShader(self.shaderObj, func, ...)
 		self.active = false
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 	end
 end

--- a/LuaUI/Widgets/Include/LuaShader.lua
+++ b/LuaUI/Widgets/Include/LuaShader.lua
@@ -758,7 +758,7 @@ function LuaShader:GetHandle()
 	if self.shaderObj ~= nil then
 		return self.shaderObj
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()?", funcName))
 	end
 end
@@ -767,7 +767,7 @@ function LuaShader:Delete()
 	if self.shaderObj ~= nil then
 		gl.DeleteShader(self.shaderObj)
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 	end
 end
@@ -779,7 +779,7 @@ function LuaShader:Activate()
 		self.active = true
 		return glUseShader(self.shaderObj)
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 		return false
 	end
@@ -800,7 +800,7 @@ function LuaShader:ActivateWith(func, ...)
 		glActiveShader(self.shaderObj, func, ...)
 		self.active = false
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 	end
 end

--- a/modules/graphics/LuaShader.lua
+++ b/modules/graphics/LuaShader.lua
@@ -929,7 +929,7 @@ function LuaShader:GetHandle()
 	if self.shaderObj ~= nil then
 		return self.shaderObj
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()?", funcName))
 	end
 end
@@ -938,7 +938,7 @@ function LuaShader:Delete()
 	if self.shaderObj ~= nil then
 		gl.DeleteShader(self.shaderObj)
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 	end
 end
@@ -959,7 +959,7 @@ function LuaShader:Activate()
 		end
 		return glUseShader(self.shaderObj)
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 		return false
 	end
@@ -980,7 +980,7 @@ function LuaShader:ActivateWith(func, ...)
 		glActiveShader(self.shaderObj, func, ...)
 		self.active = false
 	else
-		local funcName = (debug and debug.getinfo(1).name) or "UnknownFunction"
+		local funcName = (debug and debug.getinfo and debug.getinfo(1).name) or "UnknownFunction"
 		self:ShowError(string.format("Attempt to use invalid shader object in [%s](). Did you call :Compile() or :Initialize()", funcName))
 	end
 end


### PR DESCRIPTION
Basically we import the shader in a gadget and if this fails (e.g. a graphics driver fails to compile a shader) this crashes lua rules.

With this I can actually run zk in invisible pages in my WSL without it falling over.

It may be that only the LuaRules/Gadgets/ change is needed, but I'm unsure and the guard seems harmless enough...