### PR TITLE
Assorted patches

### DIFF
--- a/LuaUI/Widgets/gui_reclaiminfo.lua
+++ b/LuaUI/Widgets/gui_reclaiminfo.lua
@@ -36,7 +36,7 @@ local rangeend = {}  --counting radius end point
 local b1was = false  -- cursor was outside the map?
 local vsx, vsy = widgetHandler:GetViewSizes()
 local form = 12 --text format depends on screen size
-local xstart,ystart = 0
+local xstart,ystart = 0, 0
 local cmd,xend,yend,x,y,b1,b2
 local inMinimap = false --mouse cursor in minimap
 

--- a/effects/roach.lua
+++ b/effects/roach.lua
@@ -40,16 +40,6 @@ return {
     },
   },
   blastwing = {
-    groundflash = {
-      flashalpha         = 1,
-      flashsize          = 108,
-      ttl                = 75,
-      color = {
-        [1]  = 0.7,
-        [2]  = 0.3,
-        [3]  = 0.1,
-      },
-    },
     redploom = {
       air                = true,
       class              = [[CExpGenSpawner]],

--- a/lups/lups.lua
+++ b/lups/lups.lua
@@ -921,7 +921,7 @@ local function GameFrame(_,n)
 	CleanInvalidUnitFX()
 
 	--// update FXs
-	framesToUpdate = thisGameFrame - lastGameFrame
+	local framesToUpdate = thisGameFrame - lastGameFrame
 	for _,partFx in pairs(particles) do
 		if (n>=partFx.dieGameFrame) then
 			--// lifetime ended


### PR DESCRIPTION
LuaUI/Widgets/gui_reclaiminfo.lua
- Initilized 2 variables instead of 1 for clarity

effects/roach.lua
- Table defined 2 properties "groundflash", got rid of the redundant one. The redundant one was getting overwritten by the latter one.

lups/lups.lua
- global scope variable pulled back to local scope

LuaUI/Widgets/unit_smart_nanos.lua
- uhhh.... Errr... My linter informed me there was a reference to a global variable, which was probably meant to reference a local variable defined below it, but then I noticed many other things that are messy with this file.... This isn't even the default caretaker controller, and maybe it should be deleted. The logic is actually all over the place, Histidine added it to the repo "so someone else can figure it out" and noone seems to have done so.