### PR TITLE
Fixes #5811: Unit Auto Reclaim/Heal/Assist no longer leaves ghost idle cons

### DIFF
--- a/LuaUI/Widgets/gui_chili_core_selector.lua
+++ b/LuaUI/Widgets/gui_chili_core_selector.lua
@@ -1922,7 +1922,7 @@ function widget:UnitIdle(unitID, unitDefID, unitTeam)
 		wantUpdateCons = true
 	end
 	local ud = UnitDefs[unitDefID]
-	if CanBeAnIdleCons(ud) and IsConNotCarriedByEnemyTransport(unitID) then
+	if CanBeAnIdleCons(ud) and IsConNotCarriedByEnemyTransport(unitID) and Spring.GetUnitIsDead(unitID) == false then
 		idleCons[unitID] = true
 		wantUpdateCons = true
 	end

--- a/LuaUI/Widgets/unit_auto_reclaim_heal_assist.lua
+++ b/LuaUI/Widgets/unit_auto_reclaim_heal_assist.lua
@@ -33,9 +33,9 @@ local ConController = {
 		return self
 	end,
 
-	unset = function(self)
+	unset = function(self, isDying)
 		-- Echo("IdleConAssist removed: " .. self.unitID)
-		GiveOrderToUnit(self.unitID,CMD.STOP, {}, {""},1)
+		if not isDying then GiveOrderToUnit(self.unitID,CMD.STOP, {}, {""},1) end
 		return nil
 	end,
 	
@@ -82,7 +82,7 @@ end
 
 function widget:UnitDestroyed(unitID)
 	if not (ConStack[unitID%UPDATE_FRAME][unitID]==nil) then
-		ConStack[unitID%UPDATE_FRAME][unitID]=ConStack[unitID%UPDATE_FRAME][unitID]:unset();
+		ConStack[unitID%UPDATE_FRAME][unitID]=ConStack[unitID%UPDATE_FRAME][unitID]:unset(true);
 	end
 end
 

--- a/LuaUI/Widgets/unit_auto_reclaim_heal_assist.lua
+++ b/LuaUI/Widgets/unit_auto_reclaim_heal_assist.lua
@@ -33,9 +33,9 @@ local ConController = {
 		return self
 	end,
 
-	unset = function(self, isDying)
+	unset = function(self)
 		-- Echo("IdleConAssist removed: " .. self.unitID)
-		if not isDying then GiveOrderToUnit(self.unitID,CMD.STOP, {}, {""},1) end
+		GiveOrderToUnit(self.unitID,CMD.STOP, {}, {""},1)
 		return nil
 	end,
 	
@@ -82,7 +82,7 @@ end
 
 function widget:UnitDestroyed(unitID)
 	if not (ConStack[unitID%UPDATE_FRAME][unitID]==nil) then
-		ConStack[unitID%UPDATE_FRAME][unitID]=ConStack[unitID%UPDATE_FRAME][unitID]:unset(true);
+		ConStack[unitID%UPDATE_FRAME][unitID]=ConStack[unitID%UPDATE_FRAME][unitID]:unset();
 	end
 end
 


### PR DESCRIPTION
~~Changed the widget to not issue a stop command if the unit just died (proposed solution b in my issue).~~

~~Frankly I am not sure if we ever want it to issue a stop command.~~

The core selector widget now checks whether the unit in UnitIdle is really alive before setting its IdleCons entry to true.

I tested the change and it actually does fix the issue, idle con count stays correct. I have not done exhaustive testing with other widgets, but with such a small change it should hopefully not be necessary.