### PR TITLE
GUI for retreat order, havens player colored

### DIFF
--- a/LuaUI/Widgets/gui_havens.lua
+++ b/LuaUI/Widgets/gui_havens.lua
@@ -98,13 +98,13 @@ local RADIUS = 0
 
 ----------------------------------------------------------------------------------------
 -- functions
-function GetTeamName(teamID)
+local function GetTeamName(teamID)
 	local _, leaderID = spGetTeamInfo(teamID, false)
 	local playerName = spGetPlayerInfo(leaderID, true)
 	return playerName
 end
 
-function GetTeamHavens(teamID)
+local function GetTeamHavens(teamID)
 	local teamHavenCount = spGetTeamRulesParam(teamID, "haven_count")
 	if teamHavenCount then
 		local teamLeaderName = GetTeamName(teamID) or "???"
@@ -124,7 +124,7 @@ function GetTeamHavens(teamID)
 	end
 end
 
-function HavenUpdate()
+local function HavenUpdate()
 	havens = {}
 	local teams = spGetTeamList()
 	for i = 0, #teams-1 do

--- a/LuaUI/Widgets/gui_havens.lua
+++ b/LuaUI/Widgets/gui_havens.lua
@@ -2,16 +2,16 @@
 -------------------------------------------------------------------------------------
 
 function widget:GetInfo()
-  return {
-    name      = "Haven Handler",
-    desc      = "Haven Handler for Retreat Gadget",
-    author    = "CarRepairer",
-    date      = "2014-04-10",
-    license   = "GNU GPL, v2 or later",
-	handler   = true,
-    layer     = 0,
-    enabled   = true,
-  }
+	return {
+		name      = "Haven Handler",
+		desc      = "Haven Handler for Retreat Gadget",
+		author    = "CarRepairer",
+		date      = "2014-04-10",
+		license   = "GNU GPL, v2 or later",
+		handler   = true,
+		layer     = 0,
+		enabled   = true,
+	}
 end
 
 VFS.Include("LuaRules/Configs/customcmds.h.lua")
@@ -20,9 +20,10 @@ VFS.Include("LuaRules/Configs/customcmds.h.lua")
 -------------------------------------------------------------------------------------
 
 options_path = 'Settings/Interface/Retreat Zones'
-options_order = {'drawAllyZones', 'drawNames', 'cancelRetreat'}
+options_order = {'drawAllyZones', 'drawNames', 'customRetreatCircleColor', 'RetreatCircleColor', 'cancelRetreat'}
 
 local RETREAT_OFF_TABLE = {0}
+local PLAYER_HAVEN_COLOR = {1, 0.1, 0.1, 0.8}
 
 options = {
 	drawAllyZones = {
@@ -47,12 +48,38 @@ options = {
 			Spring.GiveOrder(CMD_RETREAT, RETREAT_OFF_TABLE, CMD.OPT_RIGHT)
 		end,
 	},
+	customRetreatCircleColor = {
+		name = 'Use custom color',
+		desc = 'Override player Retreat Circle color',
+		type = 'bool',
+		value = true,
+	},
+	RetreatCircleColor = {
+		name = 'Retreat Circle',
+		type = 'colors',
+		value = {1, 0.1, 0.1, 0.8},
+		OnChange = function (self)
+			PLAYER_HAVEN_COLOR = self.value
+		end,
+		advanced = true
+	},
 }
 
 -- speed-ups
 
 local spGetGameFrame = Spring.GetGameFrame
-local spGetLocalPlayerID = Spring.GetLocalPlayerID
+local spGetLocalTeamID = Spring.GetLocalTeamID
+local spGetTeamInfo = Spring.GetTeamInfo
+local spGetPlayerInfo = Spring.GetPlayerInfo
+local spGetTeamRulesParam = Spring.GetTeamRulesParam
+local spGetTeamColor = Spring.GetTeamColor
+local spGetGroundHeight = Spring.GetGroundHeight
+local spGetTeamList = Spring.GetTeamList
+local spGetMyPlayerID = Spring.GetMyPlayerID
+local spIsGUIHidden = Spring.IsGUIHidden
+local spGetSpectatingState = Spring.GetSpectatingState
+local spGetGameRulesParam = Spring.GetGameRulesParam
+local spSendLuaRulesMsg = Spring.SendLuaRulesMsg
 
 local glDepthTest      = gl.DepthTest
 local glAlphaTest      = gl.AlphaTest
@@ -68,29 +95,28 @@ local abs 	= math.abs
 
 local havens = {}
 local RADIUS = 0
-local DEFAULT_HAVEN_COLOR = {1, 0.1, 0.1, 0.8}
 
 ----------------------------------------------------------------------------------------
 -- functions
 function GetTeamName(teamID)
-	local _, leaderID = Spring.GetTeamInfo(teamID, false)
-    local playerName = Spring.GetPlayerInfo(leaderID, true)
+	local _, leaderID = spGetTeamInfo(teamID, false)
+	local playerName = spGetPlayerInfo(leaderID, true)
 	return playerName
 end
 
 function GetTeamHavens(teamID)
-	local teamHavenCount = Spring.GetTeamRulesParam(teamID, "haven_count")
+	local teamHavenCount = spGetTeamRulesParam(teamID, "haven_count")
 	if teamHavenCount then
 		local teamLeaderName = GetTeamName(teamID) or "???"
-		local teamcolor = {Spring.GetTeamColor(teamID)} or DEFAULT_HAVEN_COLOR
+		local teamcolor = {spGetTeamColor(teamID)}
 
 		local start = #havens
 		for i = 1, teamHavenCount do
 			havens[start + i] = {
-				x = Spring.GetTeamRulesParam(teamID, "haven_x" .. i),
-				z = Spring.GetTeamRulesParam(teamID, "haven_z" .. i)
+				x = spGetTeamRulesParam(teamID, "haven_x" .. i),
+				z = spGetTeamRulesParam(teamID, "haven_z" .. i)
 			}
-			havens[start + i].y = Spring.GetGroundHeight(havens[start + i].x, havens[start + i].z)
+			havens[start + i].y = spGetGroundHeight(havens[start + i].x, havens[start + i].z)
 			havens[start + i].name = teamLeaderName
 			havens[start + i].color = teamcolor
 			havens[start + i].team = teamID
@@ -98,18 +124,11 @@ function GetTeamHavens(teamID)
 	end
 end
 
-function GetHavens()
+function HavenUpdate()
 	havens = {}
-	local teams = Spring.GetTeamList()
+	local teams = spGetTeamList()
 	for i = 0, #teams-1 do
 		GetTeamHavens(i)
-	end
-end
-
-function HavenUpdate(teamID, allyTeamID)
-	local spectating = Spring.GetSpectatingState()
-	if (not spectating and Spring.GetLocalTeamID() == teamID) or options.drawAllyZones.value then
-		GetHavens()
 	end
 end
 
@@ -117,21 +136,21 @@ end
 --callins
 
 function widget:PlayerChanged(playerID)
-	if playerID == Spring.GetMyPlayerID() then
-		GetHavens()
+	if playerID == spGetMyPlayerID() then
+		HavenUpdate()
 	end
 end
 
 function widget:Initialize()
-	RADIUS = Spring.GetGameRulesParam('retreatZoneRadius') or 5
+	RADIUS = spGetGameRulesParam('retreatZoneRadius') or 5
 	widgetHandler:RegisterGlobal(widget, "HavenUpdate", HavenUpdate)
-	GetHavens()
+	HavenUpdate()
 end
 
 function widget:CommandNotify(cmdID, cmdParams, cmdOptions)
 	if cmdID == CMD_SETHAVEN then
 		local x,y,z = cmdParams[1], cmdParams[2], cmdParams[3]
-		Spring.SendLuaRulesMsg('sethaven|' .. x .. '|' .. y .. '|' .. z )
+		spSendLuaRulesMsg('sethaven|' .. x .. '|' .. y .. '|' .. z )
 		return true
 	end
 end
@@ -156,26 +175,26 @@ end
 local function DrawWorldFunc()
 	local fade = abs((spGetGameFrame() % 40) - 20) / 20
 	--Draw ambulance on havens.
-	if #havens == 0 or Spring.IsGUIHidden() then
+	if #havens == 0 or spIsGUIHidden() then
 		return
 	end
+	local spectating = spGetSpectatingState()
 
 	glDepthTest(true)
 	gl.LineWidth(2)
 
+	-- iterate over each haven and draw bounding circle and ?playername
 	for i = 1, #havens do
 		local havenPosition = havens[i]
-		-- TODO spGetLocalPLayerID interacts poorly when local player is cheating between teams and spectator.
-		-- Change comparison logic to work better in this edge case.
-		if options.drawAllyZones.value or havenPosition.team == spGetLocalPlayerID() then
+		if options.drawAllyZones.value or havenPosition.team == spGetLocalTeamID() then
 			local x, y, z = havenPosition.x, havenPosition.y, havenPosition.z
 
 			gl.LineWidth(4)
 			glColor(1, 1, 1, 0.5) --WHITE
 			gl.DrawGroundCircle(x, y, z, RADIUS, 32)
 			gl.LineWidth(2)
-			if havenPosition.team == spGetLocalPlayerID() then
-				glColor(DEFAULT_HAVEN_COLOR)
+			if not spectating and havenPosition.team == spGetLocalTeamID() and options.customRetreatCircleColor.value then
+				glColor(PLAYER_HAVEN_COLOR)
 			else
 				glColor(havenPosition.color)
 			end
@@ -192,12 +211,13 @@ local function DrawWorldFunc()
 		end
 	end --for
 
+	--iterate over havens again but this time paint flashing retreat indicator
 	glAlphaTest(GL_GREATER, 0)
 	glColor(1,fade,fade,fade+0.1)
 	glTexture('LuaUI/Images/commands/Bold/retreat.png')
 	for i = 1, #havens do
 		local havenPosition = havens[i]
-		if options.drawAllyZones.value or havenPosition.team == spGetLocalPlayerID() then
+		if options.drawAllyZones.value or havenPosition.team == spGetLocalTeamID() then
 			local x, y, z = havenPosition.x, max(havenPosition.y, 0.0), havenPosition.z
 
 			gl.PushMatrix()

--- a/LuaUI/Widgets/gui_havens.lua
+++ b/LuaUI/Widgets/gui_havens.lua
@@ -20,19 +20,22 @@ VFS.Include("LuaRules/Configs/customcmds.h.lua")
 -------------------------------------------------------------------------------------
 
 options_path = 'Settings/Interface/Retreat Zones'
-options_order = {'onlyShowMyZones', 'cancelRetreat'}
+options_order = {'drawAllyZones', 'drawNames', 'cancelRetreat'}
 
 local RETREAT_OFF_TABLE = {0}
 
 options = {
-	onlyShowMyZones = {
-		name = 'Only Show My Zones',
-		desc = 'With this enabled you will only see your retreat zones.',
+	drawAllyZones = {
+		name = 'Show All Player Retreat Zones',
+		desc = 'Displays retreat zones of other players',
 		type = 'bool',
 		value = true,
-		OnChange = function(self)
-			GetHavens()
-		end,
+	},
+	drawNames = {
+		name = 'Label Player Names',
+		desc = "Draws the name of other players' retreat zones",
+		type = 'bool',
+		value = false,
 	},
 	cancelRetreat = {
 		name = 'Cancel Retreat',
@@ -48,9 +51,8 @@ options = {
 
 -- speed-ups
 
-local echo = Spring.Echo
-
 local spGetGameFrame = Spring.GetGameFrame
+local spGetLocalPlayerID = Spring.GetLocalPlayerID
 
 local glDepthTest      = gl.DepthTest
 local glAlphaTest      = gl.AlphaTest
@@ -61,54 +63,52 @@ local glBillboard      = gl.Billboard
 local glColor          = gl.Color
 local GL_GREATER       = GL.GREATER
 
-local min	= math.min
 local max = math.max
-local floor = math.floor
 local abs 	= math.abs
 
 local havens = {}
-local havenCount = 0
 local RADIUS = 0
+local DEFAULT_HAVEN_COLOR = {1, 0.1, 0.1, 0.8}
 
 ----------------------------------------------------------------------------------------
 -- functions
+function GetTeamName(teamID)
+	local _, leaderID = Spring.GetTeamInfo(teamID, false)
+    local playerName = Spring.GetPlayerInfo(leaderID, true)
+	return playerName
+end
 
 function GetTeamHavens(teamID)
-	local start = havenCount
 	local teamHavenCount = Spring.GetTeamRulesParam(teamID, "haven_count")
 	if teamHavenCount then
-		havenCount = havenCount + teamHavenCount
-		if havenCount then
-			for i = 1, teamHavenCount do
-				havens[start + i] = {
-					x = Spring.GetTeamRulesParam(teamID, "haven_x" .. i),
-					z = Spring.GetTeamRulesParam(teamID, "haven_z" .. i)
-				}
-				havens[start + i].y = Spring.GetGroundHeight(havens[start + i].x, havens[start + i].z)
-			end
+		local teamLeaderName = GetTeamName(teamID) or "???"
+		local teamcolor = {Spring.GetTeamColor(teamID)} or DEFAULT_HAVEN_COLOR
+
+		local start = #havens
+		for i = 1, teamHavenCount do
+			havens[start + i] = {
+				x = Spring.GetTeamRulesParam(teamID, "haven_x" .. i),
+				z = Spring.GetTeamRulesParam(teamID, "haven_z" .. i)
+			}
+			havens[start + i].y = Spring.GetGroundHeight(havens[start + i].x, havens[start + i].z)
+			havens[start + i].name = teamLeaderName
+			havens[start + i].color = teamcolor
+			havens[start + i].team = teamID
 		end
 	end
 end
 
 function GetHavens()
 	havens = {}
-	havenCount = 0
-	if options.onlyShowMyZones.value then
-		local spectating = Spring.GetSpectatingState()
-		if not spectating then
-			GetTeamHavens(Spring.GetLocalTeamID())
-		end
-	else
-		local teams = Spring.GetTeamList()
-		for i = 0, #teams-1 do
-			GetTeamHavens(i)
-		end
+	local teams = Spring.GetTeamList()
+	for i = 0, #teams-1 do
+		GetTeamHavens(i)
 	end
 end
 
 function HavenUpdate(teamID, allyTeamID)
 	local spectating = Spring.GetSpectatingState()
-	if (not spectating and Spring.GetLocalTeamID() == teamID) or (not options.onlyShowMyZones.value) then
+	if (not spectating and Spring.GetLocalTeamID() == teamID) or options.drawAllyZones.value then
 		GetHavens()
 	end
 end
@@ -159,37 +159,55 @@ local function DrawWorldFunc()
 	if #havens == 0 or Spring.IsGUIHidden() then
 		return
 	end
-	
+
 	glDepthTest(true)
 	gl.LineWidth(2)
 
-	for i = 1, havenCount do
+	for i = 1, #havens do
 		local havenPosition = havens[i]
-		local x, y, z = havenPosition.x, havenPosition.y, havenPosition.z
+		-- TODO spGetLocalPLayerID interacts poorly when local player is cheating between teams and spectator.
+		-- Change comparison logic to work better in this edge case.
+		if options.drawAllyZones.value or havenPosition.team == spGetLocalPlayerID() then
+			local x, y, z = havenPosition.x, havenPosition.y, havenPosition.z
 
-		gl.LineWidth(4)
-		glColor(1, 1, 1, 0.5)
-		gl.DrawGroundCircle(x, y, z, RADIUS, 32)
+			gl.LineWidth(4)
+			glColor(1, 1, 1, 0.5) --WHITE
+			gl.DrawGroundCircle(x, y, z, RADIUS, 32)
+			gl.LineWidth(2)
+			if havenPosition.team == spGetLocalPlayerID() then
+				glColor(DEFAULT_HAVEN_COLOR)
+			else
+				glColor(havenPosition.color)
+			end
+			gl.DrawGroundCircle(x, y, z, RADIUS, 32)
 
-		gl.LineWidth(2)
-		glColor(1, 0.1, 0.1, 0.8)
-		gl.DrawGroundCircle(x, y, z, RADIUS, 32)
-
+			gl.PushMatrix()
+			glTranslate(x, y, z)
+			glBillboard()
+			if options.drawNames.value then
+				glColor(havenPosition.color)
+				gl.Text(havenPosition.name, 0, -10, 15, 'noc')
+			end
+			gl.PopMatrix()
+		end
 	end --for
+
 	glAlphaTest(GL_GREATER, 0)
 	glColor(1,fade,fade,fade+0.1)
 	glTexture('LuaUI/Images/commands/Bold/retreat.png')
-	
-	for i = 1, havenCount do
+	for i = 1, #havens do
 		local havenPosition = havens[i]
-		local x, y, z = havenPosition.x, max(havenPosition.y, 0.0), havenPosition.z
-		gl.PushMatrix()
-		glTranslate(x, y, z)
-		glBillboard()
-		glTexRect(-10, 0, 10, 20)
-		gl.PopMatrix()
+		if options.drawAllyZones.value or havenPosition.team == spGetLocalPlayerID() then
+			local x, y, z = havenPosition.x, max(havenPosition.y, 0.0), havenPosition.z
+
+			gl.PushMatrix()
+			glTranslate(x, y, z)
+			glBillboard()
+			glTexRect(-10, 0, 10, 20)
+			gl.PopMatrix()
+		end
 	end --for
-	
+
 	glTexture(false)
 	glAlphaTest(false)
 	glDepthTest(false)

--- a/LuaUI/Widgets/gui_havens.lua
+++ b/LuaUI/Widgets/gui_havens.lua
@@ -20,17 +20,47 @@ VFS.Include("LuaRules/Configs/customcmds.h.lua")
 -------------------------------------------------------------------------------------
 
 options_path = 'Settings/Interface/Retreat Zones'
-options_order = {'drawAllyZones', 'drawNames', 'customRetreatCircleColor', 'RetreatCircleColor', 'cancelRetreat'}
+options_order = {'drawNames', 'playerZonesRadio', 'customRetreatCircleColor', 'retreatCircleColor', 'cancelRetreat'}
 
 local RETREAT_OFF_TABLE = {0}
 local PLAYER_HAVEN_COLOR = {1, 0.1, 0.1, 0.8}
+local HavenUpdate
 
 options = {
-	drawAllyZones = {
-		name = 'Show All Player Retreat Zones',
-		desc = 'Displays retreat zones of other players',
-		type = 'bool',
-		value = true,
+	playerZonesRadio = {
+		name = "Display Zone options",
+		type = 'radioButton',
+		value = 'player_only_spectator_los',
+		items = {
+			{
+				key = "player_only",
+				name = "Player Only",
+				desc = "Only show player's own Retreat Zones",
+			},
+			{
+				key = "los",
+				name = "Team",
+				desc = "Show player's and ally's Retreat Zones",
+			},
+			{
+				key = "player_only_spectator",
+				name = "Player Only (Spectator)",
+				desc = "Only show spectated player's Retreat Zones",
+			},
+			{
+				key = "los_spectator",
+				name = "Team (Spectator)",
+				desc = "Show all Retreat Zones as Spectator",
+			},
+			{
+				key = "player_only_spectator_los",
+				name = "Player Only/ Spectator All",
+				desc = "Only show player's zones when playing, but all zones as spectator",
+			},
+		},
+		OnChange = function(self)
+			HavenUpdate()
+		end,
 		noHotkey = true,
 	},
 	drawNames = {
@@ -56,13 +86,17 @@ options = {
 		type = 'bool',
 		value = true,
 		noHotkey = true,
+		OnChange = function(self)
+			HavenUpdate()
+		end,
 	},
-	RetreatCircleColor = {
+	retreatCircleColor = {
 		name = 'Retreat Circle',
 		type = 'colors',
 		value = {1, 0.1, 0.1, 0.8},
 		OnChange = function (self)
 			PLAYER_HAVEN_COLOR = self.value
+			HavenUpdate()
 		end,
 		advanced = true
 	},
@@ -107,31 +141,49 @@ local function GetTeamName(teamID)
 	return playerName
 end
 
-local function GetTeamHavens(teamID)
-	local teamHavenCount = spGetTeamRulesParam(teamID, "haven_count")
-	if teamHavenCount then
-		local teamLeaderName = GetTeamName(teamID) or "???"
-		local teamcolor = {spGetTeamColor(teamID)}
-
-		local start = #havens
-		for i = 1, teamHavenCount do
-			havens[start + i] = {
-				x = spGetTeamRulesParam(teamID, "haven_x" .. i),
-				z = spGetTeamRulesParam(teamID, "haven_z" .. i)
-			}
-			havens[start + i].y = spGetGroundHeight(havens[start + i].x, havens[start + i].z)
-			havens[start + i].name = teamLeaderName
-			havens[start + i].color = teamcolor
-			havens[start + i].team = teamID
+HavenUpdate = function () -- local function
+	havens = {}
+	local spectating = spGetSpectatingState()
+	local teams
+	-- how many states can we be in?
+	-- we can be spectating
+	-- we can be playing
+	-- options.drawSpectatorZones.value
+	-- options.drawAllyZones.value
+	local opt = options.playerZonesRadio.value
+	if spectating and (opt == "player_only" or opt == "los") then
+		-- do not populate havens if option is not spectator option
+		teams = havens -- empty table
+	else
+		if opt == "los" or opt == "los_spectator" or (spectating and opt == "player_only_spectator_los") then
+			teams = spGetTeamList() -- all teams LOS visible
+		else -- opt is "player_only" or "player_only_spectator"
+			teams = {spGetLocalTeamID()} -- just my team
 		end
 	end
-end
+	for x = 1, #teams do
+		local teamID = teams[x]
+		local teamHavenCount = spGetTeamRulesParam(teamID, "haven_count")
+		if teamHavenCount then
+			local teamLeaderName = GetTeamName(teamID) or "???"
+			local teamcolor = {spGetTeamColor(teamID)}
+			if teamID == spGetLocalTeamID() and options.customRetreatCircleColor.value then
+				teamcolor = PLAYER_HAVEN_COLOR
+			end
 
-local function HavenUpdate()
-	havens = {}
-	local teams = spGetTeamList()
-	for i = 0, #teams-1 do
-		GetTeamHavens(i)
+			local start = #havens
+			for i = 1, teamHavenCount do
+				local px, pz = spGetTeamRulesParam(teamID, "haven_x" .. i), spGetTeamRulesParam(teamID, "haven_z" .. i)
+				havens[start + i] = {
+					x = px,
+					z = pz,
+					y = spGetGroundHeight(px, pz), -- strange when height at xz changes
+					name = teamLeaderName,
+					color = teamcolor,
+					team = teamID,
+				}
+			end
+		end
 	end
 end
 
@@ -139,7 +191,7 @@ end
 --callins
 
 function widget:PlayerChanged(playerID)
-	if playerID == spGetMyPlayerID() then
+	if playerID == spGetMyPlayerID() or spGetSpectatingState() then
 		HavenUpdate()
 	end
 end
@@ -176,12 +228,11 @@ function widget:CommandsChanged()
 end
 
 local function DrawWorldFunc()
-	local fade = abs((spGetGameFrame() % 40) - 20) / 20
-	--Draw ambulance on havens.
 	if #havens == 0 or spIsGUIHidden() then
 		return
 	end
-	local spectating = spGetSpectatingState()
+
+	local drawNames = options.drawNames.value
 
 	glDepthTest(true)
 	gl.LineWidth(2)
@@ -189,53 +240,47 @@ local function DrawWorldFunc()
 	-- iterate over each haven and draw bounding circle and ?playername
 	for i = 1, #havens do
 		local havenPosition = havens[i]
-		if options.drawAllyZones.value or havenPosition.team == spGetLocalTeamID() then
-			local x, y, z = havenPosition.x, havenPosition.y, havenPosition.z
+		local x, y, z = havenPosition.x, havenPosition.y, havenPosition.z
+		-- rather not make spring call for height here, but height can do strange things.
 
-			gl.LineWidth(4)
-			glColor(1, 1, 1, 0.5) --WHITE
-			gl.DrawGroundCircle(x, y, z, RADIUS, 32)
-			gl.LineWidth(2)
-			if not spectating and havenPosition.team == spGetLocalTeamID() and options.customRetreatCircleColor.value then
-				glColor(PLAYER_HAVEN_COLOR)
-			else
-				glColor(havenPosition.color)
-			end
-			gl.DrawGroundCircle(x, y, z, RADIUS, 32)
+		gl.LineWidth(4)
+		glColor(1, 1, 1, 0.5) --WHITE
+		gl.DrawGroundCircle(x, y, z, RADIUS, 32)
+		gl.LineWidth(2)
+		glColor(havenPosition.color)
+		gl.DrawGroundCircle(x, y, z, RADIUS, 32)
 
+		if drawNames then
 			gl.PushMatrix()
 			glTranslate(x, y, z)
 			glBillboard()
-			if options.drawNames.value then
-				glColor(havenPosition.color)
-				gl.Text(havenPosition.name, 0, -10, 15, 'noc')
-			end
+			glColor(havenPosition.color)
+			gl.Text(havenPosition.name, 0, -10, 15, 'noc')
 			gl.PopMatrix()
 		end
 	end --for
 
-	--iterate over havens again but this time paint flashing retreat indicator
+	--iterate over havens again but this time paint ambulance indicator
+	local fade = abs((spGetGameFrame() % 40) - 20) / 20
 	glAlphaTest(GL_GREATER, 0)
 	glColor(1,fade,fade,fade+0.1)
 	glTexture('LuaUI/Images/commands/Bold/retreat.png')
 	for i = 1, #havens do
 		local havenPosition = havens[i]
-		if options.drawAllyZones.value or havenPosition.team == spGetLocalTeamID() then
-			local x, y, z = havenPosition.x, max(havenPosition.y, 0.0), havenPosition.z
+		local x, y, z = havenPosition.x, max(havenPosition.y, 0.0), havenPosition.z
 
-			gl.PushMatrix()
-			glTranslate(x, y, z)
-			glBillboard()
-			glTexRect(-10, 0, 10, 20)
-			gl.PopMatrix()
-		end
+		gl.PushMatrix()
+		glTranslate(x, y, z)
+		glBillboard()
+		glTexRect(-10, 0, 10, 20)
+		gl.PopMatrix()
 	end --for
 
 	glTexture(false)
 	glAlphaTest(false)
 	glDepthTest(false)
 end
-	
+
 function widget:DrawWorld()
 	DrawWorldFunc()
 end --DrawWorld

--- a/LuaUI/Widgets/gui_havens.lua
+++ b/LuaUI/Widgets/gui_havens.lua
@@ -31,12 +31,14 @@ options = {
 		desc = 'Displays retreat zones of other players',
 		type = 'bool',
 		value = true,
+		noHotkey = true,
 	},
 	drawNames = {
 		name = 'Label Player Names',
 		desc = "Draws the name of other players' retreat zones",
 		type = 'bool',
 		value = false,
+		noHotkey = true,
 	},
 	cancelRetreat = {
 		name = 'Cancel Retreat',
@@ -53,6 +55,7 @@ options = {
 		desc = 'Override player Retreat Circle color',
 		type = 'bool',
 		value = true,
+		noHotkey = true,
 	},
 	RetreatCircleColor = {
 		name = 'Retreat Circle',

--- a/LuaUI/Widgets/gui_havens.lua
+++ b/LuaUI/Widgets/gui_havens.lua
@@ -151,6 +151,7 @@ HavenUpdate = function () -- local function
 	-- options.drawSpectatorZones.value
 	-- options.drawAllyZones.value
 	local opt = options.playerZonesRadio.value
+	local localTeamID = spGetLocalTeamID()
 	if spectating and (opt == "player_only" or opt == "los") then
 		-- do not populate havens if option is not spectator option
 		teams = havens -- empty table
@@ -158,7 +159,7 @@ HavenUpdate = function () -- local function
 		if opt == "los" or opt == "los_spectator" or (spectating and opt == "player_only_spectator_los") then
 			teams = spGetTeamList() -- all teams LOS visible
 		else -- opt is "player_only" or "player_only_spectator"
-			teams = {spGetLocalTeamID()} -- just my team
+			teams = {localTeamID} -- just my team
 		end
 	end
 	for x = 1, #teams do
@@ -167,7 +168,7 @@ HavenUpdate = function () -- local function
 		if teamHavenCount then
 			local teamLeaderName = GetTeamName(teamID) or "???"
 			local teamcolor = {spGetTeamColor(teamID)}
-			if teamID == spGetLocalTeamID() and options.customRetreatCircleColor.value then
+			if not spectating and teamID == localTeamID and options.customRetreatCircleColor.value then
 				teamcolor = PLAYER_HAVEN_COLOR
 			end
 


### PR DESCRIPTION
inspired greatly by Helwor's Hel-K widget suite
https://github.com/Helwor/New-Hel-K

--------------------

Summary: Changed the way Retreat Zones (Havens) are drawn to be team-colored, left default color and behavior as is in stable right now, but will now show all player retreat zones when spectating by default to increase discoverability/awareness of the feature.

Overview:
options revamp
- bool "Only Show My Zones" has been replaced with "Display Zone options" a 5 option radio
- added option to draw team color playernames over all retreat zones
- added options to change the default red color of Havens

Whitespace changes

Spring functions localized

Various variable cleanup (reduced to lower scopes, moved around some logic)